### PR TITLE
feat(cli): wire trench create — persist to DB + print path

### DIFF
--- a/src/cli/commands/create.rs
+++ b/src/cli/commands/create.rs
@@ -1,0 +1,129 @@
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+
+use crate::git;
+use crate::paths;
+use crate::state::Database;
+
+/// Execute the `trench create <branch>` command.
+///
+/// Discovers the git repo, resolves the worktree path, creates the worktree
+/// on disk, persists the record to SQLite, and returns the created path.
+pub fn execute(
+    branch: &str,
+    from: Option<&str>,
+    cwd: &Path,
+    worktree_root: &Path,
+    template: &str,
+    db: &Database,
+) -> Result<PathBuf> {
+    let repo_info = git::discover_repo(cwd)?;
+    let relative_path = paths::render_worktree_path(template, &repo_info.name, branch)?;
+    let worktree_path = worktree_root.join(relative_path);
+    let base = from.unwrap_or(&repo_info.default_branch);
+
+    if let Some(parent) = worktree_path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create worktree parent directory: {}", parent.display()))?;
+    }
+
+    git::create_worktree(&repo_info.path, branch, base, &worktree_path)?;
+
+    let repo_path_str = repo_info.path.to_str().unwrap_or_default();
+    let repo = match db.get_repo_by_path(repo_path_str)? {
+        Some(r) => r,
+        None => db.insert_repo(&repo_info.name, repo_path_str, Some(base))?,
+    };
+
+    let sanitized_name = paths::sanitize_branch(branch);
+    let worktree_path_str = worktree_path.to_str().unwrap_or_default();
+    let wt = db.insert_worktree(repo.id, &sanitized_name, branch, worktree_path_str, Some(base))?;
+
+    db.insert_event(repo.id, Some(wt.id), "created", None)?;
+
+    Ok(worktree_path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Helper: create a temp git repo with an initial commit.
+    fn init_repo_with_commit(dir: &Path) -> git2::Repository {
+        let repo = git2::Repository::init(dir).expect("failed to init repo");
+        {
+            let sig = git2::Signature::now("Test", "test@test.com").unwrap();
+            let tree_id = repo.index().unwrap().write_tree().unwrap();
+            let tree = repo.find_tree(tree_id).unwrap();
+            repo.commit(Some("HEAD"), &sig, &sig, "initial commit", &tree, &[])
+                .unwrap();
+        }
+        repo
+    }
+
+    #[test]
+    fn create_worktree_happy_path_end_to_end() {
+        let repo_dir = tempfile::tempdir().unwrap();
+        let _repo = init_repo_with_commit(repo_dir.path());
+        let wt_root = tempfile::tempdir().unwrap();
+        let db_dir = tempfile::tempdir().unwrap();
+        let db = Database::open(&db_dir.path().join("test.db")).unwrap();
+
+        let path = execute(
+            "my-feature",
+            None,
+            repo_dir.path(),
+            wt_root.path(),
+            paths::DEFAULT_WORKTREE_TEMPLATE,
+            &db,
+        )
+        .expect("create should succeed");
+
+        // Worktree exists on disk
+        assert!(path.exists(), "worktree directory should exist on disk");
+        assert!(path.join(".git").exists(), "worktree should have .git entry");
+
+        // Path is under worktree root at expected location
+        let repo_name = repo_dir
+            .path()
+            .canonicalize()
+            .unwrap()
+            .file_name()
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .to_string();
+        let expected_path = wt_root.path().join(&repo_name).join("my-feature");
+        assert_eq!(path, expected_path);
+
+        // DB: repo record exists
+        let repo_path_str = repo_dir
+            .path()
+            .canonicalize()
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .to_string();
+        let db_repo = db
+            .get_repo_by_path(&repo_path_str)
+            .unwrap()
+            .expect("repo should be persisted in DB");
+        assert_eq!(db_repo.name, repo_name);
+
+        // DB: worktree record exists with correct fields
+        let worktrees = db.list_worktrees(db_repo.id).unwrap();
+        assert_eq!(worktrees.len(), 1);
+        assert_eq!(worktrees[0].branch, "my-feature");
+        assert_eq!(worktrees[0].path, path.to_str().unwrap());
+        assert!(worktrees[0].managed);
+        assert!(worktrees[0].base_branch.is_some());
+        assert!(worktrees[0].created_at > 0);
+
+        // DB: "created" event written
+        let event_count = db
+            .count_events(worktrees[0].id, Some("created"))
+            .unwrap();
+        assert_eq!(event_count, 1, "exactly one 'created' event should exist");
+    }
+}

