### PR TITLE
feat(cli): trench list with table formatter

### DIFF
--- a/src/cli/commands/list.rs
+++ b/src/cli/commands/list.rs
@@ -30,7 +30,7 @@ pub fn execute(cwd: &Path, db: &Database) -> Result<String> {
 
     let mut table = Table::new(vec!["Name", "Branch", "Path", "Status"]);
     for wt in &worktrees {
-        table = table.row(vec![&wt.name, &wt.branch, &wt.path, "clean"]);
+        table = table.row(vec![&wt.name, &wt.branch, &wt.path, "clean"]); // TODO: wire real git status
     }
 
     if let Ok((cols, _)) = crossterm::terminal::size() {

--- a/src/cli/commands/list.rs
+++ b/src/cli/commands/list.rs
@@ -25,7 +25,7 @@ pub fn execute(cwd: &Path, db: &Database) -> Result<String> {
     };
 
     if worktrees.is_empty() {
-        return Ok("No worktrees. Use `trench create` to get started.".to_string());
+        return Ok("No worktrees. Use `trench create` to get started.\n".to_string());
     }
 
     let mut table = Table::new(vec!["Name", "Branch", "Path", "Status"]);
@@ -169,6 +169,20 @@ mod tests {
         assert!(
             output.contains("trench create"),
             "empty state should hint at 'trench create', got: {output}"
+        );
+    }
+
+    #[test]
+    fn empty_state_output_ends_with_newline() {
+        let repo_dir = tempfile::tempdir().unwrap();
+        let _repo = init_repo_with_commit(repo_dir.path());
+        let db = Database::open_in_memory().unwrap();
+
+        let output = execute(repo_dir.path(), &db).expect("list should succeed");
+
+        assert!(
+            output.ends_with('\n'),
+            "empty-state output must end with newline, got: {output:?}"
         );
     }
 }

--- a/src/cli/commands/list.rs
+++ b/src/cli/commands/list.rs
@@ -1,0 +1,67 @@
+use std::path::Path;
+
+use anyhow::Result;
+
+use crate::git;
+use crate::state::Database;
+
+/// Execute the `trench list` command.
+///
+/// Discovers the git repo from `cwd`, queries managed worktrees from the DB,
+/// and returns a formatted string for display.
+pub fn execute(cwd: &Path, db: &Database) -> Result<String> {
+    let repo_info = git::discover_repo(cwd)?;
+    let repo_path_str = repo_info
+        .path
+        .to_str()
+        .ok_or_else(|| anyhow::anyhow!("repo path is not valid UTF-8"))?;
+
+    let repo = db.get_repo_by_path(repo_path_str)?;
+
+    let worktrees = match repo {
+        Some(r) => db.list_worktrees(r.id)?,
+        None => Vec::new(),
+    };
+
+    if worktrees.is_empty() {
+        return Ok("No worktrees. Use `trench create` to get started.".to_string());
+    }
+
+    todo!("table formatting")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Helper: create a temp git repo with an initial commit.
+    fn init_repo_with_commit(dir: &Path) -> git2::Repository {
+        let repo = git2::Repository::init(dir).expect("failed to init repo");
+        {
+            let sig = git2::Signature::now("Test", "test@test.com").unwrap();
+            let tree_id = repo.index().unwrap().write_tree().unwrap();
+            let tree = repo.find_tree(tree_id).unwrap();
+            repo.commit(Some("HEAD"), &sig, &sig, "initial commit", &tree, &[])
+                .unwrap();
+        }
+        repo
+    }
+
+    #[test]
+    fn shows_empty_state_when_no_worktrees() {
+        let repo_dir = tempfile::tempdir().unwrap();
+        let _repo = init_repo_with_commit(repo_dir.path());
+        let db = Database::open_in_memory().unwrap();
+
+        let output = execute(repo_dir.path(), &db).expect("list should succeed");
+
+        assert!(
+            output.contains("No worktrees"),
+            "empty state should mention 'No worktrees', got: {output}"
+        );
+        assert!(
+            output.contains("trench create"),
+            "empty state should hint at 'trench create', got: {output}"
+        );
+    }
+}

--- a/src/cli/commands/list.rs
+++ b/src/cli/commands/list.rs
@@ -106,6 +106,51 @@ mod tests {
     }
 
     #[test]
+    fn create_two_worktrees_then_list_shows_both() {
+        use crate::cli::commands::create;
+        use crate::paths;
+
+        let repo_dir = tempfile::tempdir().unwrap();
+        let _repo = init_repo_with_commit(repo_dir.path());
+        let wt_root = tempfile::tempdir().unwrap();
+        let db = Database::open_in_memory().unwrap();
+
+        create::execute(
+            "feature-one",
+            None,
+            repo_dir.path(),
+            wt_root.path(),
+            paths::DEFAULT_WORKTREE_TEMPLATE,
+            &db,
+        )
+        .expect("first create should succeed");
+
+        create::execute(
+            "feature-two",
+            None,
+            repo_dir.path(),
+            wt_root.path(),
+            paths::DEFAULT_WORKTREE_TEMPLATE,
+            &db,
+        )
+        .expect("second create should succeed");
+
+        let output = execute(repo_dir.path(), &db).expect("list should succeed");
+
+        assert!(
+            output.contains("feature-one"),
+            "list should show first worktree, got: {output}"
+        );
+        assert!(
+            output.contains("feature-two"),
+            "list should show second worktree, got: {output}"
+        );
+
+        let lines: Vec<&str> = output.lines().collect();
+        assert_eq!(lines.len(), 3, "expected header + 2 data rows");
+    }
+
+    #[test]
     fn shows_empty_state_when_no_worktrees() {
         let repo_dir = tempfile::tempdir().unwrap();
         let _repo = init_repo_with_commit(repo_dir.path());

--- a/src/cli/commands/list.rs
+++ b/src/cli/commands/list.rs
@@ -33,6 +33,10 @@ pub fn execute(cwd: &Path, db: &Database) -> Result<String> {
         table = table.row(vec![&wt.name, &wt.branch, &wt.path, "clean"]);
     }
 
+    if let Ok((cols, _)) = crossterm::terminal::size() {
+        table = table.max_width(cols as usize);
+    }
+
     Ok(table.render())
 }
 

--- a/src/cli/commands/mod.rs
+++ b/src/cli/commands/mod.rs
@@ -1,1 +1,2 @@
 pub mod create;
+pub mod list;

--- a/src/main.rs
+++ b/src/main.rs
@@ -146,7 +146,11 @@ fn run_list() -> anyhow::Result<()> {
     let db = state::Database::open(&db_path)?;
 
     let output = cli::commands::list::execute(&cwd, &db)?;
-    print!("{output}");
+    if output.ends_with('\n') {
+        print!("{output}");
+    } else {
+        println!("{output}");
+    }
     Ok(())
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -99,6 +99,7 @@ fn main() -> anyhow::Result<()> {
         Some(Commands::Create { branch, from }) => {
             run_create(&branch, from.as_deref())
         }
+        Some(Commands::List) => run_list(),
         Some(_) => {
             // Other commands not yet implemented
             Ok(())
@@ -137,6 +138,16 @@ fn run_create(branch: &str, from: Option<&str>) -> anyhow::Result<()> {
             Err(e)
         }
     }
+}
+
+fn run_list() -> anyhow::Result<()> {
+    let cwd = std::env::current_dir().context("failed to determine current directory")?;
+    let db_path = paths::data_dir()?.join("trench.db");
+    let db = state::Database::open(&db_path)?;
+
+    let output = cli::commands::list::execute(&cwd, &db)?;
+    print!("{output}");
+    Ok(())
 }
 
 #[cfg(test)]

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -1,3 +1,5 @@
+pub mod table;
+
 /// Output verbosity level.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Verbosity {

--- a/src/output/table.rs
+++ b/src/output/table.rs
@@ -85,6 +85,12 @@ mod tests {
     use super::*;
 
     #[test]
+    fn empty_rows_returns_empty_string() {
+        let output = Table::new(vec!["Name", "Branch"]).render();
+        assert!(output.is_empty(), "no rows should produce empty output");
+    }
+
+    #[test]
     fn renders_headers_and_rows_with_aligned_columns() {
         let output = Table::new(vec!["Name", "Branch", "Path"])
             .row(vec!["foo", "main", "/tmp/foo"])

--- a/src/output/table.rs
+++ b/src/output/table.rs
@@ -1,0 +1,109 @@
+/// A reusable table formatter that auto-sizes columns.
+///
+/// Not coupled to any specific data type — accepts string headers and rows.
+pub struct Table {
+    headers: Vec<String>,
+    rows: Vec<Vec<String>>,
+    max_width: Option<usize>,
+}
+
+impl Table {
+    pub fn new(headers: Vec<&str>) -> Self {
+        Self {
+            headers: headers.into_iter().map(String::from).collect(),
+            rows: Vec::new(),
+            max_width: None,
+        }
+    }
+
+    pub fn row(mut self, cells: Vec<&str>) -> Self {
+        self.rows.push(cells.into_iter().map(String::from).collect());
+        self
+    }
+
+    pub fn max_width(mut self, width: usize) -> Self {
+        self.max_width = Some(width);
+        self
+    }
+
+    pub fn render(&self) -> String {
+        if self.rows.is_empty() {
+            return String::new();
+        }
+
+        let col_count = self.headers.len();
+        let mut col_widths: Vec<usize> = self.headers.iter().map(|h| h.len()).collect();
+
+        for row in &self.rows {
+            for (i, cell) in row.iter().enumerate() {
+                if i < col_count {
+                    col_widths[i] = col_widths[i].max(cell.len());
+                }
+            }
+        }
+
+        let gap = 2; // spaces between columns
+        let mut out = String::new();
+
+        // Header
+        for (i, header) in self.headers.iter().enumerate() {
+            if i > 0 {
+                out.push_str(&" ".repeat(gap));
+            }
+            if i < col_count - 1 {
+                out.push_str(&format!("{:<width$}", header, width = col_widths[i]));
+            } else {
+                out.push_str(header);
+            }
+        }
+        out.push('\n');
+
+        // Rows
+        for row in &self.rows {
+            for (i, cell) in row.iter().enumerate() {
+                if i >= col_count {
+                    break;
+                }
+                if i > 0 {
+                    out.push_str(&" ".repeat(gap));
+                }
+                if i < col_count - 1 {
+                    out.push_str(&format!("{:<width$}", cell, width = col_widths[i]));
+                } else {
+                    out.push_str(cell);
+                }
+            }
+            out.push('\n');
+        }
+
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn renders_headers_and_rows_with_aligned_columns() {
+        let output = Table::new(vec!["Name", "Branch", "Path"])
+            .row(vec!["foo", "main", "/tmp/foo"])
+            .row(vec!["bar-longer", "dev", "/tmp/bar"])
+            .render();
+
+        let lines: Vec<&str> = output.lines().collect();
+        assert_eq!(lines.len(), 3, "expected header + 2 data rows");
+
+        // All lines should have the same length (padded)
+        let widths: Vec<usize> = lines.iter().map(|l| l.trim_end().len()).collect();
+        // Check that columns are aligned by verifying "Name" and "Branch" appear at same column offsets
+        let header = lines[0];
+        let row1 = lines[1];
+        let branch_offset_header = header.find("Branch").expect("header should contain 'Branch'");
+        let branch_offset_row1 = row1.find("main").expect("row should contain 'main'");
+        assert_eq!(
+            branch_offset_header, branch_offset_row1,
+            "Branch column should align between header and row"
+        );
+    }
+}

--- a/src/output/table.rs
+++ b/src/output/table.rs
@@ -107,8 +107,7 @@ impl Table {
             out.push('\n');
         };
 
-        let headers_as_strings: Vec<String> = self.headers.clone();
-        render_line(&mut out, &headers_as_strings, &col_widths);
+        render_line(&mut out, &self.headers, &col_widths);
 
         for row in &self.rows {
             render_line(&mut out, row, &col_widths);


### PR DESCRIPTION
Closes #13

## Summary

Implement the `trench list` command that queries managed worktrees from SQLite and displays them as a formatted table with auto-sized columns. Includes a reusable `Table` formatter in the output module that handles column alignment, truncation to terminal width, and empty state messaging.

## User Stories Addressed

- US-5: See all worktrees with status indicators (partial — git status placeholder, ahead/behind not yet wired)

## Automated Testing

- Total tests added: 5
- Tests passing: 132 (all)
- Tests failing: 0
- `cargo clippy`: pass (only pre-existing warnings from unused TUI methods)
- `cargo test`: pass

## UAT Checklist

- [x] `trench create my-feature` → worktree created at expected path
- [x] `trench list` → shows the new worktree in a formatted table with columns: Name, Branch, Path, Status
- [x] Create a second worktree with `trench create another-feature` → `trench list` shows both
- [x] Run `trench list` in a repo with no worktrees → shows "No worktrees. Use `trench create` to get started."
- [x] Run `trench list` in a narrow terminal window → columns truncate to fit without wrapping
- [x] Run `trench list` in a wide terminal window → columns use full content width

## Known Issues

- Status column is a placeholder showing "clean" for all worktrees — actual git dirty/clean status will be wired in a future issue
- Sorting is by `created_at` ascending (DB default) — `last_accessed` sorting deferred until session tracking is implemented

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a List command to display worktrees in a formatted table (Name, Branch, Path, Status).
  * Table rendering adapts to terminal width, truncates long cells with indicators, and shows a friendly message when no worktrees exist.

* **Tests**
  * Added tests for table rendering, column truncation/width handling, row normalization, and empty-state output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->