### PR TITLE
feat(git): branch ahead/behind counts + dirty file detection

### DIFF
--- a/src/cli/commands/list.rs
+++ b/src/cli/commands/list.rs
@@ -762,8 +762,12 @@ mod tests {
     #[test]
     fn list_json_shows_null_ahead_behind_when_no_upstream() {
         let repo_dir = tempfile::tempdir().unwrap();
-        let _repo = init_repo_with_commit(repo_dir.path());
+        let repo = init_repo_with_commit(repo_dir.path());
         let db = Database::open_in_memory().unwrap();
+
+        // Create a real local branch with no upstream tracking
+        let head_commit = repo.head().unwrap().peel_to_commit().unwrap();
+        repo.branch("orphan-branch", &head_commit, false).unwrap();
 
         let repo_path = repo_dir.path().canonicalize().unwrap();
         let repo_name = repo_path.file_name().unwrap().to_str().unwrap();
@@ -771,12 +775,12 @@ mod tests {
             .insert_repo(repo_name, repo_path.to_str().unwrap(), Some("main"))
             .unwrap();
 
-        // Insert worktree with no base_branch — simulates no upstream info
+        // Insert worktree pointing to the real branch and repo path, no base_branch
         db.insert_worktree(
             db_repo.id,
             "orphan-wt",
             "orphan-branch",
-            "/nonexistent/path",
+            repo_path.to_str().unwrap(),
             None, // no base_branch
         )
         .unwrap();
@@ -800,8 +804,12 @@ mod tests {
     #[test]
     fn list_table_shows_dash_for_no_upstream() {
         let repo_dir = tempfile::tempdir().unwrap();
-        let _repo = init_repo_with_commit(repo_dir.path());
+        let repo = init_repo_with_commit(repo_dir.path());
         let db = Database::open_in_memory().unwrap();
+
+        // Create a real local branch with no upstream tracking
+        let head_commit = repo.head().unwrap().peel_to_commit().unwrap();
+        repo.branch("no-upstream-branch", &head_commit, false).unwrap();
 
         let repo_path = repo_dir.path().canonicalize().unwrap();
         let repo_name = repo_path.file_name().unwrap().to_str().unwrap();
@@ -813,7 +821,7 @@ mod tests {
             db_repo.id,
             "no-upstream-wt",
             "no-upstream-branch",
-            "/nonexistent/path",
+            repo_path.to_str().unwrap(),
             None,
         )
         .unwrap();

--- a/src/cli/commands/list.rs
+++ b/src/cli/commands/list.rs
@@ -828,9 +828,13 @@ mod tests {
         let output = execute(repo_dir.path(), &db, None).expect("list should succeed");
 
         // The Ahead/Behind column should show "-" for no upstream
+        let row = output
+            .lines()
+            .find(|line| line.contains("no-upstream-wt"))
+            .expect("expected no-upstream-wt row");
         assert!(
-            output.contains('-'),
-            "table should show '-' for no upstream ahead/behind, got: {output}"
+            row.split_whitespace().any(|cell| cell == "-"),
+            "Ahead/Behind cell should be '-', got row: {row}"
         );
     }
 

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -819,6 +819,38 @@ mod tests {
     }
 
     #[test]
+    fn ahead_behind_counts_commits_behind_base() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = init_repo_with_commit(tmp.path());
+        let base = head_branch(&repo);
+        let sig = git2::Signature::now("Test", "test@test.com").unwrap();
+
+        // Create feature branch at current commit
+        let base_commit = repo.head().unwrap().peel_to_commit().unwrap();
+        repo.branch("feature-behind", &base_commit, false).unwrap();
+
+        // Add 3 commits on the base branch (feature stays at original commit)
+        for i in 0..3 {
+            let parent = repo.head().unwrap().peel_to_commit().unwrap();
+            let tree = repo.find_tree(repo.index().unwrap().write_tree().unwrap()).unwrap();
+            repo.commit(
+                Some("HEAD"),
+                &sig,
+                &sig,
+                &format!("base commit {i}"),
+                &tree,
+                &[&parent],
+            )
+            .unwrap();
+        }
+
+        let result = ahead_behind(tmp.path(), "feature-behind", Some(&base))
+            .expect("should succeed");
+
+        assert_eq!(result, Some((0, 3)), "feature should be 0 ahead, 3 behind");
+    }
+
+    #[test]
     fn dirty_count_returns_zero_for_clean_worktree() {
         let tmp = tempfile::tempdir().unwrap();
         let _repo = init_repo_with_commit(tmp.path());

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -851,6 +851,21 @@ mod tests {
     }
 
     #[test]
+    fn ahead_behind_returns_none_when_no_upstream_and_no_base() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = init_repo_with_commit(tmp.path());
+
+        // Create a branch with no upstream and pass no base_branch
+        let head_commit = repo.head().unwrap().peel_to_commit().unwrap();
+        repo.branch("orphan-branch", &head_commit, false).unwrap();
+
+        let result = ahead_behind(tmp.path(), "orphan-branch", None)
+            .expect("should succeed");
+
+        assert_eq!(result, None, "no upstream and no base should return None");
+    }
+
+    #[test]
     fn dirty_count_returns_zero_for_clean_worktree() {
         let tmp = tempfile::tempdir().unwrap();
         let _repo = init_repo_with_commit(tmp.path());


### PR DESCRIPTION
Closes #23

## Summary
Implements git branch intelligence: `ahead_behind()` calculates commits ahead/behind relative to upstream or base branch using `git2::Repository::graph_ahead_behind()`, and `dirty_count()` counts modified + untracked files via `git2` status API. Both are wired into `trench list` table, JSON, and porcelain output modes with graceful fallback when worktree paths or upstream branches don't exist.

## User Stories Addressed
- US-5: See all worktrees (including manually-created ones) with ahead/behind counts

## Automated Testing
- Total tests added: 11
- Tests passing: 249
- Tests failing: 0
- `cargo clippy`: pass
- `cargo test`: pass

## UAT Checklist
- [ ] `trench create my-feature && trench list` → new worktree shows `+0/-0` ahead/behind and `clean` status
- [ ] Make changes in a worktree (edit files, add untracked) → `trench list` shows `~N` dirty count
- [ ] Commit in a worktree → `trench list` shows `+1/-0` ahead/behind
- [ ] `trench list --json` → each worktree object has `ahead`, `behind`, `dirty` numeric fields
- [ ] `trench list --json` for worktree with no upstream → `ahead` and `behind` are `null`
- [ ] `trench list --porcelain` → 8 colon-separated fields per line (name:branch:path:status:ahead:behind:dirty:managed)
- [ ] `trench list` in repo with no worktrees → still shows empty state message

## Known Issues
None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The list command now shows upstream ahead/behind counts and a dynamic dirty status in table, JSON, and porcelain outputs; headers and porcelain field ordering updated accordingly.
* **Tests**
  * Added and updated tests validating ahead/behind and dirty values across scenarios (no upstream, various upstream states, dirty files) and adjusted expected outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->