### PR TITLE
feat(create): --dry-run preview for trench create

### DIFF
--- a/src/cli/commands/create.rs
+++ b/src/cli/commands/create.rs
@@ -694,6 +694,29 @@ mod tests {
     }
 
     #[test]
+    fn dry_run_with_from_shows_custom_base() {
+        let repo_dir = tempfile::tempdir().unwrap();
+        let repo = init_repo_with_commit(repo_dir.path());
+        let wt_root = tempfile::tempdir().unwrap();
+
+        // Create a "develop" branch so --from has something valid
+        let head_commit = repo.head().unwrap().peel_to_commit().unwrap();
+        repo.branch("develop", &head_commit, false).unwrap();
+
+        let plan = execute_dry_run(
+            "my-feature",
+            Some("develop"),
+            repo_dir.path(),
+            wt_root.path(),
+            paths::DEFAULT_WORKTREE_TEMPLATE,
+            None,
+        )
+        .expect("dry-run with --from should succeed");
+
+        assert_eq!(plan.base_branch, "develop", "base should reflect --from override");
+    }
+
+    #[test]
     fn create_with_from_stores_default_branch_not_from_override() {
         let repo_dir = tempfile::tempdir().unwrap();
         let repo = init_repo_with_commit(repo_dir.path());

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -257,8 +257,11 @@ pub fn load_global_config_from(path: &Path) -> Result<GlobalConfig> {
 }
 
 /// Return the path to the global config file (`~/.config/trench/config.toml`).
+///
+/// Uses the non-mutating path accessor so config loading never creates
+/// directories as a side effect (important for `--dry-run`).
 pub fn global_config_path() -> Result<PathBuf> {
-    Ok(paths::config_dir()?.join("config.toml"))
+    Ok(paths::config_dir_path()?.join("config.toml"))
 }
 
 /// Load global config from the XDG config directory.

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -7,7 +7,7 @@ use crate::paths;
 
 // --- Hook types (FR-18, FR-19) ---
 
-#[derive(Debug, Default, Deserialize, PartialEq, Clone)]
+#[derive(Debug, Default, Deserialize, serde::Serialize, PartialEq, Clone)]
 pub struct HookDef {
     pub copy: Option<Vec<String>>,
     pub run: Option<Vec<String>>,
@@ -15,7 +15,7 @@ pub struct HookDef {
     pub timeout_secs: Option<u64>,
 }
 
-#[derive(Debug, Default, Deserialize, PartialEq, Clone)]
+#[derive(Debug, Default, Deserialize, serde::Serialize, PartialEq, Clone)]
 pub struct HooksConfig {
     pub pre_create: Option<HookDef>,
     pub post_create: Option<HookDef>,

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -13,11 +13,21 @@ fn ensure_dir(path: &Path) -> Result<()> {
     Ok(())
 }
 
-/// Return the trench config directory (`~/.config/trench/`), creating it if needed.
-pub fn config_dir() -> Result<PathBuf> {
+/// Return the trench config directory path (`~/.config/trench/`) without creating it.
+///
+/// Use this in read-only contexts (e.g. config loading, `--dry-run`) where no
+/// side effects are allowed. For contexts that need the directory to exist,
+/// use [`config_dir`].
+pub fn config_dir_path() -> Result<PathBuf> {
     let path = dirs::config_dir()
         .context("could not determine config directory")?
         .join(APP_NAME);
+    Ok(path)
+}
+
+/// Return the trench config directory (`~/.config/trench/`), creating it if needed.
+pub fn config_dir() -> Result<PathBuf> {
+    let path = config_dir_path()?;
     ensure_dir(&path)?;
     Ok(path)
 }
@@ -185,6 +195,13 @@ mod tests {
         let path = worktree_root_path().unwrap();
         assert!(path.ends_with(".worktrees"));
         assert!(path.starts_with(dirs::home_dir().unwrap()));
+    }
+
+    #[test]
+    fn config_dir_path_returns_path_without_creating_it() {
+        let path = config_dir_path().unwrap();
+        assert!(path.ends_with("trench"));
+        assert!(path.starts_with(dirs::config_dir().unwrap()));
     }
 
     #[test]

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -51,11 +51,21 @@ pub fn state_dir() -> Result<PathBuf> {
     Ok(path)
 }
 
-/// Return the worktree root directory (`~/.worktrees/`), creating it if needed.
-pub fn worktree_root() -> Result<PathBuf> {
+/// Return the worktree root path (`~/.worktrees/`) without creating it on disk.
+///
+/// Use this in read-only contexts (e.g. `--dry-run`) where no side effects
+/// are allowed. For real execution, use [`worktree_root`] which also creates
+/// the directory.
+pub fn worktree_root_path() -> Result<PathBuf> {
     let path = dirs::home_dir()
         .context("could not determine home directory")?
         .join(DEFAULT_WORKTREE_DIR);
+    Ok(path)
+}
+
+/// Return the worktree root directory (`~/.worktrees/`), creating it if needed.
+pub fn worktree_root() -> Result<PathBuf> {
+    let path = worktree_root_path()?;
     ensure_dir(&path)?;
     Ok(path)
 }
@@ -164,6 +174,17 @@ mod tests {
         assert!(path.ends_with(".worktrees"));
         assert!(path.starts_with(dirs::home_dir().unwrap()));
         assert!(path.exists());
+    }
+
+    #[test]
+    fn worktree_root_path_returns_path_without_creating_it() {
+        // worktree_root_path() should return the same path as worktree_root()
+        // but must NOT create the directory. We can't easily test non-creation
+        // on a real home dir (it likely already exists), so we verify the
+        // function exists and returns the expected path shape.
+        let path = worktree_root_path().unwrap();
+        assert!(path.ends_with(".worktrees"));
+        assert!(path.starts_with(dirs::home_dir().unwrap()));
     }
 
     #[test]


### PR DESCRIPTION
Closes #16

## Summary

Implements `--dry-run` behavior for `trench create`: shows what would happen (branch, base branch, resolved worktree path, configured hooks) without performing any git operations, DB writes, or hook execution. Supports both human-readable text and `--json` structured output.

## User Stories Addressed

- US-1: Preview before creating a worktree (`--dry-run` shows the full plan)
- US-4: Structured dry-run output for AI agents (`--dry-run --json` returns machine-readable JSON)

## Automated Testing

- Total tests added: 9
- Tests passing: 9
- Tests failing: 0
- `cargo clippy`: pass
- `cargo test`: pass (151 total, 0 failures)

## UAT Checklist

- [x] `trench create my-feature --dry-run` → prints plan with branch, base, path, hooks status
- [x] `trench create my-feature --dry-run --json` → outputs valid JSON with `dry_run: true`, branch, base_branch, worktree_path, hooks
- [x] `trench create my-feature --dry-run --from develop` → plan shows "develop" as base branch
- [x] After `--dry-run`, verify no directory at the worktree path (e.g. `ls ~/.worktrees/repo/my-feature` fails)
- [x] After `--dry-run`, verify no new records in `~/.local/share/trench/trench.db`
- [x] With a `.trench.toml` containing `[hooks.post_create]`, `--dry-run` output shows the configured hooks
- [x] `trench create my-feature` (without `--dry-run`) still works normally and creates the worktree

## Known Issues

None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dry-run preview for the create command so users can preview branch, base branch, repository and worktree path without side effects.
  * Dry-run can output JSON or human-readable text via --json and now includes configured hooks.

* **Tests**
  * Added tests for dry-run behavior, JSON/plain output, hook inclusion, and flag parsing.

* **Chores**
  * Hook configuration is now serializable for JSON output.
  * Added non-creating path helpers for config and worktree lookups used by dry-run.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->