### PR TITLE
feat(list): add --json and --porcelain output modes

### DIFF
--- a/src/cli/commands/list.rs
+++ b/src/cli/commands/list.rs
@@ -108,18 +108,18 @@ pub fn execute_porcelain(cwd: &Path, db: &Database, tag: Option<&str>) -> Result
 
     let items: Vec<WorktreeJson> = worktrees
         .iter()
-        .map(|wt| {
-            let tags = db.list_tags(wt.id).unwrap_or_default();
-            WorktreeJson {
+        .map(|wt| -> Result<WorktreeJson> {
+            let tags = db.list_tags(wt.id)?;
+            Ok(WorktreeJson {
                 name: wt.name.clone(),
                 branch: wt.branch.clone(),
                 path: wt.path.clone(),
                 status: "clean".to_string(),
                 managed: wt.managed,
                 tags,
-            }
+            })
         })
-        .collect();
+        .collect::<Result<Vec<_>>>()?;
 
     Ok(format_porcelain(&items))
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,7 @@ struct Cli {
     json: bool,
 
     /// Output in porcelain format
-    #[arg(long, global = true)]
+    #[arg(long, global = true, conflicts_with = "json")]
     porcelain: bool,
 
     /// Disable colored output
@@ -362,16 +362,30 @@ mod tests {
     #[test]
     fn global_flags_are_accepted() {
         let cli = Cli::try_parse_from([
-            "trench", "--json", "--porcelain", "--no-color", "--quiet", "--verbose", "--dry-run",
+            "trench", "--json", "--no-color", "--quiet", "--verbose", "--dry-run",
         ])
         .expect("all global flags should be accepted");
 
         assert!(cli.json);
-        assert!(cli.porcelain);
         assert!(cli.no_color);
         assert!(cli.quiet);
         assert!(cli.verbose);
         assert!(cli.dry_run);
+
+        let cli2 = Cli::try_parse_from(["trench", "--porcelain"])
+            .expect("porcelain flag should be accepted");
+        assert!(cli2.porcelain);
+    }
+
+    #[test]
+    fn json_and_porcelain_conflict() {
+        let result = Cli::try_parse_from(["trench", "--json", "--porcelain"]);
+        let err = result.unwrap_err();
+        assert_eq!(
+            err.kind(),
+            clap::error::ErrorKind::ArgumentConflict,
+            "expected ArgumentConflict, got: {err}"
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -129,6 +129,7 @@ fn main() -> anyhow::Result<()> {
 
     let dry_run = cli.dry_run;
     let json = cli.json;
+    let porcelain = cli.porcelain;
 
     match cli.command {
         Some(Commands::Create { branch, from }) => {
@@ -137,7 +138,7 @@ fn main() -> anyhow::Result<()> {
         Some(Commands::Remove { branch, force }) => run_remove(&branch, force),
         Some(Commands::Switch { branch, print_path }) => run_switch(&branch, print_path),
         Some(Commands::Tag { branch, tags }) => run_tag(&branch, &tags),
-        Some(Commands::List { tag }) => run_list(tag.as_deref(), json),
+        Some(Commands::List { tag }) => run_list(tag.as_deref(), json, porcelain),
         Some(Commands::Init { force }) => run_init(force),
         Some(_) => {
             // Other commands not yet implemented
@@ -301,13 +302,15 @@ fn run_tag(identifier: &str, tags: &[String]) -> anyhow::Result<()> {
     Ok(())
 }
 
-fn run_list(tag: Option<&str>, json: bool) -> anyhow::Result<()> {
+fn run_list(tag: Option<&str>, json: bool, porcelain: bool) -> anyhow::Result<()> {
     let cwd = std::env::current_dir().context("failed to determine current directory")?;
     let db_path = paths::data_dir()?.join("trench.db");
     let db = state::Database::open(&db_path)?;
 
     let output = if json {
         cli::commands::list::execute_json(&cwd, &db, tag)?
+    } else if porcelain {
+        cli::commands::list::execute_porcelain(&cwd, &db, tag)?
     } else {
         cli::commands::list::execute(&cwd, &db, tag)?
     };

--- a/src/output/json.rs
+++ b/src/output/json.rs
@@ -1,0 +1,76 @@
+use anyhow::Result;
+use serde::Serialize;
+
+/// Serialize a slice of items as a pretty-printed JSON array.
+///
+/// This is the canonical way to produce `--json` output across all trench
+/// commands. The caller is responsible for constructing the concrete
+/// `Serialize`-able type; this function handles formatting only.
+pub fn format_json<T: Serialize>(items: &[T]) -> Result<String> {
+    Ok(serde_json::to_string_pretty(items)?)
+}
+
+/// Serialize a single item as a pretty-printed JSON object.
+///
+/// Used by commands that output a single resource (e.g. `trench create --json`).
+pub fn format_json_value<T: Serialize>(item: &T) -> Result<String> {
+    Ok(serde_json::to_string_pretty(item)?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::Deserialize;
+
+    #[derive(Serialize, Deserialize, Debug, PartialEq)]
+    struct Dummy {
+        name: String,
+        count: u32,
+    }
+
+    #[test]
+    fn format_json_serializes_array() {
+        let items = vec![
+            Dummy { name: "alpha".into(), count: 1 },
+            Dummy { name: "beta".into(), count: 2 },
+        ];
+
+        let output = format_json(&items).unwrap();
+        let parsed: Vec<Dummy> = serde_json::from_str(&output).unwrap();
+
+        assert_eq!(parsed.len(), 2);
+        assert_eq!(parsed[0].name, "alpha");
+        assert_eq!(parsed[1].count, 2);
+    }
+
+    #[test]
+    fn format_json_empty_array() {
+        let items: Vec<Dummy> = vec![];
+        let output = format_json(&items).unwrap();
+        assert_eq!(output, "[]");
+    }
+
+    #[test]
+    fn format_json_value_serializes_single_object() {
+        let item = Dummy { name: "solo".into(), count: 42 };
+        let output = format_json_value(&item).unwrap();
+        let parsed: Dummy = serde_json::from_str(&output).unwrap();
+        assert_eq!(parsed, item);
+    }
+
+    #[test]
+    fn format_json_output_is_pretty_printed() {
+        let items = vec![Dummy { name: "x".into(), count: 0 }];
+        let output = format_json(&items).unwrap();
+        // Pretty-printed JSON has newlines and indentation
+        assert!(output.contains('\n'), "output should be pretty-printed");
+        assert!(output.contains("  "), "output should have indentation");
+    }
+
+    #[test]
+    fn format_json_contains_no_ansi_codes() {
+        let items = vec![Dummy { name: "test".into(), count: 1 }];
+        let output = format_json(&items).unwrap();
+        assert!(!output.contains('\x1b'), "JSON output must not contain ANSI escape codes");
+    }
+}

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -1,3 +1,5 @@
+pub mod json;
+pub mod porcelain;
 pub mod table;
 
 /// Output verbosity level.

--- a/src/output/porcelain.rs
+++ b/src/output/porcelain.rs
@@ -20,3 +20,76 @@ pub fn format_porcelain(items: &[impl PorcelainRecord]) -> String {
     }
     out
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct TestRecord {
+        name: String,
+        branch: String,
+        managed: bool,
+    }
+
+    impl PorcelainRecord for TestRecord {
+        fn porcelain_fields(&self) -> Vec<String> {
+            vec![
+                self.name.clone(),
+                self.branch.clone(),
+                self.managed.to_string(),
+            ]
+        }
+    }
+
+    #[test]
+    fn format_porcelain_produces_colon_separated_lines() {
+        let items = vec![
+            TestRecord { name: "alpha".into(), branch: "feature/alpha".into(), managed: true },
+            TestRecord { name: "beta".into(), branch: "fix/beta".into(), managed: false },
+        ];
+
+        let output = format_porcelain(&items);
+        let lines: Vec<&str> = output.lines().collect();
+
+        assert_eq!(lines.len(), 2);
+        assert_eq!(lines[0], "alpha:feature/alpha:true");
+        assert_eq!(lines[1], "beta:fix/beta:false");
+    }
+
+    #[test]
+    fn format_porcelain_empty_list() {
+        let items: Vec<TestRecord> = vec![];
+        let output = format_porcelain(&items);
+        assert!(output.is_empty());
+    }
+
+    #[test]
+    fn format_porcelain_single_record() {
+        let items = vec![
+            TestRecord { name: "solo".into(), branch: "main".into(), managed: true },
+        ];
+
+        let output = format_porcelain(&items);
+        assert_eq!(output, "solo:main:true\n");
+    }
+
+    #[test]
+    fn format_porcelain_ends_each_line_with_newline() {
+        let items = vec![
+            TestRecord { name: "a".into(), branch: "b".into(), managed: true },
+        ];
+
+        let output = format_porcelain(&items);
+        assert!(output.ends_with('\n'), "each record line must end with newline");
+    }
+
+    #[test]
+    fn format_porcelain_contains_no_ansi_codes() {
+        let items = vec![
+            TestRecord { name: "test".into(), branch: "dev".into(), managed: false },
+        ];
+
+        let output = format_porcelain(&items);
+        assert!(!output.contains('\x1b'), "porcelain output must not contain ANSI escape codes");
+    }
+}

--- a/src/output/porcelain.rs
+++ b/src/output/porcelain.rs
@@ -1,0 +1,22 @@
+/// Trait for types that can be rendered as porcelain (colon-separated) output.
+///
+/// Implement this on any struct that should support `--porcelain` output.
+/// Each implementor defines its own field ordering.
+pub trait PorcelainRecord {
+    /// Return the ordered field values for this record.
+    fn porcelain_fields(&self) -> Vec<String>;
+}
+
+/// Format a slice of porcelain records as newline-delimited, colon-separated lines.
+///
+/// This is the canonical way to produce `--porcelain` output across all trench
+/// commands.
+pub fn format_porcelain(items: &[impl PorcelainRecord]) -> String {
+    let mut out = String::new();
+    for item in items {
+        let line = item.porcelain_fields().join(":");
+        out.push_str(&line);
+        out.push('\n');
+    }
+    out
+}

--- a/src/output/porcelain.rs
+++ b/src/output/porcelain.rs
@@ -11,6 +11,13 @@ pub trait PorcelainRecord {
 ///
 /// This is the canonical way to produce `--porcelain` output across all trench
 /// commands.
+///
+/// # Limitations
+///
+/// Fields are joined with `:` and records are separated by `\n`. If a field
+/// value contains either character the output becomes ambiguous. Consumers
+/// should parse left-to-right using the known field count for each record
+/// type rather than splitting blindly on `:`.
 pub fn format_porcelain(items: &[impl PorcelainRecord]) -> String {
     let mut out = String::new();
     for item in items {


### PR DESCRIPTION
Closes #22

## Summary
Add structured output modes to `trench list`: `--json` outputs a JSON array of worktree objects with name, branch, path, status, managed, and tags fields; `--porcelain` outputs colon-separated lines (`name:branch:path:status:managed`). Both formatters are implemented as reusable modules in `src/output/` so other commands can adopt them without duplication.

## User Stories Addressed
- US-4: Structured output for AI agents — `trench list --json` and `--porcelain` enable programmatic consumption
- US-5: List worktrees in machine-readable format — both modes provide complete worktree metadata

## Automated Testing
- Total tests added: 14
- Tests passing: 14
- Tests failing: 0
- `cargo clippy`: pass
- `cargo test`: pass (237 total)

## UAT Checklist
- [ ] `trench list --json` in a repo with worktrees → valid JSON array printed to stdout
- [ ] `trench list --porcelain` in a repo with worktrees → colon-separated lines printed to stdout
- [ ] `trench list --json --tag wip` → only worktrees tagged "wip" in JSON
- [ ] `trench list --porcelain --tag wip` → only worktrees tagged "wip" in porcelain
- [ ] `trench list --json` with no worktrees → empty JSON array `[]`
- [ ] `trench list --porcelain` with no worktrees → no output
- [ ] `trench list --json | jq .` → parses cleanly without errors
- [ ] `trench list --porcelain | cut -d: -f1` → outputs just worktree names
- [ ] `trench list --json --no-color` → no ANSI codes in output (same as without flag, since JSON never emits ANSI)

## Known Issues
None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a porcelain output format (colon-separated, newline-terminated) for the list command.
  * Added a global --porcelain flag to request structured porcelain output.
  * JSON output now includes a new "managed" field for each worktree and uses pretty-printed formatting.

* **Bug Fixes / Behavior**
  * porcelain and JSON output modes are mutually exclusive to avoid conflicting flags.

* **Tests**
  * Added tests validating porcelain formatting, JSON formatting, and presence of the managed field.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->