### PR TITLE
feat(tui): ratatui + crossterm event loop + terminal setup/teardown

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -72,9 +72,15 @@ impl Cli {
     }
 }
 
-fn main() {
+fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
-    let output_config = cli.output_config();
+    let _output_config = cli.output_config();
+
+    if cli.command.is_none() {
+        return tui::run();
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1,6 +1,7 @@
 pub mod screens;
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use ratatui::{layout::Alignment, widgets::Paragraph, Frame};
 
 pub struct App {
     running: bool,
@@ -13,6 +14,12 @@ impl App {
 
     pub fn is_running(&self) -> bool {
         self.running
+    }
+
+    pub fn ui(&self, frame: &mut Frame) {
+        let placeholder = Paragraph::new("trench TUI — press q to quit")
+            .alignment(Alignment::Center);
+        frame.render_widget(placeholder, frame.area());
     }
 
     pub fn handle_key_event(&mut self, key: KeyEvent) {
@@ -56,5 +63,26 @@ mod tests {
         app.handle_key_event(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
         app.handle_key_event(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
         assert!(app.is_running(), "non-quit keys should not stop the app");
+    }
+
+    #[test]
+    fn placeholder_ui_renders_trench_tui() {
+        let app = App::new();
+        let backend = ratatui::backend::TestBackend::new(80, 24);
+        let mut terminal = ratatui::Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| app.ui(frame))
+            .unwrap();
+        let buffer = terminal.backend().buffer().clone();
+        let content: String = buffer
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect();
+        assert!(
+            content.contains("trench TUI"),
+            "placeholder screen should contain 'trench TUI', got: {:?}",
+            content.trim()
+        );
     }
 }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -48,4 +48,13 @@ mod tests {
         app.handle_key_event(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL));
         assert!(!app.is_running(), "app should stop after Ctrl+C");
     }
+
+    #[test]
+    fn app_ignores_other_keys() {
+        let mut app = App::new();
+        app.handle_key_event(KeyEvent::new(KeyCode::Char('a'), KeyModifiers::NONE));
+        app.handle_key_event(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+        app.handle_key_event(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
+        assert!(app.is_running(), "non-quit keys should not stop the app");
+    }
 }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1,6 +1,6 @@
 pub mod screens;
 
-use crossterm::event::{KeyCode, KeyEvent};
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
 pub struct App {
     running: bool,
@@ -16,8 +16,10 @@ impl App {
     }
 
     pub fn handle_key_event(&mut self, key: KeyEvent) {
-        if key.code == KeyCode::Char('q') {
-            self.running = false;
+        match (key.code, key.modifiers) {
+            (KeyCode::Char('q'), _) => self.running = false,
+            (KeyCode::Char('c'), KeyModifiers::CONTROL) => self.running = false,
+            _ => {}
         }
     }
 }
@@ -38,5 +40,12 @@ mod tests {
         let mut app = App::new();
         app.handle_key_event(KeyEvent::new(KeyCode::Char('q'), KeyModifiers::NONE));
         assert!(!app.is_running(), "app should stop after pressing 'q'");
+    }
+
+    #[test]
+    fn app_exits_on_ctrl_c() {
+        let mut app = App::new();
+        app.handle_key_event(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL));
+        assert!(!app.is_running(), "app should stop after Ctrl+C");
     }
 }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1,5 +1,7 @@
 pub mod screens;
 
+use crossterm::event::{KeyCode, KeyEvent};
+
 pub struct App {
     running: bool,
 }
@@ -12,15 +14,29 @@ impl App {
     pub fn is_running(&self) -> bool {
         self.running
     }
+
+    pub fn handle_key_event(&mut self, key: KeyEvent) {
+        if key.code == KeyCode::Char('q') {
+            self.running = false;
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
     #[test]
     fn app_starts_in_running_state() {
         let app = App::new();
         assert!(app.is_running(), "newly created app should be running");
+    }
+
+    #[test]
+    fn app_exits_on_q_key() {
+        let mut app = App::new();
+        app.handle_key_event(KeyEvent::new(KeyCode::Char('q'), KeyModifiers::NONE));
+        assert!(!app.is_running(), "app should stop after pressing 'q'");
     }
 }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1,1 +1,26 @@
 pub mod screens;
+
+pub struct App {
+    running: bool,
+}
+
+impl App {
+    pub fn new() -> Self {
+        Self { running: true }
+    }
+
+    pub fn is_running(&self) -> bool {
+        self.running
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn app_starts_in_running_state() {
+        let app = App::new();
+        assert!(app.is_running(), "newly created app should be running");
+    }
+}


### PR DESCRIPTION
Closes #6

## Summary
Set up the TUI foundation in `src/tui/`: terminal initialization via ratatui (crossterm raw mode + alternate screen), clean teardown on exit, panic hook for terminal restoration, main event loop with keyboard input processing, and a basic `App` struct. Running `trench` with no subcommand now launches a placeholder TUI screen with `q`/`Ctrl+C` to quit.

## User Stories Addressed
- US-11: Use a TUI to browse worktrees, create new ones, and view details (foundation)

## Automated Testing
- Total tests added: 5
- Tests passing: 5
- Tests failing: 0
- `cargo clippy`: pass
- `cargo test`: pass (53 total, 5 new TUI tests)

## UAT Checklist
- [x] Run `cargo run` (no subcommand) → TUI appears with placeholder "trench TUI" text
- [x] Press `q` → TUI exits cleanly, terminal restored to normal
- [x] Press `Ctrl+C` → TUI exits cleanly, terminal restored to normal
- [x] Press other keys (a, Enter, arrows) → TUI stays open, no crash
- [x] Run `cargo run -- list` → does NOT enter TUI (subcommand handled normally)
- [x] Force a panic in the event loop (e.g., `unwrap()` on `None`) → terminal still restores on crash

## Known Issues
None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a terminal user interface (TUI) mode that launches when an interactive terminal is detected and no command is provided.
  * TUI includes keyboard handling to exit with `q` or `Ctrl+C` and a basic centered UI placeholder.

* **Behavior Changes**
  * CLI now enforces interactive-terminal requirements and exits with a clear error if TUI cannot be started.

* **Tests**
  * Added and expanded tests covering TUI launch conditions, lifecycle, input handling, and panic restoration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->