### PR TITLE
feat(config): global config TOML loading from XDG path

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use serde::Deserialize;
 
 #[derive(Debug, Default, Deserialize, PartialEq)]
@@ -39,7 +39,11 @@ pub fn load_global_config_from(path: &Path) -> Result<GlobalConfig> {
     if !path.exists() {
         return Ok(GlobalConfig::default());
     }
-    todo!()
+    let contents = std::fs::read_to_string(path)
+        .with_context(|| format!("failed to read config file: {}", path.display()))?;
+    let config: GlobalConfig = toml::from_str(&contents)
+        .with_context(|| format!("invalid TOML in config file: {}", path.display()))?;
+    Ok(config)
 }
 
 /// Load global config from the XDG config directory.
@@ -55,6 +59,12 @@ mod tests {
     use super::*;
     use tempfile::TempDir;
 
+    fn write_config(dir: &TempDir, content: &str) -> std::path::PathBuf {
+        let path = dir.path().join("config.toml");
+        std::fs::write(&path, content).unwrap();
+        path
+    }
+
     #[test]
     fn missing_file_returns_defaults() {
         let dir = TempDir::new().unwrap();
@@ -66,5 +76,55 @@ mod tests {
         assert!(config.ui.is_none());
         assert!(config.git.is_none());
         assert!(config.worktrees.is_none());
+    }
+
+    #[test]
+    fn full_valid_toml_loads_all_fields() {
+        let dir = TempDir::new().unwrap();
+        let path = write_config(
+            &dir,
+            r#"
+[ui]
+theme = "dark"
+date_format = "%Y-%m-%d"
+show_ahead_behind = true
+show_dirty_count = false
+
+[git]
+default_base = "main"
+auto_prune = true
+fetch_on_open = false
+
+[worktrees]
+root = "{{ repo }}/{{ branch | sanitize }}"
+scan = ["/home/user/projects", "/tmp/worktrees"]
+"#,
+        );
+
+        let config = load_global_config_from(&path).unwrap();
+
+        let ui = config.ui.unwrap();
+        assert_eq!(ui.theme.as_deref(), Some("dark"));
+        assert_eq!(ui.date_format.as_deref(), Some("%Y-%m-%d"));
+        assert_eq!(ui.show_ahead_behind, Some(true));
+        assert_eq!(ui.show_dirty_count, Some(false));
+
+        let git = config.git.unwrap();
+        assert_eq!(git.default_base.as_deref(), Some("main"));
+        assert_eq!(git.auto_prune, Some(true));
+        assert_eq!(git.fetch_on_open, Some(false));
+
+        let wt = config.worktrees.unwrap();
+        assert_eq!(
+            wt.root.as_deref(),
+            Some("{{ repo }}/{{ branch | sanitize }}")
+        );
+        assert_eq!(
+            wt.scan,
+            Some(vec![
+                "/home/user/projects".to_string(),
+                "/tmp/worktrees".to_string()
+            ])
+        );
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -272,12 +272,4 @@ show_ahead_behind = "yes"
         assert!(path.starts_with(dirs::config_dir().unwrap()));
     }
 
-    #[test]
-    fn load_global_config_returns_valid_result() {
-        // On the test runner, the file likely doesn't exist — should return defaults.
-        // If it does exist, should parse successfully.
-        let config = load_global_config().unwrap();
-        // Regardless of file state, this should not error
-        let _ = config;
-    }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -48,15 +48,15 @@ pub fn load_global_config_from(path: &Path) -> Result<GlobalConfig> {
     Ok(config)
 }
 
-/// Load global config from the XDG config directory.
-///
-/// Reads `~/.config/trench/config.toml` (or platform equivalent).
-/// Returns defaults if the file does not exist.
 /// Return the path to the global config file (`~/.config/trench/config.toml`).
 pub fn global_config_path() -> Result<PathBuf> {
     Ok(paths::config_dir()?.join("config.toml"))
 }
 
+/// Load global config from the XDG config directory.
+///
+/// Reads `~/.config/trench/config.toml` (or platform equivalent).
+/// Returns defaults if the file does not exist.
 pub fn load_global_config() -> Result<GlobalConfig> {
     let path = global_config_path()?;
     load_global_config_from(&path)

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,0 +1,70 @@
+use std::path::Path;
+
+use anyhow::Result;
+use serde::Deserialize;
+
+#[derive(Debug, Default, Deserialize, PartialEq)]
+pub struct GlobalConfig {
+    pub ui: Option<UiConfig>,
+    pub git: Option<GitConfig>,
+    pub worktrees: Option<WorktreesConfig>,
+}
+
+#[derive(Debug, Default, Deserialize, PartialEq)]
+pub struct UiConfig {
+    pub theme: Option<String>,
+    pub date_format: Option<String>,
+    pub show_ahead_behind: Option<bool>,
+    pub show_dirty_count: Option<bool>,
+}
+
+#[derive(Debug, Default, Deserialize, PartialEq)]
+pub struct GitConfig {
+    pub default_base: Option<String>,
+    pub auto_prune: Option<bool>,
+    pub fetch_on_open: Option<bool>,
+}
+
+#[derive(Debug, Default, Deserialize, PartialEq)]
+pub struct WorktreesConfig {
+    pub root: Option<String>,
+    pub scan: Option<Vec<String>>,
+}
+
+/// Load global config from a specific file path.
+///
+/// Returns `GlobalConfig::default()` if the file does not exist.
+/// Returns an error if the file exists but contains invalid TOML.
+pub fn load_global_config_from(path: &Path) -> Result<GlobalConfig> {
+    if !path.exists() {
+        return Ok(GlobalConfig::default());
+    }
+    todo!()
+}
+
+/// Load global config from the XDG config directory.
+///
+/// Reads `~/.config/trench/config.toml` (or platform equivalent).
+/// Returns defaults if the file does not exist.
+pub fn load_global_config() -> Result<GlobalConfig> {
+    todo!()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn missing_file_returns_defaults() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("nonexistent.toml");
+
+        let config = load_global_config_from(&path).unwrap();
+
+        assert_eq!(config, GlobalConfig::default());
+        assert!(config.ui.is_none());
+        assert!(config.git.is_none());
+        assert!(config.worktrees.is_none());
+    }
+}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -187,4 +187,40 @@ scan = ["/opt/trees"]
         let config = load_global_config_from(&path).unwrap();
         assert_eq!(config, GlobalConfig::default());
     }
+
+    #[test]
+    fn invalid_toml_returns_error_with_path() {
+        let dir = TempDir::new().unwrap();
+        let path = write_config(&dir, "this is not [valid toml");
+
+        let err = load_global_config_from(&path).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("invalid TOML"),
+            "expected 'invalid TOML' in error: {msg}"
+        );
+        assert!(
+            msg.contains("config.toml"),
+            "expected file path in error: {msg}"
+        );
+    }
+
+    #[test]
+    fn wrong_type_returns_error() {
+        let dir = TempDir::new().unwrap();
+        let path = write_config(
+            &dir,
+            r#"
+[ui]
+show_ahead_behind = "yes"
+"#,
+        );
+
+        let err = load_global_config_from(&path).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("invalid TOML"),
+            "expected 'invalid TOML' in error: {msg}"
+        );
+    }
 }


