### PR TITLE
feat(cli): trench init — scaffold commented .trench.toml

### DIFF
--- a/src/cli/commands/init.rs
+++ b/src/cli/commands/init.rs
@@ -1,0 +1,36 @@
+use std::path::{Path, PathBuf};
+
+use anyhow::Result;
+
+const TRENCH_TOML_FILENAME: &str = ".trench.toml";
+
+/// The scaffold content for `.trench.toml`.
+const SCAFFOLD: &str = "# trench — project configuration\n";
+
+/// Execute `trench init` — scaffold a commented `.trench.toml` at the repo root.
+pub fn execute(repo_root: &Path, _force: bool) -> Result<PathBuf> {
+    let path = repo_root.join(TRENCH_TOML_FILENAME);
+    std::fs::write(&path, SCAFFOLD)?;
+    Ok(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn init_creates_trench_toml_at_repo_root() {
+        let dir = TempDir::new().unwrap();
+
+        let result = execute(dir.path(), false);
+
+        assert!(result.is_ok(), "init should succeed: {:?}", result.err());
+        let created_path = result.unwrap();
+        assert_eq!(created_path, dir.path().join(".trench.toml"));
+        assert!(created_path.exists(), ".trench.toml should exist on disk");
+
+        let contents = std::fs::read_to_string(&created_path).unwrap();
+        assert!(!contents.is_empty(), "file should not be empty");
+    }
+}

--- a/src/cli/commands/init.rs
+++ b/src/cli/commands/init.rs
@@ -2,7 +2,7 @@ use std::path::{Path, PathBuf};
 
 use anyhow::Result;
 
-const TRENCH_TOML_FILENAME: &str = ".trench.toml";
+use crate::config::PROJECT_CONFIG_FILENAME;
 
 /// Errors specific to the `init` command.
 #[derive(Debug, thiserror::Error)]
@@ -81,7 +81,7 @@ const SCAFFOLD: &str = r#"# trench — project configuration
 
 /// Execute `trench init` — scaffold a commented `.trench.toml` at the repo root.
 pub fn execute(repo_root: &Path, force: bool) -> Result<PathBuf> {
-    let path = repo_root.join(TRENCH_TOML_FILENAME);
+    let path = repo_root.join(PROJECT_CONFIG_FILENAME);
 
     if path.exists() && !force {
         return Err(InitError::FileAlreadyExists.into());

--- a/src/cli/commands/init.rs
+++ b/src/cli/commands/init.rs
@@ -169,4 +169,24 @@ mod tests {
         let contents = std::fs::read_to_string(&existing).unwrap();
         assert_eq!(contents, "# existing config\n");
     }
+
+    #[test]
+    fn init_force_overwrites_existing_file() {
+        let dir = TempDir::new().unwrap();
+        let existing = dir.path().join(".trench.toml");
+        std::fs::write(&existing, "# old config\n").unwrap();
+
+        let result = execute(dir.path(), true);
+
+        assert!(result.is_ok(), "init --force should succeed: {:?}", result.err());
+        let contents = std::fs::read_to_string(&existing).unwrap();
+        assert!(
+            contents.contains("# trench — project configuration"),
+            "file should contain scaffold content, not old content"
+        );
+        assert!(
+            !contents.contains("# old config"),
+            "old content should be replaced"
+        );
+    }
 }

--- a/src/cli/commands/init.rs
+++ b/src/cli/commands/init.rs
@@ -5,7 +5,72 @@ use anyhow::Result;
 const TRENCH_TOML_FILENAME: &str = ".trench.toml";
 
 /// The scaffold content for `.trench.toml`.
-const SCAFFOLD: &str = "# trench — project configuration\n";
+const SCAFFOLD: &str = r#"# trench — project configuration
+# Uncomment and modify the sections you need.
+# This file is intended to be committed to version control.
+#
+# Configuration precedence:
+#   CLI flags > .trench.toml > ~/.config/trench/config.toml > defaults
+
+# ─── UI ──────────────────────────────────────────────────────────────
+
+# [ui]
+# theme = "default"
+# date_format = "%Y-%m-%d %H:%M"
+# show_ahead_behind = true
+# show_dirty_count = true
+
+# ─── Git ─────────────────────────────────────────────────────────────
+
+# [git]
+# default_base = "main"          # Base branch for new worktrees
+# auto_prune = false              # Prune stale remote-tracking branches
+# fetch_on_open = true            # Fetch from remote when opening a worktree
+
+# ─── Worktrees ───────────────────────────────────────────────────────
+
+# [worktrees]
+# root = "{{ repo }}/{{ branch | sanitize }}"   # Path template for worktree dirs
+# scan = []                                      # Extra directories to scan for worktrees
+
+# ─── Hooks ───────────────────────────────────────────────────────────
+#
+# Six lifecycle hooks: pre_create, post_create, pre_sync, post_sync,
+# pre_remove, post_remove.
+#
+# Each hook supports:
+#   copy         — glob patterns to copy from repo root (prefix with ! to exclude)
+#   run          — commands to execute sequentially
+#   shell        — a shell script to run
+#   timeout_secs — max seconds for run + shell combined (default: 120)
+#
+# Execution order within a hook: copy → run → shell
+# If any step fails (non-zero exit), the hook stops.
+#
+# Pre-hooks cancel the operation on failure.
+# Project hooks (.trench.toml) completely replace global hooks — no merging.
+
+# [hooks.pre_create]
+# run = []
+
+# [hooks.post_create]
+# copy = [".env*", "!.env.example"]
+# run = ["bun install"]
+# shell = ""
+# timeout_secs = 300
+
+# [hooks.pre_sync]
+# run = []
+
+# [hooks.post_sync]
+# run = []
+
+# [hooks.pre_remove]
+# shell = "pkill -f 'next dev' || true"
+
+# [hooks.post_remove]
+# run = []
+"#;
 
 /// Execute `trench init` — scaffold a commented `.trench.toml` at the repo root.
 pub fn execute(repo_root: &Path, _force: bool) -> Result<PathBuf> {
@@ -32,5 +97,39 @@ mod tests {
 
         let contents = std::fs::read_to_string(&created_path).unwrap();
         assert!(!contents.is_empty(), "file should not be empty");
+    }
+
+    #[test]
+    fn scaffold_contains_all_config_sections_commented_out() {
+        let dir = TempDir::new().unwrap();
+        let path = execute(dir.path(), false).unwrap();
+        let contents = std::fs::read_to_string(path).unwrap();
+
+        // All config sections should be present as comments
+        assert!(contents.contains("# [ui]"), "should contain commented [ui] section");
+        assert!(contents.contains("# [git]"), "should contain commented [git] section");
+        assert!(contents.contains("# [worktrees]"), "should contain commented [worktrees] section");
+
+        // All six hook sections
+        assert!(contents.contains("# [hooks.pre_create]"), "should contain pre_create hook");
+        assert!(contents.contains("# [hooks.post_create]"), "should contain post_create hook");
+        assert!(contents.contains("# [hooks.pre_sync]"), "should contain pre_sync hook");
+        assert!(contents.contains("# [hooks.post_sync]"), "should contain post_sync hook");
+        assert!(contents.contains("# [hooks.pre_remove]"), "should contain pre_remove hook");
+        assert!(contents.contains("# [hooks.post_remove]"), "should contain post_remove hook");
+
+        // Key config fields should be documented
+        assert!(contents.contains("# theme"), "should document theme");
+        assert!(contents.contains("# default_base"), "should document default_base");
+        assert!(contents.contains("# root"), "should document worktrees.root");
+
+        // Hook fields should be documented
+        assert!(contents.contains("# copy"), "should document hook copy field");
+        assert!(contents.contains("# run"), "should document hook run field");
+        assert!(contents.contains("# shell"), "should document hook shell field");
+        assert!(contents.contains("# timeout_secs"), "should document hook timeout_secs");
+
+        // Should have inline documentation
+        assert!(contents.contains("Uncomment"), "should have usage instructions");
     }
 }

--- a/src/cli/commands/mod.rs
+++ b/src/cli/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod create;
+pub mod init;
 pub mod list;
 pub mod remove;
 pub mod switch;

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -237,7 +237,7 @@ pub fn resolve_config(
     }
 }
 
-const PROJECT_CONFIG_FILENAME: &str = ".trench.toml";
+pub const PROJECT_CONFIG_FILENAME: &str = ".trench.toml";
 
 /// Load project config from the repo root directory.
 ///


### PR DESCRIPTION
Closes #20

## Summary

Implements `trench init` command that scaffolds a fully-commented `.trench.toml` at the repo root, serving as self-documenting project configuration. The file includes all config sections (`[ui]`, `[git]`, `[worktrees]`) and all six lifecycle hooks, commented out with inline documentation. Fails with exit code 6 if the file already exists, with `--force` to overwrite.

## User Stories Addressed

- US-3: Commit a `.trench.toml` to the repo so every team member gets consistent post-create hooks

## Automated Testing

- Total tests added: 8 (6 in init.rs, 2 in main.rs)
- Tests passing: 214 (all)
- Tests failing: 0
- `cargo clippy`: pass
- `cargo test`: pass

## UAT Checklist

- [x] `cd` into a git repo without `.trench.toml` → `trench init` → file created with "Created .trench.toml" message
- [x] Open the generated `.trench.toml` → all sections are commented out, readable as documentation
- [ ] Uncomment `[hooks.post_create]` section, add `run = ["echo hello"]` → `trench create` uses the hook
- [x] Run `trench init` again in the same repo → error with "already exists" message and exit code 6
- [x] Run `trench init --force` → file is overwritten with fresh scaffold
- [x] Run `trench init` outside a git repo → error (not a git repository)

## Known Issues

None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an init command to scaffold a .trench.toml at the repository root
  * Added a --force option to allow overwriting an existing configuration file

* **Bug Fixes / Safety**
  * Prevents accidental overwrites by default and reports clear error messages and exit on conflict

* **Tests**
  * Added tests covering scaffold contents, error cases, overwrite behavior, and integration initialization
<!-- end of auto-generated comment: release notes by coderabbit.ai -->