### PR TITLE
feat(cli): tags — attach, remove, list, filter by tags

### DIFF
--- a/src/cli/commands/mod.rs
+++ b/src/cli/commands/mod.rs
@@ -2,3 +2,4 @@ pub mod create;
 pub mod list;
 pub mod remove;
 pub mod switch;
+pub mod tag;

--- a/src/cli/commands/tag.rs
+++ b/src/cli/commands/tag.rs
@@ -1,0 +1,209 @@
+use std::path::Path;
+
+use anyhow::Result;
+
+use crate::git;
+use crate::state::Database;
+
+/// Parsed tag operation from CLI input.
+#[derive(Debug, PartialEq)]
+pub enum TagOp {
+    Add(String),
+    Remove(String),
+}
+
+/// Parse raw CLI tag arguments into structured operations.
+///
+/// `+name` → Add, `-name` → Remove. Returns error for invalid format.
+pub fn parse_tag_args(args: &[String]) -> Result<Vec<TagOp>> {
+    let mut ops = Vec::new();
+    for arg in args {
+        if let Some(name) = arg.strip_prefix('+') {
+            if name.is_empty() {
+                anyhow::bail!("tag name cannot be empty: '{arg}'");
+            }
+            ops.push(TagOp::Add(name.to_string()));
+        } else if let Some(name) = arg.strip_prefix('-') {
+            if name.is_empty() {
+                anyhow::bail!("tag name cannot be empty: '{arg}'");
+            }
+            ops.push(TagOp::Remove(name.to_string()));
+        } else {
+            anyhow::bail!(
+                "invalid tag argument '{arg}': must start with '+' (add) or '-' (remove)"
+            );
+        }
+    }
+    Ok(ops)
+}
+
+/// Execute the `trench tag` command.
+///
+/// If `tags` is empty, lists current tags. Otherwise, applies add/remove operations.
+/// Returns a formatted string for display.
+pub fn execute(identifier: &str, tags: &[String], cwd: &Path, db: &Database) -> Result<String> {
+    let repo_info = git::discover_repo(cwd)?;
+    let repo_path_str = repo_info
+        .path
+        .to_str()
+        .ok_or_else(|| anyhow::anyhow!("repo path is not valid UTF-8"))?;
+
+    let repo = db
+        .get_repo_by_path(repo_path_str)?
+        .ok_or_else(|| anyhow::anyhow!("repo not tracked by trench: {repo_path_str}"))?;
+
+    let wt = db
+        .find_worktree_by_identifier(repo.id, identifier)?
+        .ok_or_else(|| anyhow::anyhow!("worktree not found: {identifier}"))?;
+
+    if tags.is_empty() {
+        // List mode
+        let current_tags = db.list_tags(wt.id)?;
+        if current_tags.is_empty() {
+            return Ok(format!("No tags on worktree '{}'.\n", wt.name));
+        }
+        return Ok(current_tags.join(", ") + "\n");
+    }
+
+    let ops = parse_tag_args(tags)?;
+    for op in &ops {
+        match op {
+            TagOp::Add(name) => db.add_tag(wt.id, name)?,
+            TagOp::Remove(name) => db.remove_tag(wt.id, name)?,
+        }
+    }
+
+    let current_tags = db.list_tags(wt.id)?;
+    if current_tags.is_empty() {
+        Ok(format!("All tags removed from worktree '{}'.\n", wt.name))
+    } else {
+        Ok(format!(
+            "Tags on '{}': {}\n",
+            wt.name,
+            current_tags.join(", ")
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_add_tags() {
+        let ops = parse_tag_args(&["+wip".to_string(), "+review".to_string()]).unwrap();
+        assert_eq!(
+            ops,
+            vec![TagOp::Add("wip".to_string()), TagOp::Add("review".to_string())]
+        );
+    }
+
+    #[test]
+    fn parse_remove_tags() {
+        let ops = parse_tag_args(&["-wip".to_string()]).unwrap();
+        assert_eq!(ops, vec![TagOp::Remove("wip".to_string())]);
+    }
+
+    #[test]
+    fn parse_mixed_tags() {
+        let ops = parse_tag_args(&["+wip".to_string(), "-old".to_string()]).unwrap();
+        assert_eq!(
+            ops,
+            vec![TagOp::Add("wip".to_string()), TagOp::Remove("old".to_string())]
+        );
+    }
+
+    #[test]
+    fn parse_rejects_bare_name() {
+        let err = parse_tag_args(&["bare".to_string()]).unwrap_err();
+        assert!(err.to_string().contains("must start with"));
+    }
+
+    #[test]
+    fn parse_rejects_empty_tag_name() {
+        let err = parse_tag_args(&["+".to_string()]).unwrap_err();
+        assert!(err.to_string().contains("cannot be empty"));
+    }
+
+    #[test]
+    fn execute_adds_tags_to_worktree() {
+        let repo_dir = tempfile::tempdir().unwrap();
+        let _repo = init_repo_with_commit(repo_dir.path());
+        let db = Database::open_in_memory().unwrap();
+
+        let repo_path = repo_dir.path().canonicalize().unwrap();
+        let repo_name = repo_path.file_name().unwrap().to_str().unwrap();
+        let db_repo = db
+            .insert_repo(repo_name, repo_path.to_str().unwrap(), Some("main"))
+            .unwrap();
+        let wt = db
+            .insert_worktree(db_repo.id, "my-wt", "my-branch", "/wt/my-wt", Some("main"))
+            .unwrap();
+
+        let output = execute(
+            "my-wt",
+            &["+wip".to_string(), "+review".to_string()],
+            repo_dir.path(),
+            &db,
+        )
+        .unwrap();
+
+        assert!(output.contains("wip"), "output should mention wip tag");
+        assert!(output.contains("review"), "output should mention review tag");
+
+        // Verify in DB
+        let tags = db.list_tags(wt.id).unwrap();
+        assert_eq!(tags, vec!["review", "wip"]); // sorted alphabetically
+    }
+
+    #[test]
+    fn execute_lists_tags_when_no_ops() {
+        let repo_dir = tempfile::tempdir().unwrap();
+        let _repo = init_repo_with_commit(repo_dir.path());
+        let db = Database::open_in_memory().unwrap();
+
+        let repo_path = repo_dir.path().canonicalize().unwrap();
+        let repo_name = repo_path.file_name().unwrap().to_str().unwrap();
+        let db_repo = db
+            .insert_repo(repo_name, repo_path.to_str().unwrap(), Some("main"))
+            .unwrap();
+        let wt = db
+            .insert_worktree(db_repo.id, "my-wt", "my-branch", "/wt/my-wt", Some("main"))
+            .unwrap();
+
+        db.add_tag(wt.id, "wip").unwrap();
+
+        let output = execute("my-wt", &[], repo_dir.path(), &db).unwrap();
+        assert!(output.contains("wip"));
+    }
+
+    #[test]
+    fn execute_shows_empty_state_when_no_tags() {
+        let repo_dir = tempfile::tempdir().unwrap();
+        let _repo = init_repo_with_commit(repo_dir.path());
+        let db = Database::open_in_memory().unwrap();
+
+        let repo_path = repo_dir.path().canonicalize().unwrap();
+        let repo_name = repo_path.file_name().unwrap().to_str().unwrap();
+        let db_repo = db
+            .insert_repo(repo_name, repo_path.to_str().unwrap(), Some("main"))
+            .unwrap();
+        db.insert_worktree(db_repo.id, "my-wt", "my-branch", "/wt/my-wt", Some("main"))
+            .unwrap();
+
+        let output = execute("my-wt", &[], repo_dir.path(), &db).unwrap();
+        assert!(output.contains("No tags"));
+    }
+
+    fn init_repo_with_commit(dir: &Path) -> git2::Repository {
+        let repo = git2::Repository::init(dir).expect("failed to init repo");
+        {
+            let sig = git2::Signature::now("Test", "test@test.com").unwrap();
+            let tree_id = repo.index().unwrap().write_tree().unwrap();
+            let tree = repo.find_tree(tree_id).unwrap();
+            repo.commit(Some("HEAD"), &sig, &sig, "initial commit", &tree, &[])
+                .unwrap();
+        }
+        repo
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -558,6 +558,50 @@ mod tests {
     }
 
     #[test]
+    fn tag_subcommand_requires_branch() {
+        let result = Cli::try_parse_from(["trench", "tag"]);
+        assert!(result.is_err(), "tag without branch should fail");
+    }
+
+    #[test]
+    fn tag_subcommand_accepts_branch_only() {
+        let cli = Cli::try_parse_from(["trench", "tag", "my-feature"])
+            .expect("tag with branch should succeed");
+        match cli.command {
+            Some(Commands::Tag { branch, tags }) => {
+                assert_eq!(branch, "my-feature");
+                assert!(tags.is_empty());
+            }
+            _ => panic!("expected Commands::Tag"),
+        }
+    }
+
+    #[test]
+    fn tag_subcommand_accepts_add_and_remove_args() {
+        let cli = Cli::try_parse_from(["trench", "tag", "my-feature", "+wip", "-old", "+review"])
+            .expect("tag with +/- args should succeed");
+        match cli.command {
+            Some(Commands::Tag { branch, tags }) => {
+                assert_eq!(branch, "my-feature");
+                assert_eq!(tags, vec!["+wip", "-old", "+review"]);
+            }
+            _ => panic!("expected Commands::Tag"),
+        }
+    }
+
+    #[test]
+    fn list_subcommand_accepts_tag_filter() {
+        let cli = Cli::try_parse_from(["trench", "list", "--tag", "wip"])
+            .expect("list with --tag should succeed");
+        match cli.command {
+            Some(Commands::List { tag }) => {
+                assert_eq!(tag.as_deref(), Some("wip"));
+            }
+            _ => panic!("expected Commands::List"),
+        }
+    }
+
+    #[test]
     fn cli_produces_output_config() {
         let cli = Cli::try_parse_from(["trench", "--no-color", "--quiet"])
             .expect("flags should parse");

--- a/src/main.rs
+++ b/src/main.rs
@@ -133,7 +133,7 @@ fn main() -> anyhow::Result<()> {
         Some(Commands::Remove { branch, force }) => run_remove(&branch, force),
         Some(Commands::Switch { branch, print_path }) => run_switch(&branch, print_path),
         Some(Commands::Tag { branch, tags }) => run_tag(&branch, &tags),
-        Some(Commands::List { tag }) => run_list(tag.as_deref()),
+        Some(Commands::List { tag }) => run_list(tag.as_deref(), json),
         Some(_) => {
             // Other commands not yet implemented
             Ok(())
@@ -296,12 +296,16 @@ fn run_tag(identifier: &str, tags: &[String]) -> anyhow::Result<()> {
     Ok(())
 }
 
-fn run_list(tag: Option<&str>) -> anyhow::Result<()> {
+fn run_list(tag: Option<&str>, json: bool) -> anyhow::Result<()> {
     let cwd = std::env::current_dir().context("failed to determine current directory")?;
     let db_path = paths::data_dir()?.join("trench.db");
     let db = state::Database::open(&db_path)?;
 
-    let output = cli::commands::list::execute(&cwd, &db, tag)?;
+    let output = if json {
+        cli::commands::list::execute_json(&cwd, &db, tag)?
+    } else {
+        cli::commands::list::execute(&cwd, &db, tag)?
+    };
     if output.ends_with('\n') {
         print!("{output}");
     } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -74,6 +74,15 @@ enum Commands {
         #[arg(long)]
         print_path: bool,
     },
+    /// Manage tags on a worktree
+    Tag {
+        /// Branch name or sanitized name of the worktree
+        branch: String,
+
+        /// Tags to add (+name) or remove (-name). No arguments = list current tags
+        #[arg(allow_hyphen_values = true)]
+        tags: Vec<String>,
+    },
     /// Open a worktree in $EDITOR
     Open,
     /// List all worktrees
@@ -119,6 +128,7 @@ fn main() -> anyhow::Result<()> {
         }
         Some(Commands::Remove { branch, force }) => run_remove(&branch, force),
         Some(Commands::Switch { branch, print_path }) => run_switch(&branch, print_path),
+        Some(Commands::Tag { branch, tags }) => run_tag(&branch, &tags),
         Some(Commands::List) => run_list(),
         Some(_) => {
             // Other commands not yet implemented
@@ -270,6 +280,16 @@ fn run_switch(identifier: &str, print_path: bool) -> anyhow::Result<()> {
             Err(e)
         }
     }
+}
+
+fn run_tag(identifier: &str, tags: &[String]) -> anyhow::Result<()> {
+    let cwd = std::env::current_dir().context("failed to determine current directory")?;
+    let db_path = paths::data_dir()?.join("trench.db");
+    let db = state::Database::open(&db_path)?;
+
+    let output = cli::commands::tag::execute(identifier, tags, &cwd, &db)?;
+    print!("{output}");
+    Ok(())
 }
 
 fn run_list() -> anyhow::Result<()> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -86,7 +86,11 @@ enum Commands {
     /// Open a worktree in $EDITOR
     Open,
     /// List all worktrees
-    List,
+    List {
+        /// Filter worktrees by tag
+        #[arg(long)]
+        tag: Option<String>,
+    },
     /// Show worktree status
     Status,
     /// Sync worktree with base branch
@@ -129,7 +133,7 @@ fn main() -> anyhow::Result<()> {
         Some(Commands::Remove { branch, force }) => run_remove(&branch, force),
         Some(Commands::Switch { branch, print_path }) => run_switch(&branch, print_path),
         Some(Commands::Tag { branch, tags }) => run_tag(&branch, &tags),
-        Some(Commands::List) => run_list(),
+        Some(Commands::List { tag }) => run_list(tag.as_deref()),
         Some(_) => {
             // Other commands not yet implemented
             Ok(())
@@ -292,12 +296,12 @@ fn run_tag(identifier: &str, tags: &[String]) -> anyhow::Result<()> {
     Ok(())
 }
 
-fn run_list() -> anyhow::Result<()> {
+fn run_list(tag: Option<&str>) -> anyhow::Result<()> {
     let cwd = std::env::current_dir().context("failed to determine current directory")?;
     let db_path = paths::data_dir()?.join("trench.db");
     let db = state::Database::open(&db_path)?;
 
-    let output = cli::commands::list::execute(&cwd, &db)?;
+    let output = cli::commands::list::execute(&cwd, &db, tag)?;
     if output.ends_with('\n') {
         print!("{output}");
     } else {

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -661,6 +661,35 @@ mod tests {
     }
 
     #[test]
+    fn remove_tag_deletes_tag() {
+        let db = Database::open_in_memory().unwrap();
+        let repo = db.insert_repo("r", "/r", None).unwrap();
+        let wt = db
+            .insert_worktree(repo.id, "wt", "branch", "/wt", None)
+            .unwrap();
+
+        db.add_tag(wt.id, "wip").unwrap();
+        db.add_tag(wt.id, "review").unwrap();
+
+        db.remove_tag(wt.id, "wip").unwrap();
+
+        let tags = db.list_tags(wt.id).unwrap();
+        assert_eq!(tags, vec!["review"]);
+    }
+
+    #[test]
+    fn remove_nonexistent_tag_is_noop() {
+        let db = Database::open_in_memory().unwrap();
+        let repo = db.insert_repo("r", "/r", None).unwrap();
+        let wt = db
+            .insert_worktree(repo.id, "wt", "branch", "/wt", None)
+            .unwrap();
+
+        // Should not error
+        db.remove_tag(wt.id, "nonexistent").unwrap();
+    }
+
+    #[test]
     fn get_repo_by_path_returns_existing_repo() {
         let db = Database::open_in_memory().unwrap();
         let repo = db.insert_repo("my-project", "/home/user/my-project", Some("main")).unwrap();

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -690,6 +690,56 @@ mod tests {
     }
 
     #[test]
+    fn list_worktrees_by_tag_filters_correctly() {
+        let db = Database::open_in_memory().unwrap();
+        let repo = db.insert_repo("r", "/r", None).unwrap();
+        let wt1 = db
+            .insert_worktree(repo.id, "wt1", "branch1", "/wt1", None)
+            .unwrap();
+        let wt2 = db
+            .insert_worktree(repo.id, "wt2", "branch2", "/wt2", None)
+            .unwrap();
+        let _wt3 = db
+            .insert_worktree(repo.id, "wt3", "branch3", "/wt3", None)
+            .unwrap();
+
+        db.add_tag(wt1.id, "wip").unwrap();
+        db.add_tag(wt2.id, "wip").unwrap();
+        db.add_tag(wt2.id, "review").unwrap();
+
+        let wip_wts = db.list_worktrees_by_tag(repo.id, "wip").unwrap();
+        assert_eq!(wip_wts.len(), 2);
+        assert!(wip_wts.iter().any(|w| w.name == "wt1"));
+        assert!(wip_wts.iter().any(|w| w.name == "wt2"));
+
+        let review_wts = db.list_worktrees_by_tag(repo.id, "review").unwrap();
+        assert_eq!(review_wts.len(), 1);
+        assert_eq!(review_wts[0].name, "wt2");
+    }
+
+    #[test]
+    fn list_worktrees_by_tag_excludes_removed() {
+        let db = Database::open_in_memory().unwrap();
+        let repo = db.insert_repo("r", "/r", None).unwrap();
+        let wt1 = db
+            .insert_worktree(repo.id, "wt1", "branch1", "/wt1", None)
+            .unwrap();
+
+        db.add_tag(wt1.id, "wip").unwrap();
+        db.update_worktree(
+            wt1.id,
+            &WorktreeUpdate {
+                removed_at: Some(Some(1_700_000_000)),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        let wts = db.list_worktrees_by_tag(repo.id, "wip").unwrap();
+        assert!(wts.is_empty(), "removed worktree should not appear");
+    }
+
+    #[test]
     fn get_repo_by_path_returns_existing_repo() {
         let db = Database::open_in_memory().unwrap();
         let repo = db.insert_repo("my-project", "/home/user/my-project", Some("main")).unwrap();

--- a/src/state/queries.rs
+++ b/src/state/queries.rs
@@ -339,6 +339,17 @@ impl Database {
         Ok(tags)
     }
 
+    /// Remove a tag from a worktree. No-op if the tag doesn't exist.
+    pub fn remove_tag(&self, worktree_id: i64, name: &str) -> Result<()> {
+        self.conn
+            .execute(
+                "DELETE FROM tags WHERE worktree_id = ?1 AND name = ?2",
+                rusqlite::params![worktree_id, name],
+            )
+            .context("failed to remove tag")?;
+        Ok(())
+    }
+
     /// Count events for a worktree, optionally filtered by event type.
     pub fn count_events(
         &self,

--- a/src/state/queries.rs
+++ b/src/state/queries.rs
@@ -339,6 +339,41 @@ impl Database {
         Ok(tags)
     }
 
+    /// List worktrees that have a specific tag, excluding removed worktrees.
+    pub fn list_worktrees_by_tag(&self, repo_id: i64, tag: &str) -> Result<Vec<Worktree>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT w.id, w.repo_id, w.name, w.branch, w.path, w.base_branch, w.managed, w.adopted_at, w.last_accessed, w.removed_at, w.created_at
+             FROM worktrees w
+             INNER JOIN tags t ON t.worktree_id = w.id
+             WHERE w.repo_id = ?1 AND t.name = ?2 AND w.removed_at IS NULL
+             ORDER BY w.created_at",
+        ).context("failed to prepare list_worktrees_by_tag query")?;
+
+        let rows = stmt
+            .query_map(rusqlite::params![repo_id, tag], |row| {
+                Ok(Worktree {
+                    id: row.get(0)?,
+                    repo_id: row.get(1)?,
+                    name: row.get(2)?,
+                    branch: row.get(3)?,
+                    path: row.get(4)?,
+                    base_branch: row.get(5)?,
+                    managed: row.get::<_, i64>(6)? != 0,
+                    adopted_at: row.get(7)?,
+                    last_accessed: row.get(8)?,
+                    removed_at: row.get(9)?,
+                    created_at: row.get(10)?,
+                })
+            })
+            .context("failed to list worktrees by tag")?;
+
+        let mut worktrees = Vec::new();
+        for row in rows {
+            worktrees.push(row.context("failed to read worktree row")?);
+        }
+        Ok(worktrees)
+    }
+
     /// Remove a tag from a worktree. No-op if the tag doesn't exist.
     pub fn remove_tag(&self, worktree_id: i64, name: &str) -> Result<()> {
         self.conn


### PR DESCRIPTION
Closes #19

## Summary
Implement a tagging system for worktrees with `trench tag <branch> +name` to add tags, `-name` to remove, bare `trench tag <branch>` to list, and `trench list --tag <name>` to filter. Tags are stored in the existing SQLite `tags` table and appear in both table and `--json` output.

## User Stories Addressed
- (Power user workflow — organizing worktrees with tags)

## Automated Testing
- Total tests added: 23
- Tests passing: 206
- Tests failing: 0
- `cargo clippy`: pass
- `cargo test`: pass

## UAT Checklist
- [ ] `trench create my-feature` → creates a worktree
- [ ] `trench tag my-feature +wip +review` → adds two tags, output shows both
- [ ] `trench tag my-feature` → lists "review, wip"
- [ ] `trench tag my-feature -wip` → removes wip tag
- [ ] `trench tag my-feature` → lists only "review"
- [ ] `trench list` → shows Tags column with tags per worktree
- [ ] `trench list --tag review` → shows only worktrees tagged "review"
- [ ] `trench list --tag nonexistent` → shows "No worktrees" empty state
- [ ] `trench list --json` → JSON array includes `"tags"` array per worktree
- [ ] `trench list --json --tag wip` → filtered JSON output

## Known Issues
None