### PR TITLE
feat(hooks): hook config struct + TRENCH_* env var builder

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -7,17 +7,30 @@ use crate::paths;
 
 // --- Hook types (FR-18, FR-19) ---
 
+pub const DEFAULT_HOOK_TIMEOUT_SECS: u64 = 120;
+
 fn default_timeout_secs() -> Option<u64> {
-    Some(120)
+    Some(DEFAULT_HOOK_TIMEOUT_SECS)
 }
 
-#[derive(Debug, Default, Deserialize, serde::Serialize, PartialEq, Clone)]
+#[derive(Debug, Deserialize, serde::Serialize, PartialEq, Clone)]
 pub struct HookDef {
     pub copy: Option<Vec<String>>,
     pub run: Option<Vec<String>>,
     pub shell: Option<String>,
     #[serde(default = "default_timeout_secs")]
     pub timeout_secs: Option<u64>,
+}
+
+impl Default for HookDef {
+    fn default() -> Self {
+        Self {
+            copy: None,
+            run: None,
+            shell: None,
+            timeout_secs: Some(DEFAULT_HOOK_TIMEOUT_SECS),
+        }
+    }
 }
 
 #[derive(Debug, Default, Deserialize, serde::Serialize, PartialEq, Clone)]
@@ -1003,6 +1016,16 @@ shell = "echo cleanup"
         let err = load_project_config_from(&path).unwrap_err();
         let msg = err.to_string();
         assert!(msg.contains("invalid TOML"), "error should mention 'invalid TOML': {msg}");
+    }
+
+    #[test]
+    fn hook_def_default_timeout_matches_serde_default() {
+        let def = HookDef::default();
+        assert_eq!(
+            def.timeout_secs,
+            Some(120),
+            "HookDef::default() must match serde default of 120"
+        );
     }
 
     #[test]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -7,11 +7,16 @@ use crate::paths;
 
 // --- Hook types (FR-18, FR-19) ---
 
+fn default_timeout_secs() -> Option<u64> {
+    Some(120)
+}
+
 #[derive(Debug, Default, Deserialize, serde::Serialize, PartialEq, Clone)]
 pub struct HookDef {
     pub copy: Option<Vec<String>>,
     pub run: Option<Vec<String>>,
     pub shell: Option<String>,
+    #[serde(default = "default_timeout_secs")]
     pub timeout_secs: Option<u64>,
 }
 

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -38,6 +38,7 @@ impl fmt::Display for HookEvent {
 }
 
 /// Context needed to build TRENCH_* environment variables for hook processes (FR-23).
+#[derive(Debug, Clone)]
 pub struct HookEnvContext {
     pub worktree_path: String,
     pub worktree_name: String,
@@ -198,6 +199,26 @@ timeout_secs = 60
         assert!(get_hook_config(&hooks, &HookEvent::PreSync).is_none());
         assert!(get_hook_config(&hooks, &HookEvent::PostSync).is_none());
         assert!(get_hook_config(&hooks, &HookEvent::PostRemove).is_none());
+    }
+
+    #[test]
+    fn hook_env_context_is_debug_and_clone() {
+        let ctx = HookEnvContext {
+            worktree_path: "/tmp/wt".into(),
+            worktree_name: "wt".into(),
+            branch: "main".into(),
+            repo_name: "repo".into(),
+            repo_path: "/tmp/repo".into(),
+            base_branch: "main".into(),
+        };
+
+        // Debug
+        let debug_str = format!("{:?}", ctx);
+        assert!(debug_str.contains("HookEnvContext"));
+
+        // Clone
+        let cloned = ctx.clone();
+        assert_eq!(cloned.worktree_name, "wt");
     }
 
     #[test]

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -222,6 +222,18 @@ timeout_secs = 60
     }
 
     #[test]
