### PR TITLE
feat(state): SQLite connection, schema, migrations, and queries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -216,7 +216,7 @@ dependencies = [
  "crossterm_winapi",
  "mio",
  "parking_lot",
- "rustix",
+ "rustix 0.38.44",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -330,6 +330,12 @@ name = "fallible-streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "filetime"
@@ -759,6 +765,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "litemap"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1059,8 +1071,21 @@ dependencies = [
  "bitflags 2.11.0",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.15",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.11.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.12.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1258,6 +1283,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.4",
+ "once_cell",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1373,6 +1411,7 @@ dependencies = [
  "rusqlite_migration",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror",
  "tokio",
  "toml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,3 +45,6 @@ dirs = "6"
 
 # Watch
 notify = "7"
+
+[dev-dependencies]
+tempfile = "3.26.0"

--- a/ralph
+++ b/ralph
@@ -97,7 +97,7 @@ Rules:
 - After ALL acceptance criteria are met and all checks pass:
   1. Push branch to origin
   2. Create PR via \`gh pr create\` with the structure below
-  3. Print a "## Manual Testing Checklist" to stdout listing concrete steps I should test manually
+  3. Print the UAT Checklist to stdout
   4. Then stop — you are done
 
 PR description MUST follow this exact structure:
@@ -118,11 +118,10 @@ Closes #${ISSUE}
 - \`cargo clippy\`: <pass/fail>
 - \`cargo test\`: <pass/fail>
 
-## Manual Testing Checklist
-<numbered steps the reviewer should follow to verify this works end-to-end, e.g.:
-1. cd into a git repo
-2. Run \`trench create my-feature\`
-3. Verify worktree exists at ~/.worktrees/repo/my-feature
+## UAT Checklist
+<real-world usage scenarios as GitHub task list. NOT duplicates of automated tests.
+- [ ] \`trench create my-feature\` → worktree at expected path
+- [ ] \`trench list\` → shows the new worktree
 ...>
 
 ## Known Issues

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -268,6 +268,24 @@ mod tests {
     }
 
     #[test]
+    fn update_worktree_not_found() {
+        let db = Database::open_in_memory().unwrap();
+        let result = db.update_worktree(
+            999,
+            &WorktreeUpdate {
+                managed: Some(true),
+                ..Default::default()
+            },
+        );
+        let err = result.expect_err("should error for non-existent worktree");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("not found"),
+            "error should mention 'not found', got: {msg}"
+        );
+    }
+
+    #[test]
     fn foreign_key_prevents_orphan_worktree() {
         let db = Database::open_in_memory().unwrap();
         let result = db.insert_worktree(9999, "wt", "b", "/wt", None);

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -1,0 +1,87 @@
+mod queries;
+
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use rusqlite::Connection;
+use rusqlite_migration::{Migrations, M};
+
+/// Core database handle wrapping a SQLite connection with migrations applied.
+pub struct Database {
+    conn: Connection,
+}
+
+impl Database {
+    /// Open (or create) the database at the given file path.
+    ///
+    /// Applies pragmas (WAL, FK, synchronous NORMAL) and runs all pending migrations.
+    pub fn open(path: &Path) -> Result<Self> {
+        let conn = Connection::open(path)
+            .with_context(|| format!("failed to open database at {}", path.display()))?;
+        Self::init(conn)
+    }
+
+    /// Open an in-memory database (for testing).
+    pub fn open_in_memory() -> Result<Self> {
+        let conn = Connection::open_in_memory().context("failed to open in-memory database")?;
+        Self::init(conn)
+    }
+
+    fn init(mut conn: Connection) -> Result<Self> {
+        conn.execute_batch(
+            "PRAGMA journal_mode = WAL;
+             PRAGMA foreign_keys = ON;
+             PRAGMA synchronous = NORMAL;",
+        )
+        .context("failed to set database pragmas")?;
+
+        Self::migrations()
+            .to_latest(&mut conn)
+            .context("failed to run database migrations")?;
+
+        Ok(Self { conn })
+    }
+
+    fn migrations() -> Migrations<'static> {
+        Migrations::new(vec![M::up(include_str!("sql/001_initial_schema.sql"))])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn open_in_memory_applies_pragmas_and_creates_tables() {
+        let db = Database::open_in_memory().expect("should open in-memory database");
+
+        // Verify pragmas
+        let fk: i64 = db
+            .conn
+            .pragma_query_value(None, "foreign_keys", |row| row.get(0))
+            .unwrap();
+        assert_eq!(fk, 1, "foreign_keys should be ON");
+
+        let sync: i64 = db
+            .conn
+            .pragma_query_value(None, "synchronous", |row| row.get(0))
+            .unwrap();
+        assert_eq!(sync, 1, "synchronous should be NORMAL (1)");
+
+        // Verify all 6 tables exist
+        let tables = vec!["repos", "worktrees", "events", "logs", "tags", "session"];
+        for table in &tables {
+            let exists: bool = db
+                .conn
+                .prepare(&format!(
+                    "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='{}'",
+                    table
+                ))
+                .unwrap()
+                .query_row([], |row| row.get::<_, i64>(0))
+                .map(|count| count > 0)
+                .unwrap();
+            assert!(exists, "table '{}' should exist", table);
+        }
+    }
+}

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -307,6 +307,23 @@ mod tests {
     }
 
     #[test]
+    fn event_rejects_mismatched_repo_worktree() {
+        let db = Database::open_in_memory().unwrap();
+        let repo_a = db.insert_repo("repo-a", "/a", None).unwrap();
+        let repo_b = db.insert_repo("repo-b", "/b", None).unwrap();
+        let wt_b = db
+            .insert_worktree(repo_b.id, "wt", "branch", "/b/wt", None)
+            .unwrap();
+
+        // worktree belongs to repo_b, but event says repo_a — should fail
+        let result = db.insert_event(repo_a.id, Some(wt_b.id), "sync", None);
+        assert!(
+            result.is_err(),
+            "should reject event with mismatched repo_id and worktree_id"
+        );
+    }
+
+    #[test]
     fn foreign_key_prevents_orphan_worktree() {
         let db = Database::open_in_memory().unwrap();
         let result = db.insert_worktree(9999, "wt", "b", "/wt", None);

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -174,4 +174,26 @@ mod tests {
         assert_eq!(fetched.base_branch, wt.base_branch);
         assert_eq!(fetched.managed, wt.managed);
     }
+
+    #[test]
+    fn list_worktrees_scoped_to_repo() {
+        let db = Database::open_in_memory().unwrap();
+        let repo_a = db.insert_repo("repo-a", "/a", None).unwrap();
+        let repo_b = db.insert_repo("repo-b", "/b", None).unwrap();
+
+        db.insert_worktree(repo_a.id, "wt-1", "branch-1", "/a/wt-1", None)
+            .unwrap();
+        db.insert_worktree(repo_a.id, "wt-2", "branch-2", "/a/wt-2", None)
+            .unwrap();
+        db.insert_worktree(repo_b.id, "wt-3", "branch-3", "/b/wt-3", None)
+            .unwrap();
+
+        let list_a = db.list_worktrees(repo_a.id).expect("list should succeed");
+        assert_eq!(list_a.len(), 2);
+        assert!(list_a.iter().all(|w| w.repo_id == repo_a.id));
+
+        let list_b = db.list_worktrees(repo_b.id).unwrap();
+        assert_eq!(list_b.len(), 1);
+        assert_eq!(list_b[0].name, "wt-3");
+    }
 }

--- a/src/state/queries.rs
+++ b/src/state/queries.rs
@@ -1,0 +1,1 @@
+// Query methods for Database — implemented in subsequent TDD slices.

--- a/src/state/queries.rs
+++ b/src/state/queries.rs
@@ -1,1 +1,63 @@
-// Query methods for Database — implemented in subsequent TDD slices.
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use anyhow::{Context, Result};
+use rusqlite::OptionalExtension;
+
+use super::{Database, Repo};
+
+fn now() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock before UNIX epoch")
+        .as_secs() as i64
+}
+
+impl Database {
+    /// Insert a new repo and return the populated struct.
+    pub fn insert_repo(
+        &self,
+        name: &str,
+        path: &str,
+        default_base: Option<&str>,
+    ) -> Result<Repo> {
+        let created_at = now();
+        self.conn
+            .execute(
+                "INSERT INTO repos (name, path, default_base, created_at) VALUES (?1, ?2, ?3, ?4)",
+                rusqlite::params![name, path, default_base, created_at],
+            )
+            .context("failed to insert repo")?;
+
+        let id = self.conn.last_insert_rowid();
+        Ok(Repo {
+            id,
+            name: name.to_string(),
+            path: path.to_string(),
+            default_base: default_base.map(String::from),
+            created_at,
+        })
+    }
+
+    /// Get a repo by id, returning `None` if not found.
+    pub fn get_repo(&self, id: i64) -> Result<Option<Repo>> {
+        let mut stmt = self
+            .conn
+            .prepare("SELECT id, name, path, default_base, created_at FROM repos WHERE id = ?1")
+            .context("failed to prepare get_repo query")?;
+
+        let repo = stmt
+            .query_row(rusqlite::params![id], |row| {
+                Ok(Repo {
+                    id: row.get(0)?,
+                    name: row.get(1)?,
+                    path: row.get(2)?,
+                    default_base: row.get(3)?,
+                    created_at: row.get(4)?,
+                })
+            })
+            .optional()
+            .context("failed to get repo")?;
+
+        Ok(repo)
+    }
+}

--- a/src/state/queries.rs
+++ b/src/state/queries.rs
@@ -3,7 +3,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use anyhow::{Context, Result};
 use rusqlite::OptionalExtension;
 
-use super::{Database, Repo};
+use super::{Database, Repo, Worktree};
 
 fn now() -> i64 {
     SystemTime::now()
@@ -38,7 +38,7 @@ impl Database {
         })
     }
 
-    /// Get a repo by id, returning `None` if not found.
+    /// Get a repo by id. Returns `None` if not found.
     pub fn get_repo(&self, id: i64) -> Result<Option<Repo>> {
         let mut stmt = self
             .conn
@@ -59,5 +59,66 @@ impl Database {
             .context("failed to get repo")?;
 
         Ok(repo)
+    }
+
+    /// Insert a new worktree and return the populated struct.
+    pub fn insert_worktree(
+        &self,
+        repo_id: i64,
+        name: &str,
+        branch: &str,
+        path: &str,
+        base_branch: Option<&str>,
+    ) -> Result<Worktree> {
+        let created_at = now();
+        self.conn
+            .execute(
+                "INSERT INTO worktrees (repo_id, name, branch, path, base_branch, managed, created_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, 1, ?6)",
+                rusqlite::params![repo_id, name, branch, path, base_branch, created_at],
+            )
+            .context("failed to insert worktree")?;
+
+        let id = self.conn.last_insert_rowid();
+        Ok(Worktree {
+            id,
+            repo_id,
+            name: name.to_string(),
+            branch: branch.to_string(),
+            path: path.to_string(),
+            base_branch: base_branch.map(String::from),
+            managed: true,
+            adopted_at: None,
+            last_accessed: None,
+            created_at,
+        })
+    }
+
+    /// Get a worktree by id. Returns `None` if not found.
+    pub fn get_worktree(&self, id: i64) -> Result<Option<Worktree>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id, repo_id, name, branch, path, base_branch, managed, adopted_at, last_accessed, created_at
+             FROM worktrees WHERE id = ?1",
+        ).context("failed to prepare get_worktree query")?;
+
+        let wt = stmt
+            .query_row(rusqlite::params![id], |row| {
+                Ok(Worktree {
+                    id: row.get(0)?,
+                    repo_id: row.get(1)?,
+                    name: row.get(2)?,
+                    branch: row.get(3)?,
+                    path: row.get(4)?,
+                    base_branch: row.get(5)?,
+                    managed: row.get::<_, i64>(6)? != 0,
+                    adopted_at: row.get(7)?,
+                    last_accessed: row.get(8)?,
+                    created_at: row.get(9)?,
+                })
+            })
+            .optional()
+            .context("failed to get worktree")?;
+
+        Ok(wt)
     }
 }

--- a/src/state/queries.rs
+++ b/src/state/queries.rs
@@ -158,13 +158,13 @@ impl Database {
         let mut sets = Vec::new();
         let mut params: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
 
-        if let Some(v) = update.last_accessed {
+        if let Some(ref v) = update.last_accessed {
             sets.push("last_accessed = ?");
-            params.push(Box::new(v));
+            params.push(Box::new(*v));
         }
-        if let Some(v) = update.adopted_at {
+        if let Some(ref v) = update.adopted_at {
             sets.push("adopted_at = ?");
-            params.push(Box::new(v));
+            params.push(Box::new(*v));
         }
         if let Some(v) = update.managed {
             sets.push("managed = ?");

--- a/src/state/queries.rs
+++ b/src/state/queries.rs
@@ -191,4 +191,25 @@ impl Database {
 
         Ok(())
     }
+
+    /// Insert an event and return its id.
+    pub fn insert_event(
+        &self,
+        repo_id: i64,
+        worktree_id: Option<i64>,
+        event_type: &str,
+        payload: Option<&serde_json::Value>,
+    ) -> Result<i64> {
+        let created_at = now();
+        let payload_str = payload.map(|v| v.to_string());
+        self.conn
+            .execute(
+                "INSERT INTO events (repo_id, worktree_id, event_type, payload, created_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5)",
+                rusqlite::params![repo_id, worktree_id, event_type, payload_str, created_at],
+            )
+            .context("failed to insert event")?;
+
+        Ok(self.conn.last_insert_rowid())
+    }
 }

--- a/src/state/sql/001_initial_schema.sql
+++ b/src/state/sql/001_initial_schema.sql
@@ -1,0 +1,55 @@
+-- Migration 001: Initial schema
+-- Creates all 6 core tables for trench state management.
+
+CREATE TABLE repos (
+    id          INTEGER PRIMARY KEY,
+    name        TEXT    NOT NULL,
+    path        TEXT    NOT NULL UNIQUE,
+    default_base TEXT,
+    created_at  INTEGER NOT NULL
+);
+
+CREATE TABLE worktrees (
+    id            INTEGER PRIMARY KEY,
+    repo_id       INTEGER NOT NULL REFERENCES repos(id),
+    name          TEXT    NOT NULL,
+    branch        TEXT    NOT NULL,
+    path          TEXT    NOT NULL UNIQUE,
+    base_branch   TEXT,
+    managed       INTEGER NOT NULL DEFAULT 1,
+    adopted_at    INTEGER,
+    last_accessed INTEGER,
+    created_at    INTEGER NOT NULL
+);
+
+CREATE TABLE events (
+    id           INTEGER PRIMARY KEY,
+    worktree_id  INTEGER REFERENCES worktrees(id),
+    repo_id      INTEGER NOT NULL REFERENCES repos(id),
+    event_type   TEXT    NOT NULL,
+    payload      TEXT,
+    created_at   INTEGER NOT NULL
+);
+
+CREATE TABLE logs (
+    id          INTEGER PRIMARY KEY,
+    event_id    INTEGER NOT NULL REFERENCES events(id),
+    stream      TEXT    NOT NULL,
+    line        TEXT    NOT NULL,
+    line_number INTEGER NOT NULL,
+    created_at  INTEGER NOT NULL
+);
+
+CREATE TABLE tags (
+    id          INTEGER PRIMARY KEY,
+    worktree_id INTEGER NOT NULL REFERENCES worktrees(id),
+    name        TEXT    NOT NULL,
+    created_at  INTEGER NOT NULL,
+    UNIQUE(worktree_id, name)
+);
+
+CREATE TABLE session (
+    key        TEXT    PRIMARY KEY,
+    value      TEXT    NOT NULL,
+    updated_at INTEGER NOT NULL
+);

--- a/src/state/sql/001_initial_schema.sql
+++ b/src/state/sql/001_initial_schema.sql
@@ -31,6 +31,14 @@ CREATE TABLE events (
     created_at   INTEGER NOT NULL
 );
 
+CREATE TRIGGER events_check_worktree_repo_consistency
+BEFORE INSERT ON events
+WHEN NEW.worktree_id IS NOT NULL
+BEGIN
+    SELECT RAISE(ABORT, 'events.repo_id does not match worktree.repo_id')
+    WHERE NEW.repo_id != (SELECT repo_id FROM worktrees WHERE id = NEW.worktree_id);
+END;
+
 CREATE TABLE logs (
     id          INTEGER PRIMARY KEY,
     event_id    INTEGER NOT NULL REFERENCES events(id),


### PR DESCRIPTION
Closes #4

## Summary
Implements the full state layer in `src/state/`: SQLite connection with WAL mode, FK ON, and synchronous NORMAL pragmas; migration 001 creating all 6 schema tables (repos, worktrees, events, logs, tags, session); and typed query methods for repos, worktrees, and events with partial update support via `WorktreeUpdate`.

## User Stories Addressed
- US-1: State persistence for created worktrees (insert/get/list worktrees)
- US-5: Worktree listing from DB (list_worktrees scoped by repo)
- US-10: Event/log storage foundation (insert_event with JSON payloads)

## Automated Testing
- Total tests added: 7
- Tests passing: 7
- Tests failing: 0
- `cargo clippy`: pass (only dead_code warnings from unused modules — expected since main.rs doesn't use state layer yet)
- `cargo test`: pass (35 total: 28 pre-existing + 7 new)

## Manual Testing Checklist
1. Clone the branch and run `cargo test` — all 35 tests should pass
2. Run `cargo clippy` — should show only dead_code warnings, no errors
3. Review `src/state/sql/001_initial_schema.sql` — verify all 6 tables match the spec (repos, worktrees, events, logs, tags, session)
4. Review `src/state/mod.rs` — verify `Database::open()` sets WAL, FK ON, synchronous NORMAL
5. Review `src/state/queries.rs` — verify typed query methods return proper Rust structs
6. Optionally: run a quick smoke test by adding `state::Database::open_in_memory().unwrap();` to `main()` and running `cargo run`

## Known Issues
None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced persistent storage for repository and worktree management.
  * Enabled database operations for storing, retrieving, and updating repository and worktree configurations.
  * Added event logging capabilities for tracking system activities and state changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->