### PR TITLE
feat(paths): XDG paths + branch sanitizer + path template renderer

### DIFF
--- a/src/paths.rs
+++ b/src/paths.rs
@@ -81,7 +81,7 @@ pub fn render_worktree_path(template: &str, repo: &str, branch: &str) -> Result<
 /// - `/` → `-`
 /// - spaces → `-`
 /// - `@` → `-`
-/// - `..` → stripped
+/// - `..` → `-`
 /// - consecutive dashes collapsed
 /// - single dots preserved
 pub fn sanitize_branch(branch: &str) -> String {

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -36,10 +36,16 @@ pub fn data_dir() -> Result<PathBuf> {
 /// Uses `dirs::state_dir()` when available (Linux), falls back to
 /// `~/.local/state` on platforms that return `None` (macOS/Windows).
 pub fn state_dir() -> Result<PathBuf> {
-    let base = dirs::state_dir().unwrap_or_else(|| {
-        let home = dirs::home_dir().expect("could not determine home directory");
-        STATE_DIR_FALLBACK_SEGMENTS.iter().fold(home, |p, s| p.join(s))
-    });
+    let base = match dirs::state_dir() {
+        Some(path) => path,
+        None => {
+            let home = dirs::home_dir()
+                .context("could not determine home directory for state directory fallback")?;
+            STATE_DIR_FALLBACK_SEGMENTS
+                .iter()
+                .fold(home, |p, s| p.join(s))
+        }
+    };
     let path = base.join(APP_NAME);
     ensure_dir(&path)?;
     Ok(path)

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -210,6 +210,22 @@ mod tests {
     }
 
     #[test]
+    fn sanitize_empty_branch() {
+        assert_eq!(sanitize_branch(""), "");
+    }
+
+    #[test]
+    fn sanitize_single_dot() {
+        assert_eq!(sanitize_branch("."), ".");
+    }
+
+    #[test]
+    fn sanitize_triple_dots() {
+        // "..." → ".." replaced with "-" → "-." → trim leading dash → "."
+        assert_eq!(sanitize_branch("..."), ".");
+    }
+
+    #[test]
     fn sanitize_combined_edge_cases() {
         // Multiple replaceable chars in a row collapse to single dash
         assert_eq!(sanitize_branch("a/@b"), "a-b");

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -1,0 +1,85 @@
+/// Sanitize a branch name for use as a filesystem directory name.
+///
+/// Rules (FR-15, FR-16):
+/// - `/` → `-`
+/// - spaces → `-`
+/// - `@` → `-`
+/// - `..` → stripped
+/// - consecutive dashes collapsed
+/// - single dots preserved
+pub fn sanitize_branch(branch: &str) -> String {
+    // Replace `..` sequences (path traversal) with dash
+    let stripped = branch.replace("..", "-");
+
+    let mut result = String::with_capacity(stripped.len());
+    for ch in stripped.chars() {
+        match ch {
+            '/' | '@' | ' ' => {
+                // Replace with dash, but avoid consecutive dashes
+                if !result.ends_with('-') {
+                    result.push('-');
+                }
+            }
+            '-' => {
+                if !result.ends_with('-') {
+                    result.push('-');
+                }
+            }
+            _ => result.push(ch),
+        }
+    }
+
+    // Trim leading/trailing dashes
+    result.trim_matches('-').to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sanitize_slash_to_dash() {
+        assert_eq!(sanitize_branch("feature/auth"), "feature-auth");
+    }
+
+    #[test]
+    fn sanitize_at_to_dash() {
+        assert_eq!(sanitize_branch("fix@home"), "fix-home");
+    }
+
+    #[test]
+    fn sanitize_double_dots_stripped() {
+        assert_eq!(sanitize_branch("a..b"), "a-b");
+    }
+
+    #[test]
+    fn sanitize_consecutive_dashes_collapsed() {
+        assert_eq!(sanitize_branch("a--b"), "a-b");
+    }
+
+    #[test]
+    fn sanitize_single_dots_preserved() {
+        assert_eq!(sanitize_branch("v2.1.3"), "v2.1.3");
+    }
+
+    #[test]
+    fn sanitize_spaces_to_dash() {
+        assert_eq!(sanitize_branch("my branch"), "my-branch");
+    }
+
+    #[test]
+    fn sanitize_leading_trailing_dashes_trimmed() {
+        assert_eq!(sanitize_branch("/leading"), "leading");
+        assert_eq!(sanitize_branch("trailing/"), "trailing");
+    }
+
+    #[test]
+    fn sanitize_combined_edge_cases() {
+        // Multiple replaceable chars in a row collapse to single dash
+        assert_eq!(sanitize_branch("a/@b"), "a-b");
+        // Empty after stripping
+        assert_eq!(sanitize_branch(".."), "");
+        // Nested double dots with other chars
+        assert_eq!(sanitize_branch("feature/..secret/auth"), "feature-secret-auth");
+    }
+}


### PR DESCRIPTION
Closes #3

## Summary
Implements three foundational utilities in `src/paths.rs`: XDG-compliant directory resolution functions (`config_dir`, `data_dir`, `state_dir`, `worktree_root`) using the `dirs` crate with automatic directory creation, a branch name sanitizer that converts branch names to filesystem-safe directory names per FR-15/FR-16, and a path template renderer using minijinja with `{{ repo }}` and `{{ branch | sanitize }}` support per FR-17.

## User Stories Addressed
- US-1: Create a new worktree for a feature branch with one command (worktree path resolution)
- US-7: Batch-sync all worktrees with a single command (opinionated path convention)

## Automated Testing
- Total tests added: 15
- Tests passing: 15
- Tests failing: 0
- `cargo clippy`: pass
- `cargo test`: pass (23 total tests, 15 new + 8 existing)

## Manual Testing Checklist
1. Clone the repo and checkout this branch
2. Run `cargo test paths::tests` — all 15 tests should pass
3. Run `cargo clippy --tests` — no warnings beyond expected dead_code (module not yet wired into main)
4. Verify XDG directories were created: `ls ~/.config/trench/ ~/.local/share/trench/ ~/.local/state/trench/ ~/.worktrees/`
5. Open `src/paths.rs` and verify `sanitize_branch` handles: slashes, @, spaces, double dots, consecutive dashes, single dots preserved
6. Verify `render_worktree_path` with default template produces `repo/sanitized-branch` format
7. Run `cargo test` — all 23 tests (8 existing CLI + 15 new paths) should pass

## Known Issues
None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added standardized directory management for config, data, and state with automatic creation and environment-aware resolution.
  * Added worktree path templating with a default template and branch name sanitization to produce safe filesystem paths.

* **Tests**
  * Added unit tests validating directory resolution, template rendering, and branch sanitizer behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->