### PR TITLE
feat(hooks): run step — sequential command execution with streaming output

### DIFF
--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -1,4 +1,5 @@
 pub mod copy;
+pub mod run;
 
 use std::collections::HashMap;
 use std::fmt;

--- a/src/hooks/run.rs
+++ b/src/hooks/run.rs
@@ -224,4 +224,16 @@ mod tests {
         assert_eq!(run_err.results.executed[0].stdout.trim(), "first");
         assert_eq!(run_err.results.executed[1].exit_code, 42);
     }
+
+    #[tokio::test]
+    async fn stderr_captured_separately_from_stdout() {
+        let dir = TempDir::new().unwrap();
+        let commands = vec!["echo out_msg; echo err_msg >&2".to_string()];
+        let env = HashMap::new();
+
+        let result = execute_run_step(&commands, dir.path(), &env).await.unwrap();
+
+        assert_eq!(result.executed[0].stdout.trim(), "out_msg");
+        assert_eq!(result.executed[0].stderr.trim(), "err_msg");
+    }
 }

--- a/src/hooks/run.rs
+++ b/src/hooks/run.rs
@@ -236,4 +236,15 @@ mod tests {
         assert_eq!(result.executed[0].stdout.trim(), "out_msg");
         assert_eq!(result.executed[0].stderr.trim(), "err_msg");
     }
+
+    #[tokio::test]
+    async fn empty_commands_is_noop() {
+        let dir = TempDir::new().unwrap();
+        let commands: Vec<String> = vec![];
+        let env = HashMap::new();
+
+        let result = execute_run_step(&commands, dir.path(), &env).await.unwrap();
+
+        assert!(result.executed.is_empty());
+    }
 }

--- a/src/hooks/run.rs
+++ b/src/hooks/run.rs
@@ -144,4 +144,22 @@ mod tests {
         assert_eq!(result.executed[0].stdout.trim(), "hello");
         assert_eq!(result.executed[0].exit_code, 0);
     }
+
+    #[tokio::test]
+    async fn sequential_commands_execute_in_order() {
+        let dir = TempDir::new().unwrap();
+        let commands = vec![
+            "echo first".to_string(),
+            "echo second".to_string(),
+            "echo third".to_string(),
+        ];
+        let env = HashMap::new();
+
+        let result = execute_run_step(&commands, dir.path(), &env).await.unwrap();
+
+        assert_eq!(result.executed.len(), 3);
+        assert_eq!(result.executed[0].stdout.trim(), "first");
+        assert_eq!(result.executed[1].stdout.trim(), "second");
+        assert_eq!(result.executed[2].stdout.trim(), "third");
+    }
 }

--- a/src/hooks/run.rs
+++ b/src/hooks/run.rs
@@ -162,4 +162,19 @@ mod tests {
         assert_eq!(result.executed[1].stdout.trim(), "second");
         assert_eq!(result.executed[2].stdout.trim(), "third");
     }
+
+    #[tokio::test]
+    async fn commands_run_with_specified_working_directory() {
+        let dir = TempDir::new().unwrap();
+        let commands = vec!["pwd".to_string()];
+        let env = HashMap::new();
+
+        let result = execute_run_step(&commands, dir.path(), &env).await.unwrap();
+
+        let output_path = result.executed[0].stdout.trim();
+        // Canonicalize both to handle symlinks like /tmp -> /private/tmp on macOS
+        let expected = dir.path().canonicalize().unwrap();
+        let actual = std::path::PathBuf::from(output_path).canonicalize().unwrap();
+        assert_eq!(actual, expected);
+    }
 }

--- a/src/hooks/run.rs
+++ b/src/hooks/run.rs
@@ -177,4 +177,21 @@ mod tests {
         let actual = std::path::PathBuf::from(output_path).canonicalize().unwrap();
         assert_eq!(actual, expected);
     }
+
+    #[tokio::test]
+    async fn env_vars_available_in_commands() {
+        let dir = TempDir::new().unwrap();
+        let commands = vec![
+            "echo $TRENCH_BRANCH".to_string(),
+            "echo $TRENCH_EVENT".to_string(),
+        ];
+        let mut env = HashMap::new();
+        env.insert("TRENCH_BRANCH".to_string(), "feature/auth".to_string());
+        env.insert("TRENCH_EVENT".to_string(), "post_create".to_string());
+
+        let result = execute_run_step(&commands, dir.path(), &env).await.unwrap();
+
+        assert_eq!(result.executed[0].stdout.trim(), "feature/auth");
+        assert_eq!(result.executed[1].stdout.trim(), "post_create");
+    }
 }

