### PR TITLE
feat(list): unmanaged worktree discovery + [unmanaged] badge

### DIFF
--- a/src/cli/commands/list.rs
+++ b/src/cli/commands/list.rs
@@ -62,20 +62,18 @@ fn fetch_all_worktrees(
 
     // When filtering by tag, only return managed worktrees (unmanaged can't have tags)
     if tag.is_some() {
-        let entries = db_worktrees
-            .iter()
-            .map(|wt| {
-                let tags = db.list_tags(wt.id).unwrap_or_default();
-                ListEntry {
-                    name: wt.name.clone(),
-                    branch: wt.branch.clone(),
-                    path: wt.path.clone(),
-                    base_branch: wt.base_branch.clone(),
-                    managed: true,
-                    tags,
-                }
-            })
-            .collect();
+        let mut entries = Vec::with_capacity(db_worktrees.len());
+        for wt in &db_worktrees {
+            let tags = db.list_tags(wt.id)?;
+            entries.push(ListEntry {
+                name: wt.name.clone(),
+                branch: wt.branch.clone(),
+                path: wt.path.clone(),
+                base_branch: wt.base_branch.clone(),
+                managed: true,
+                tags,
+            });
+        }
         return Ok((repo_path, entries));
     }
 
@@ -93,7 +91,7 @@ fn fetch_all_worktrees(
 
     // Add managed worktrees first
     for wt in &db_worktrees {
-        let tags = db.list_tags(wt.id).unwrap_or_default();
+        let tags = db.list_tags(wt.id)?;
         entries.push(ListEntry {
             name: wt.name.clone(),
             branch: wt.branch.clone(),

--- a/src/cli/commands/list.rs
+++ b/src/cli/commands/list.rs
@@ -103,18 +103,17 @@ fn fetch_all_worktrees(
     }
 
     // Discover git worktrees and add unmanaged ones
-    if let Ok(git_worktrees) = git::list_worktrees(&repo_path) {
-        for gw in git_worktrees {
-            if !managed_paths.contains(&gw.path) {
-                entries.push(ListEntry {
-                    name: gw.name.clone(),
-                    branch: gw.branch.unwrap_or_else(|| "(detached)".to_string()),
-                    path: gw.path.to_string_lossy().into_owned(),
-                    base_branch: None,
-                    managed: false,
-                    tags: Vec::new(),
-                });
-            }
+    let git_worktrees = git::list_worktrees(&repo_path)?;
+    for gw in git_worktrees {
+        if !managed_paths.contains(&gw.path) {
+            entries.push(ListEntry {
+                name: gw.name.clone(),
+                branch: gw.branch.unwrap_or_else(|| "(detached)".to_string()),
+                path: gw.path.to_string_lossy().into_owned(),
+                base_branch: None,
+                managed: false,
+                tags: Vec::new(),
+            });
         }
     }
 


### PR DESCRIPTION
Closes #24

## Summary
Enhanced `trench list` to discover and display ALL git worktrees — not just trench-managed ones. Worktrees created outside trench (including the main worktree) now appear with an `[unmanaged]` badge, dimmed ANSI styling in table output, and `"managed": false` in JSON/porcelain output.

## User Stories Addressed
- US-5: See all worktrees (including manually-created ones) with ahead/behind counts

## Automated Testing
- Total tests added: 8
- Tests passing: 257
- Tests failing: 0
- `cargo clippy`: pass
- `cargo test`: pass

## UAT Checklist
- [ ] `cd` into any git repo → `trench list` shows the main worktree with `[unmanaged]` badge
- [ ] `git worktree add ../my-external-wt -b external-branch` → `trench list` shows the external worktree with `[unmanaged]` badge and dimmed styling
- [ ] `trench create my-feature` → `trench list` shows both the managed worktree (no badge) and the main worktree (with badge)
- [ ] `trench list --json` → unmanaged worktrees have `"managed": false`, managed ones have `"managed": true`
- [ ] `trench list --porcelain` → last field is `false` for unmanaged, `true` for managed
- [ ] `trench list --tag wip` → only shows managed worktrees with the tag (unmanaged worktrees excluded from tag filter)
- [ ] Unmanaged worktrees show ahead/behind counts and dirty file counts just like managed ones

## Known Issues
None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * List command shows both DB-managed and unmanaged git worktrees.
  * Unmanaged worktrees are marked with a badge and dimmed in table output.
  * All output formats (table, JSON, porcelain) include unmanaged entries with flags.
  * Main worktree now appears in list output as an unmanaged entry.

* **Tests**
  * Added tests covering unmanaged worktrees, main worktree visibility, and format consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->