### PR TITLE
feat(create): --from <base> flag with remote resolution

### DIFF
--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -85,10 +85,14 @@ pub fn discover_repo(path: &Path) -> Result<RepoInfo, GitError> {
 
 /// Create a new git worktree at `target_path` for the given branch.
 ///
-/// Opens the repository at `repo_path`, creates the branch from `base` if it
-/// doesn't exist locally, and adds a worktree at `target_path`.
+/// Opens the repository at `repo_path`, resolves `base` as a local branch
+/// first, then falls back to `origin/<base>` remote tracking branch.
+/// Creates the new branch from the resolved base commit and adds a
+/// worktree at `target_path`.
 ///
 /// Returns `GitError::BranchAlreadyExists` if the branch already exists.
+/// Returns `GitError::BaseBranchNotFound` if `base` is not found locally
+/// or as `origin/<base>`.
 pub fn create_worktree(
     repo_path: &Path,
     branch: &str,

--- a/src/main.rs
+++ b/src/main.rs
@@ -129,11 +129,18 @@ fn run_create(branch: &str, from: Option<&str>) -> anyhow::Result<()> {
             Ok(())
         }
         Err(e) => {
-            if e.downcast_ref::<git::GitError>().is_some_and(|g| {
-                matches!(g, git::GitError::BranchAlreadyExists { .. })
-            }) {
-                eprintln!("error: {e}");
-                std::process::exit(3);
+            if let Some(git_err) = e.downcast_ref::<git::GitError>() {
+                match git_err {
+                    git::GitError::BranchAlreadyExists { .. } => {
+                        eprintln!("error: {e}");
+                        std::process::exit(3);
+                    }
+                    git::GitError::BaseBranchNotFound { .. } => {
+                        eprintln!("error: {e}");
+                        std::process::exit(2);
+                    }
+                    _ => {}
+                }
             }
             Err(e)
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,7 +51,8 @@ enum Commands {
         /// Branch name for the new worktree
         branch: String,
 
-        /// Base branch to create from (defaults to repo's HEAD branch)
+        /// Base branch to create from (defaults to repo's HEAD branch).
+        /// Falls back to origin/<base> if not found locally.
         #[arg(long)]
         from: Option<String>,
     },


### PR DESCRIPTION
Closes #14

## Summary

Adds typed `BaseBranchNotFound` error for the `--from` flag, remote tracking branch fallback (tries `origin/<base>` when base doesn't exist locally), exit code 2 for missing base branch per FR-37, and an integration test verifying commit ancestry when creating from a non-default base.

## User Stories Addressed

- US-1: Create a new worktree for a feature branch with one command (specifically: `trench create <branch> --from <base>`)

## Automated Testing

- Total tests added: 2
- Tests passing: 137
- Tests failing: 0
- `cargo clippy`: pass (only pre-existing dead_code warnings from unimplemented modules)
- `cargo test`: pass

## UAT Checklist

- [x] `trench create fix-123 --from develop` → worktree created branching from `develop`
- [x] `trench create fix-456` (no `--from`) → worktree created from repo's default HEAD branch
- [x] `trench create fix-789 --from nonexistent-branch` → error message and exit code 2
- [x] `trench create fix-abc --from origin/release` where `release` exists only on remote → worktree created from remote tracking branch
- [x] `trench list` after creating with `--from` → shows the worktree with correct base branch

## Known Issues

None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Create command now automatically falls back to remote-tracking branches (origin/<base>) when a specified base branch is not found locally.

* **Tests**
  * Added comprehensive tests for base branch resolution and error handling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->