### PR TITLE
feat(git): repo discovery + create worktree on disk

### DIFF
--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -100,4 +100,19 @@ mod tests {
         let expected_name = tmp.path().file_name().unwrap().to_str().unwrap();
         assert_eq!(info.name, expected_name);
     }
+
+    #[test]
+    fn discover_repo_fails_for_non_git_directory() {
+        let tmp = tempfile::tempdir().unwrap();
+        // No git init — just a plain directory
+
+        let result = discover_repo(tmp.path());
+
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(
+            matches!(err, GitError::NotAGitRepo { .. }),
+            "expected NotAGitRepo, got: {err:?}"
+        );
+    }
 }

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -1,0 +1,87 @@
+use std::path::{Path, PathBuf};
+
+/// Information about a discovered git repository.
+#[derive(Debug, Clone)]
+pub struct RepoInfo {
+    pub name: String,
+    pub path: PathBuf,
+    pub remote_url: Option<String>,
+    pub default_branch: String,
+}
+
+/// Errors specific to git operations.
+#[derive(Debug, thiserror::Error)]
+pub enum GitError {
+    #[error("not a git repository: {path}")]
+    NotAGitRepo { path: PathBuf },
+
+    #[error("branch already exists: {branch}")]
+    BranchAlreadyExists { branch: String },
+
+    #[error("{0}")]
+    Git(#[from] git2::Error),
+}
+
+/// Discover a git repository by walking up from the given path.
+///
+/// Returns a `RepoInfo` with the repo name (derived from the working directory),
+/// the canonical repo path, optional origin remote URL, and the default branch.
+pub fn discover_repo(path: &Path) -> Result<RepoInfo, GitError> {
+    let repo = git2::Repository::discover(path).map_err(|_| GitError::NotAGitRepo {
+        path: path.to_path_buf(),
+    })?;
+
+    let workdir = repo
+        .workdir()
+        .ok_or_else(|| GitError::NotAGitRepo {
+            path: path.to_path_buf(),
+        })?
+        .canonicalize()
+        .map_err(|_| GitError::NotAGitRepo {
+            path: path.to_path_buf(),
+        })?;
+
+    let name = workdir
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_default();
+
+    Ok(RepoInfo {
+        name,
+        path: workdir,
+        remote_url: None,
+        default_branch: String::from("main"),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Helper: create a temp git repo with an initial commit.
+    fn init_repo_with_commit(dir: &Path) -> git2::Repository {
+        let repo = git2::Repository::init(dir).expect("failed to init repo");
+        // Create an initial commit so HEAD is valid
+        {
+            let sig = git2::Signature::now("Test", "test@test.com").unwrap();
+            let tree_id = repo.index().unwrap().write_tree().unwrap();
+            let tree = repo.find_tree(tree_id).unwrap();
+            repo.commit(Some("HEAD"), &sig, &sig, "initial commit", &tree, &[])
+                .unwrap();
+        }
+        repo
+    }
+
+    #[test]
+    fn discover_repo_finds_repo_at_root() {
+        let tmp = tempfile::tempdir().unwrap();
+        let _repo = init_repo_with_commit(tmp.path());
+
+        let info = discover_repo(tmp.path()).expect("should discover repo");
+
+        assert_eq!(info.path, tmp.path().canonicalize().unwrap());
+        // Name is derived from directory name
+        let expected_name = tmp.path().file_name().unwrap().to_str().unwrap();
+        assert_eq!(info.name, expected_name);
+    }
+}

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -84,4 +84,20 @@ mod tests {
         let expected_name = tmp.path().file_name().unwrap().to_str().unwrap();
         assert_eq!(info.name, expected_name);
     }
+
+    #[test]
+    fn discover_repo_finds_repo_from_subdirectory() {
+        let tmp = tempfile::tempdir().unwrap();
+        let _repo = init_repo_with_commit(tmp.path());
+
+        // Create a nested subdirectory
+        let subdir = tmp.path().join("src").join("deep");
+        std::fs::create_dir_all(&subdir).unwrap();
+
+        let info = discover_repo(&subdir).expect("should discover repo from subdir");
+
+        assert_eq!(info.path, tmp.path().canonicalize().unwrap());
+        let expected_name = tmp.path().file_name().unwrap().to_str().unwrap();
+        assert_eq!(info.name, expected_name);
+    }
 }

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 
 /// Information about a discovered git repository.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct RepoInfo {
     pub name: String,
     pub path: PathBuf,
@@ -22,14 +22,27 @@ pub enum GitError {
     Git(#[from] git2::Error),
 }
 
+/// Map a git2 error to the appropriate `GitError`.
+///
+/// Returns `NotAGitRepo` when the error code is `NotFound`, preserving the
+/// original `git2::Error` for all other failure modes.
+fn map_repo_open_error(e: git2::Error, path: &Path) -> GitError {
+    if e.code() == git2::ErrorCode::NotFound {
+        GitError::NotAGitRepo {
+            path: path.to_path_buf(),
+        }
+    } else {
+        GitError::Git(e)
+    }
+}
+
 /// Discover a git repository by walking up from the given path.
 ///
 /// Returns a `RepoInfo` with the repo name (derived from the working directory),
 /// the canonical repo path, optional origin remote URL, and the default branch.
 pub fn discover_repo(path: &Path) -> Result<RepoInfo, GitError> {
-    let repo = git2::Repository::discover(path).map_err(|_| GitError::NotAGitRepo {
-        path: path.to_path_buf(),
-    })?;
+    let repo =
+        git2::Repository::discover(path).map_err(|e| map_repo_open_error(e, path))?;
 
     let workdir = repo
         .workdir()
@@ -44,7 +57,7 @@ pub fn discover_repo(path: &Path) -> Result<RepoInfo, GitError> {
     let name = workdir
         .file_name()
         .map(|n| n.to_string_lossy().into_owned())
-        .unwrap_or_default();
+        .unwrap_or_else(|| String::from("repo"));
 
     // Extract origin remote URL if present
     let remote_url = repo
@@ -79,9 +92,8 @@ pub fn create_worktree(
     base: &str,
     target_path: &Path,
 ) -> Result<(), GitError> {
-    let repo = git2::Repository::open(repo_path).map_err(|_| GitError::NotAGitRepo {
-        path: repo_path.to_path_buf(),
-    })?;
+    let repo =
+        git2::Repository::open(repo_path).map_err(|e| map_repo_open_error(e, repo_path))?;
 
     // Check if branch already exists locally
     if repo
@@ -97,11 +109,21 @@ pub fn create_worktree(
     let base_ref = repo.find_branch(base, git2::BranchType::Local)?;
     let base_commit = base_ref.get().peel_to_commit()?;
 
-    // Create the new branch from base and add the worktree
-    let new_branch = repo.branch(branch, &base_commit, false)?;
-    let mut opts = git2::WorktreeAddOptions::new();
-    opts.reference(Some(new_branch.get()));
-    repo.worktree(branch, target_path, Some(&opts))?;
+    // Create the new branch from base and add the worktree.
+    // If worktree creation fails, clean up the orphaned branch.
+    let worktree_result = {
+        let new_branch = repo.branch(branch, &base_commit, false)?;
+        let mut opts = git2::WorktreeAddOptions::new();
+        opts.reference(Some(new_branch.get()));
+        repo.worktree(branch, target_path, Some(&opts))
+    };
+
+    if let Err(e) = worktree_result {
+        if let Ok(mut orphan) = repo.find_branch(branch, git2::BranchType::Local) {
+            let _ = orphan.delete();
+        }
+        return Err(GitError::Git(e));
+    }
 
     Ok(())
 }
@@ -126,6 +148,60 @@ mod tests {
     /// Helper: get the default branch name from HEAD.
     fn head_branch(repo: &git2::Repository) -> String {
         repo.head().unwrap().shorthand().unwrap().to_string()
+    }
+
+    #[test]
+    fn repo_info_supports_equality() {
+        let a = RepoInfo {
+            name: "repo".into(),
+            path: PathBuf::from("/tmp/repo"),
+            remote_url: Some("https://github.com/test/repo.git".into()),
+            default_branch: "main".into(),
+        };
+        let b = RepoInfo {
+            name: "repo".into(),
+            path: PathBuf::from("/tmp/repo"),
+            remote_url: Some("https://github.com/test/repo.git".into()),
+            default_branch: "main".into(),
+        };
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn discover_repo_name_is_nonempty() {
+        let tmp = tempfile::tempdir().unwrap();
+        let _repo = init_repo_with_commit(tmp.path());
+
+        let info = discover_repo(tmp.path()).expect("should discover repo");
+
+        assert!(!info.name.is_empty(), "repo name must never be empty");
+    }
+
+    #[test]
+    fn discover_repo_on_nonexistent_path_returns_not_a_git_repo() {
+        let result = discover_repo(Path::new("/tmp/nonexistent_path_xyz_abc"));
+
+        assert!(result.is_err());
+        assert!(
+            matches!(result.unwrap_err(), GitError::NotAGitRepo { .. }),
+            "nonexistent path should yield NotAGitRepo"
+        );
+    }
+
+    #[test]
+    fn create_worktree_on_nonexistent_repo_returns_not_a_git_repo() {
+        let result = create_worktree(
+            Path::new("/tmp/nonexistent_repo_xyz_abc"),
+            "branch",
+            "main",
+            Path::new("/tmp/wt"),
+        );
+
+        assert!(result.is_err());
+        assert!(
+            matches!(result.unwrap_err(), GitError::NotAGitRepo { .. }),
+            "nonexistent repo path should yield NotAGitRepo"
+        );
     }
 
     #[test]
@@ -256,6 +332,61 @@ mod tests {
             target.join(".git").exists(),
             "worktree should have .git entry"
         );
+    }
+
+    #[test]
+    fn create_worktree_cleans_up_branch_on_worktree_failure() {
+        let repo_dir = tempfile::tempdir().unwrap();
+        let repo = init_repo_with_commit(repo_dir.path());
+        let base = head_branch(&repo);
+        let wt_dir = tempfile::tempdir().unwrap();
+        let target = wt_dir.path().join("will-fail");
+
+        // Place a regular file at the target path so worktree creation fails
+        std::fs::write(&target, "blocker").unwrap();
+
+        let result = create_worktree(repo_dir.path(), "will-fail", &base, &target);
+
+        assert!(result.is_err(), "should fail when target path is occupied");
+
+        // The orphaned branch must have been cleaned up
+        assert!(
+            repo.find_branch("will-fail", git2::BranchType::Local)
+                .is_err(),
+            "branch should be deleted after worktree creation failure"
+        );
+    }
+
+    #[test]
+    fn create_worktree_errors_when_base_branch_does_not_exist() {
+        let repo_dir = tempfile::tempdir().unwrap();
+        let _repo = init_repo_with_commit(repo_dir.path());
+        let wt_dir = tempfile::tempdir().unwrap();
+        let target = wt_dir.path().join("feature");
+
+        let result = create_worktree(repo_dir.path(), "feature", "nonexistent-base", &target);
+
+        assert!(result.is_err());
+        assert!(
+            matches!(result.unwrap_err(), GitError::Git(_)),
+            "missing base branch should yield GitError::Git"
+        );
+    }
+
+    #[test]
+    fn create_worktree_errors_when_target_path_already_exists() {
+        let repo_dir = tempfile::tempdir().unwrap();
+        let repo = init_repo_with_commit(repo_dir.path());
+        let base = head_branch(&repo);
+        let wt_dir = tempfile::tempdir().unwrap();
+        let target = wt_dir.path().join("occupied");
+
+        // Create a directory at the target path
+        std::fs::create_dir_all(&target).unwrap();
+
+        let result = create_worktree(repo_dir.path(), "occupied", &base, &target);
+
+        assert!(result.is_err(), "should fail when target path already exists");
     }
 
     #[test]


### PR DESCRIPTION
Closes #7

## Summary
Implements git repository discovery (`discover_repo`) and worktree creation (`create_worktree`) in `src/git/mod.rs` using `git2` (libgit2 bindings). Discovery walks up from any path to find the `.git` directory and extracts repo name, path, origin remote URL, and default branch. Worktree creation validates branch uniqueness, creates a new branch from the specified base, and adds a git worktree at the target path on disk.

## User Stories Addressed
- US-1: Create a new worktree for a feature branch with one command

## Automated Testing
- Total tests added: 9 (in `src/git/mod.rs`)
- Tests passing: 9
- Tests failing: 0
- `cargo clippy`: pass (only pre-existing dead_code warnings from unused modules)
- `cargo test`: pass (67 total, 0 failures)

## UAT Checklist
- [ ] Clone the repo, run `cargo test git::tests` — all 9 git tests pass
- [ ] In a git repo, call `discover_repo(".")` from a Rust test/script — returns correct repo name, path, remote URL, and default branch
- [ ] Call `discover_repo` from a nested subdirectory — still finds the repo
- [ ] Call `discover_repo` on a plain (non-git) directory — returns `NotAGitRepo` error
- [ ] Call `create_worktree` with a new branch name — worktree directory exists on disk, `git worktree list` shows it
- [ ] Call `create_worktree` with an already-existing branch — returns `BranchAlreadyExists` error, no directory created
- [ ] Verify created worktree has a `.git` file (not directory) and the branch points to the same commit as base

## Known Issues
None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Repository discovery to surface repo metadata (name, path, remote, default branch)
  * Create worktrees with branch creation from an existing base and configurable target location

* **Bug Fixes**
  * Ensures branches/worktrees are cleaned up if worktree creation fails to avoid leftover state
<!-- end of auto-generated comment: release notes by coderabbit.ai -->