--- a/src/cli/commands/create.rs
+++ b/src/cli/commands/create.rs
@@ -38,7 +38,7 @@ pub fn execute(
     let repo_path_str = path_to_utf8(&repo_info.path)?;
     let repo = match db.get_repo_by_path(repo_path_str)? {
         Some(r) => r,
-        None => db.insert_repo(&repo_info.name, repo_path_str, Some(base))?,
+        None => db.insert_repo(&repo_info.name, repo_path_str, Some(&repo_info.default_branch))?,
     };
 
     let sanitized_name = paths::sanitize_branch(branch);

--- a/src/cli/commands/mod.rs
+++ b/src/cli/commands/mod.rs
@@ -1,0 +1,1 @@
+pub mod create;

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -395,4 +395,25 @@ mod tests {
         let result = db.insert_worktree(9999, "wt", "b", "/wt", None);
         assert!(result.is_err(), "FK should reject non-existent repo_id");
     }
+
+    #[test]
+    fn get_repo_by_path_returns_none_for_missing() {
+        let db = Database::open_in_memory().unwrap();
+        let result = db.get_repo_by_path("/nonexistent").unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn get_repo_by_path_returns_existing_repo() {
+        let db = Database::open_in_memory().unwrap();
+        let repo = db.insert_repo("my-project", "/home/user/my-project", Some("main")).unwrap();
+
+        let found = db.get_repo_by_path("/home/user/my-project").unwrap()
+            .expect("should find repo by path");
+
+        assert_eq!(found.id, repo.id);
+        assert_eq!(found.name, "my-project");
+        assert_eq!(found.path, "/home/user/my-project");
+        assert_eq!(found.default_base.as_deref(), Some("main"));
+    }
 }

--- a/src/state/queries.rs
+++ b/src/state/queries.rs
@@ -1,15 +1,10 @@
-use std::time::{SystemTime, UNIX_EPOCH};
-
 use anyhow::{bail, Context, Result};
 use rusqlite::OptionalExtension;
 
-use super::{Database, Repo, Worktree, WorktreeUpdate};
+use super::{unix_epoch_secs, Database, Repo, Worktree, WorktreeUpdate};
 
 fn now() -> i64 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .expect("system clock before UNIX epoch")
-        .as_secs() as i64
+    unix_epoch_secs() as i64
 }
 
 impl Database {

--- a/src/state/queries.rs
+++ b/src/state/queries.rs
@@ -61,6 +61,29 @@ impl Database {
         Ok(repo)
     }
 
+    /// Get a repo by its filesystem path. Returns `None` if not found.
+    pub fn get_repo_by_path(&self, path: &str) -> Result<Option<Repo>> {
+        let mut stmt = self
+            .conn
+            .prepare("SELECT id, name, path, default_base, created_at FROM repos WHERE path = ?1")
+            .context("failed to prepare get_repo_by_path query")?;
+
+        let repo = stmt
+            .query_row(rusqlite::params![path], |row| {
+                Ok(Repo {
+                    id: row.get(0)?,
+                    name: row.get(1)?,
+                    path: row.get(2)?,
+                    default_base: row.get(3)?,
+                    created_at: row.get(4)?,
+                })
+            })
+            .optional()
+            .context("failed to get repo by path")?;
+
+        Ok(repo)
+    }
+
     /// Insert a new worktree and return the populated struct.
     pub fn insert_worktree(
         &self,


### PR DESCRIPTION
Closes #10

## Summary
Wires together all Track 1 pieces into the first end-to-end command: `trench create <branch>` discovers the git repo, resolves the worktree path via template rendering, creates the worktree on disk using git2, persists the repo and worktree records to SQLite, inserts a "created" event, and prints the path to stdout. Exit code 3 on branch-already-exists.

## User Stories Addressed
- US-1: Create a worktree with one command

## Automated Testing
- Total tests added: 8 (5 in create handler, 3 in CLI parsing)
- Tests passing: 102
- Tests failing: 0
- `cargo clippy`: pass (warnings only — unused code from prior PRs)
- `cargo test`: pass

## UAT Checklist
- [ ] `trench create my-feature` in a git repo → worktree created at `~/.worktrees/{repo}/my-feature/`, path printed to stdout
- [ ] `git worktree list` → shows the newly created worktree
- [ ] `trench create my-feature` again → error message with exit code 3
- [ ] `trench create feature/auth` → worktree at `~/.worktrees/{repo}/feature-auth/` (branch sanitized)
- [ ] `trench create new-branch --from develop` → worktree based on develop branch
- [ ] Run from a subdirectory of a git repo → still discovers repo and creates worktree correctly
- [ ] Run outside any git repo → clear error message
- [ ] Inspect `~/.local/share/trench/trench.db` → repos, worktrees, and events tables populated

## Known Issues
None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `trench create <branch>` command with automatic worktree creation and DB tracking
  * Added optional `--from` flag to specify alternate base branch
  * New queries to look up repositories by path and to count worktree events

* **Reliability**
  * Automatic DB backup and recovery when schema version mismatches are detected

* **Tests**
  * Extensive tests covering worktree creation, DB persistence/recovery, UTF-8 path handling, and error cases
<!-- end of auto-generated comment: release notes by coderabbit.ai -->