+    fn hooks_timeout_defaults_to_120_when_omitted() {
+        let toml_str = r#"
+[hooks.post_sync]
+run = ["echo synced"]
+"#;
+        let config: crate::config::ProjectConfig = toml::from_str(toml_str).unwrap();
+        let hooks = config.hooks.unwrap();
+        let post_sync = get_hook_config(&hooks, &HookEvent::PostSync).unwrap();
+        assert_eq!(post_sync.timeout_secs, Some(120));
+    }
+
+    #[test]
     fn hook_event_has_six_variants_with_correct_strings() {
         let cases = vec![
             (HookEvent::PreCreate, "pre_create"),

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -1,0 +1,60 @@
+use std::collections::HashMap;
+use std::fmt;
+
+use crate::config::{HookDef, HooksConfig};
+
+/// Re-export HookDef as HookConfig for the hooks module public API.
+/// This is the per-hook configuration with copy, run, shell, timeout_secs fields.
+pub type HookConfig = HookDef;
+
+/// Six lifecycle hooks fired during worktree operations (FR-18).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HookEvent {
+    PreCreate,
+    PostCreate,
+    PreSync,
+    PostSync,
+    PreRemove,
+    PostRemove,
+}
+
+impl HookEvent {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::PreCreate => "pre_create",
+            Self::PostCreate => "post_create",
+            Self::PreSync => "pre_sync",
+            Self::PostSync => "post_sync",
+            Self::PreRemove => "pre_remove",
+            Self::PostRemove => "post_remove",
+        }
+    }
+}
+
+impl fmt::Display for HookEvent {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hook_event_has_six_variants_with_correct_strings() {
+        let cases = vec![
+            (HookEvent::PreCreate, "pre_create"),
+            (HookEvent::PostCreate, "post_create"),
+            (HookEvent::PreSync, "pre_sync"),
+            (HookEvent::PostSync, "post_sync"),
+            (HookEvent::PreRemove, "pre_remove"),
+            (HookEvent::PostRemove, "post_remove"),
+        ];
+
+        for (event, expected) in cases {
+            assert_eq!(event.as_str(), expected);
+            assert_eq!(format!("{event}"), expected);
+        }
+    }
+}


### PR DESCRIPTION
Closes #21

## Summary
Implements the hook configuration and environment infrastructure in `src/hooks/`. Adds `HookEvent` enum for six lifecycle hooks (pre_create, post_create, pre_sync, post_sync, pre_remove, post_remove), `build_env()` to construct the 7 TRENCH_* environment variables for hook processes, `get_hook_config()` to retrieve a hook's configuration by event type, and re-exports `HookDef` as `HookConfig` for the hooks module public API.

## User Stories Addressed
- US-2: Hook configuration (`.env` files and `node_modules` set up automatically via hooks)
- US-3: Project-level hooks (`.trench.toml` with `[hooks.post_create]` etc.)

## Automated Testing
- Total tests added: 5
- Tests passing: 5
- Tests failing: 0
- `cargo clippy`: pass (no new warnings)
- `cargo test`: pass (220 total)

## UAT Checklist
- [ ] Add `[hooks.post_create]` with `copy` and `run` fields to a `.trench.toml` — config parses without error
- [ ] Add `[hooks.pre_remove]` with `shell` and `timeout_secs` fields — config parses without error
- [ ] Confirm that omitting `timeout_secs` from a hook config does not cause a parse error (field is optional)
- [ ] Confirm that all six hook types (`pre_create`, `post_create`, `pre_sync`, `post_sync`, `pre_remove`, `post_remove`) are recognized in `.trench.toml`
- [ ] Future hook runner can call `build_env()` and receive all 7 `TRENCH_*` vars in the returned HashMap

## Known Issues
None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Exposed a public hooks API covering six lifecycle events (pre/post for create, sync, remove).
  * Hooks now receive rich environment context (worktree, repository, branch, base branch, and event name).

* **Behavior Changes**
  * Hook timeouts default to 120 seconds when unspecified.

* **Tests**
  * Added comprehensive tests for hook resolution, event string mapping, environment construction, and public hook behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->