--- a/src/hooks/run.rs
+++ b/src/hooks/run.rs
@@ -1,0 +1,147 @@
+use std::collections::HashMap;
+use std::path::Path;
+use std::process::Stdio;
+
+use anyhow::{Context, Result};
+use tokio::io::{AsyncBufReadExt, BufReader};
+
+/// Output from a single command execution.
+#[derive(Debug, Clone)]
+pub struct CommandOutput {
+    /// The command string that was executed.
+    pub command: String,
+    /// Captured stdout.
+    pub stdout: String,
+    /// Captured stderr.
+    pub stderr: String,
+    /// Process exit code.
+    pub exit_code: i32,
+}
+
+/// Result of executing the run step.
+#[derive(Debug, Clone)]
+pub struct RunResult {
+    /// Output from each executed command, in order.
+    pub executed: Vec<CommandOutput>,
+}
+
+/// Error returned when a command in the run step exits with a non-zero code.
+/// Contains partial results from all commands that executed (including the failed one).
+#[derive(Debug, thiserror::Error)]
+#[error("command failed: `{command}` exited with code {exit_code}")]
+pub struct RunStepError {
+    pub command: String,
+    pub exit_code: i32,
+    pub results: RunResult,
+}
+
+/// Execute the run step of a hook: run commands sequentially with streaming output.
+///
+/// Each command string is executed via `sh -c "<command>"`.
+/// Commands run with cwd set to `cwd` and TRENCH_* env vars from `env_vars`.
+/// stdout/stderr stream to the terminal in real time and are captured for logging.
+/// Stops on first non-zero exit code (FR-20, FR-22).
+pub async fn execute_run_step(
+    commands: &[String],
+    cwd: &Path,
+    env_vars: &HashMap<String, String>,
+) -> Result<RunResult> {
+    let mut executed = Vec::new();
+
+    for cmd in commands {
+        let mut child = tokio::process::Command::new("sh")
+            .arg("-c")
+            .arg(cmd)
+            .current_dir(cwd)
+            .envs(env_vars.iter())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .with_context(|| format!("failed to spawn command: {cmd}"))?;
+
+        let stdout = child.stdout.take().expect("stdout piped");
+        let stderr = child.stderr.take().expect("stderr piped");
+
+        let mut stdout_reader = BufReader::new(stdout).lines();
+        let mut stderr_reader = BufReader::new(stderr).lines();
+
+        let mut stdout_buf = String::new();
+        let mut stderr_buf = String::new();
+        let mut stdout_done = false;
+        let mut stderr_done = false;
+
+        while !stdout_done || !stderr_done {
+            tokio::select! {
+                result = stdout_reader.next_line(), if !stdout_done => {
+                    match result? {
+                        Some(line) => {
+                            println!("{line}");
+                            if !stdout_buf.is_empty() {
+                                stdout_buf.push('\n');
+                            }
+                            stdout_buf.push_str(&line);
+                        }
+                        None => stdout_done = true,
+                    }
+                }
+                result = stderr_reader.next_line(), if !stderr_done => {
+                    match result? {
+                        Some(line) => {
+                            eprintln!("{line}");
+                            if !stderr_buf.is_empty() {
+                                stderr_buf.push('\n');
+                            }
+                            stderr_buf.push_str(&line);
+                        }
+                        None => stderr_done = true,
+                    }
+                }
+            }
+        }
+
+        let status = child
+            .wait()
+            .await
+            .with_context(|| format!("failed to wait for command: {cmd}"))?;
+
+        let exit_code = status.code().unwrap_or(-1);
+
+        executed.push(CommandOutput {
+            command: cmd.clone(),
+            stdout: stdout_buf,
+            stderr: stderr_buf,
+            exit_code,
+        });
+
+        if !status.success() {
+            return Err(RunStepError {
+                command: cmd.clone(),
+                exit_code,
+                results: RunResult { executed },
+            }
+            .into());
+        }
+    }
+
+    Ok(RunResult { executed })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[tokio::test]
+    async fn single_command_executes_and_captures_stdout() {
+        let dir = TempDir::new().unwrap();
+        let commands = vec!["echo hello".to_string()];
+        let env = HashMap::new();
+
+        let result = execute_run_step(&commands, dir.path(), &env).await.unwrap();
+
+        assert_eq!(result.executed.len(), 1);
+        assert_eq!(result.executed[0].command, "echo hello");
+        assert_eq!(result.executed[0].stdout.trim(), "hello");
+        assert_eq!(result.executed[0].exit_code, 0);
+    }
+}


### PR DESCRIPTION
Closes #26

## Summary
Implements the hook `run` step in `src/hooks/run.rs` — sequential shell command execution with real-time stdout/stderr streaming, TRENCH_* environment variable injection, and output capture for DB logging. Commands execute via `sh -c` with configurable working directory. Non-zero exit codes halt the sequence and return a structured error with partial results.

## User Stories Addressed
- US-2: Run setup commands like `bun install` in new worktrees (via `[hooks.post_create] run = [...]`)

## Automated Testing
- Total tests added: 8
- Tests passing: 8
- Tests failing: 0
- `cargo clippy`: pass
- `cargo test`: pass (274 total, 0 failures)

## UAT Checklist
- [ ] Create a `.trench.toml` with `[hooks.post_create] run = ["echo hello", "ls -la"]` and verify both commands execute when creating a worktree
- [ ] Verify hook output streams to terminal line-by-line during execution (not buffered until completion)
- [ ] Verify `run = ["echo ok", "false", "echo should_not_appear"]` stops after `false` and reports the failure
- [ ] Verify environment variables like `$TRENCH_BRANCH` and `$TRENCH_WORKTREE_PATH` are accessible inside hook commands
- [ ] Verify hook commands run in the worktree directory (e.g., `run = ["pwd"]` should output the worktree path)

## Known Issues
None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for executing sequential shell commands with real-time output streaming to terminal.
  * Captures detailed execution results including command output, error streams, and exit codes.
  * Handles environment variables and custom working directories for each execution.

* **Tests**
  * Added comprehensive test coverage for command execution, output capture, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->