### PR DESCRIPTION
Closes #8

## Summary
Implements global config loading in `src/config/mod.rs`. Defines `GlobalConfig`, `UiConfig`, `GitConfig`, and `WorktreesConfig` structs with all fields as `Option<T>` for partial config support. `load_global_config()` reads from `~/.config/trench/config.toml` via XDG path resolution, returning defaults when the file is missing and clear errors when the TOML is invalid.

## User Stories Addressed
- US-3: Configuration system (commit `.trench.toml` to repo for consistent team hooks)

## Automated Testing
- Total tests added: 9
- Tests passing: 9
- Tests failing: 0
- `cargo clippy`: pass
- `cargo test`: pass (83 total, 9 new)

## UAT Checklist
- [ ] Create `~/.config/trench/config.toml` with `[ui] theme = "dark"` → `load_global_config()` returns theme = "dark"
- [ ] Delete `~/.config/trench/config.toml` → `load_global_config()` returns defaults without error
- [ ] Create config with only `[git] default_base = "develop"` → ui and worktrees sections are None
- [ ] Create config with `[ui] show_ahead_behind = "yes"` (wrong type) → returns error mentioning "invalid TOML"
- [ ] Verify `global_config_path()` returns `~/.config/trench/config.toml` on macOS/Linux

## Known Issues
None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added global configuration system supporting TOML-based configuration files
  * Configuration can now be loaded from the standard config directory
  * Supports UI, Git, and Worktrees configuration sections with comprehensive error handling

* **Tests**
  * Added unit tests for configuration loading, file validation, and error scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->