### PR TITLE
feat(remove): add --force and --prune flags for remote branch cleanup

### DIFF
--- a/src/cli/commands/list.rs
+++ b/src/cli/commands/list.rs
@@ -543,7 +543,7 @@ mod tests {
         )
         .expect("create should succeed");
 
-        remove::execute("ephemeral", repo_dir.path(), &db)
+        remove::execute("ephemeral", repo_dir.path(), &db, false)
             .expect("remove should succeed");
 
         let output = render_table(repo_dir.path(), &db, None, None).expect("list should succeed");

--- a/src/cli/commands/remove.rs
+++ b/src/cli/commands/remove.rs
@@ -6,12 +6,26 @@ use crate::git;
 use crate::paths;
 use crate::state::Database;
 
+/// Result of a worktree removal.
+#[derive(Debug)]
+pub struct RemoveResult {
+    /// The name of the removed worktree.
+    pub name: String,
+    /// Whether the remote branch was pruned (only `true` if `--prune` was
+    /// requested and the remote branch existed).
+    pub pruned_remote: bool,
+}
+
 /// Execute the `trench remove <identifier>` command.
 ///
 /// Resolves the worktree by sanitized name or branch name, removes it from
 /// disk via git2, updates the DB record with `removed_at`, and inserts a
 /// "removed" event.
-pub fn execute(identifier: &str, cwd: &Path, db: &Database) -> Result<String> {
+///
+/// When `prune` is true, also deletes the corresponding remote branch.
+/// Returns a warning via `RemoveResult.pruned_remote = false` if the remote
+/// branch was not found (non-fatal).
+pub fn execute(identifier: &str, cwd: &Path, db: &Database, prune: bool) -> Result<RemoveResult> {
     let repo_info = git::discover_repo(cwd)?;
 
     let repo_path_str = repo_info
@@ -66,7 +80,22 @@ pub fn execute(identifier: &str, cwd: &Path, db: &Database) -> Result<String> {
     db.insert_event(repo.id, Some(wt.id), "removed", None)
         .context("failed to insert removed event")?;
 
-    Ok(wt.name.clone())
+    // Optionally delete the remote branch
+    let mut pruned_remote = false;
+    if prune {
+        match git::delete_remote_branch(&repo_info.path, "origin", &wt.branch) {
+            Ok(()) => pruned_remote = true,
+            Err(git::GitError::RemoteBranchNotFound { branch, remote }) => {
+                eprintln!("warning: remote branch '{branch}' not found on {remote}");
+            }
+            Err(e) => return Err(e.into()),
+        }
+    }
+
+    Ok(RemoveResult {
+        name: wt.name.clone(),
+        pruned_remote,
+    })
 }
 
 #[cfg(test)]
@@ -120,9 +149,9 @@ mod tests {
         let wt_id = wt_before.id;
 
         // Remove it
-        let name = execute("my-feature", repo_dir.path(), &db)
+        let result = execute("my-feature", repo_dir.path(), &db, false)
             .expect("remove should succeed");
-        assert_eq!(name, "my-feature");
+        assert_eq!(result.name, "my-feature");
 
         // Verify: directory is gone
         assert!(!path.exists(), "worktree directory should be deleted");
@@ -179,9 +208,9 @@ mod tests {
         ).unwrap();
 
         // Remove using the original branch name (feature/auth)
-        let name = execute("feature/auth", repo_dir.path(), &db)
+        let result = execute("feature/auth", repo_dir.path(), &db, false)
             .expect("remove by branch name should succeed");
-        assert_eq!(name, "feature-auth");
+        assert_eq!(result.name, "feature-auth");
         assert!(!path.exists(), "worktree directory should be deleted");
     }
 
@@ -204,9 +233,119 @@ mod tests {
         .expect("create should succeed");
 
         // Remove using the sanitized name
-        let name = execute("feature-auth", repo_dir.path(), &db)
+        let result = execute("feature-auth", repo_dir.path(), &db, false)
             .expect("remove by sanitized name should succeed");
-        assert_eq!(name, "feature-auth");
+        assert_eq!(result.name, "feature-auth");
+        assert!(!path.exists(), "worktree directory should be deleted");
+    }
+
+    /// Helper: create a bare remote, clone it, and return (clone_path, remote_dir).
+    /// The clone_dir TempDir is returned to keep it alive.
+    fn setup_repo_with_remote() -> (tempfile::TempDir, tempfile::TempDir) {
+        let remote_dir = tempfile::tempdir().unwrap();
+        let remote_repo = git2::Repository::init_bare(remote_dir.path()).unwrap();
+        {
+            let sig = git2::Signature::now("Test", "test@test.com").unwrap();
+            let empty_tree = remote_repo.treebuilder(None).unwrap().write().unwrap();
+            let tree = remote_repo.find_tree(empty_tree).unwrap();
+            remote_repo
+                .commit(Some("refs/heads/main"), &sig, &sig, "init", &tree, &[])
+                .unwrap();
+        }
+        let clone_dir = tempfile::tempdir().unwrap();
+        git2::build::RepoBuilder::new()
+            .clone(remote_dir.path().to_str().unwrap(), clone_dir.path())
+            .unwrap();
+        (clone_dir, remote_dir)
+    }
+
+    #[test]
+    fn remove_with_prune_deletes_remote_branch() {
+        let (clone_dir, remote_dir) = setup_repo_with_remote();
+        let wt_root = tempfile::tempdir().unwrap();
+        let db_dir = tempfile::tempdir().unwrap();
+        let db = Database::open(&db_dir.path().join("test.db")).unwrap();
+
+        // Create a worktree
+        let path = crate::cli::commands::create::execute(
+            "prune-me",
+            None,
+            clone_dir.path(),
+            wt_root.path(),
+            crate::paths::DEFAULT_WORKTREE_TEMPLATE,
+            &db,
+        )
+        .expect("create should succeed");
+        assert!(path.exists());
+
+        // Push the branch to the remote
+        let clone = git2::Repository::open(clone_dir.path()).unwrap();
+        {
+            let mut origin = clone.find_remote("origin").unwrap();
+            origin
+                .push(
+                    &["refs/heads/prune-me:refs/heads/prune-me"],
+                    None,
+                )
+                .unwrap();
+        }
+        // Fetch to update remote-tracking refs
+        {
+            let mut origin = clone.find_remote("origin").unwrap();
+            origin.fetch(&[] as &[&str], None, None).unwrap();
+        }
+
+        // Verify the remote branch exists on the bare remote
+        let remote_repo = git2::Repository::open_bare(remote_dir.path()).unwrap();
+        assert!(
+            remote_repo.find_branch("prune-me", git2::BranchType::Local).is_ok(),
+            "branch should exist on remote before prune"
+        );
+
+        // Remove with prune
+        let result = execute("prune-me", clone_dir.path(), &db, true)
+            .expect("remove with prune should succeed");
+        assert_eq!(result.name, "prune-me");
+        assert!(result.pruned_remote, "should have pruned remote branch");
+
+        // Verify: worktree directory is gone
+        assert!(!path.exists(), "worktree directory should be deleted");
+
+        // Verify: remote branch is gone
+        // Reopen the bare remote to get fresh state
+        let remote_repo = git2::Repository::open_bare(remote_dir.path()).unwrap();
+        assert!(
+            remote_repo.find_branch("prune-me", git2::BranchType::Local).is_err(),
+            "branch should be deleted on remote after prune"
+        );
+    }
+
+    #[test]
+    fn remove_with_prune_warns_when_remote_branch_missing() {
+        let (clone_dir, _remote_dir) = setup_repo_with_remote();
+        let wt_root = tempfile::tempdir().unwrap();
+        let db_dir = tempfile::tempdir().unwrap();
+        let db = Database::open(&db_dir.path().join("test.db")).unwrap();
+
+        // Create a worktree (but DON'T push the branch to remote)
+        let path = crate::cli::commands::create::execute(
+            "no-remote",
+            None,
+            clone_dir.path(),
+            wt_root.path(),
+            crate::paths::DEFAULT_WORKTREE_TEMPLATE,
+            &db,
+        )
+        .expect("create should succeed");
+        assert!(path.exists());
+
+        // Remove with prune — remote branch doesn't exist, should warn but succeed
+        let result = execute("no-remote", clone_dir.path(), &db, true)
+            .expect("remove with prune should succeed even without remote branch");
+        assert_eq!(result.name, "no-remote");
+        assert!(!result.pruned_remote, "should NOT have pruned remote branch");
+
+        // Verify: worktree directory is gone
         assert!(!path.exists(), "worktree directory should be deleted");
     }
 
@@ -228,7 +367,7 @@ mod tests {
         db.insert_repo("test-repo", &repo_path_str, Some("main"))
             .unwrap();
 
-        let result = execute("nonexistent", repo_dir.path(), &db);
+        let result = execute("nonexistent", repo_dir.path(), &db, false);
         let err = result.expect_err("should error for nonexistent worktree");
         let msg = err.to_string();
         assert!(

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -367,7 +367,7 @@ pub fn delete_remote_branch(
     // which can be stale or missing after push-without-fetch).
     let target_ref = format!("refs/heads/{branch}");
     let exists = {
-        let connection = remote.connect_auth(git2::Direction::Fetch, None, None)?;
+        let connection = remote.connect_auth(git2::Direction::Push, None, None)?;
         connection
             .list()?
             .iter()


### PR DESCRIPTION
Closes #27

## Summary
Added `--prune` flag to `trench remove` that deletes the corresponding remote branch after removing the worktree. The `--force` flag (already implemented) skips the confirmation prompt, and both flags can be combined. When `--prune` is used but the remote branch doesn't exist, a warning is printed instead of failing.

## User Stories Addressed
- US-8: Clean removal with remote cleanup — `trench remove foo --prune` deletes the worktree and its remote branch in one command

## Automated Testing
- Total tests added: 5
- Tests passing: 281
- Tests failing: 0
- `cargo clippy`: pass
- `cargo test`: pass

## UAT Checklist
- [ ] `trench create my-feature && trench remove my-feature --force` → worktree removed without prompt
- [ ] `trench create pr-branch`, push branch to remote, then `trench remove pr-branch --prune --force` → worktree removed and `git branch -r` no longer shows `origin/pr-branch`
- [ ] `trench create local-only && trench remove local-only --prune --force` → worktree removed, warning printed about missing remote branch, exit code 0
- [ ] `trench remove my-feature --prune` (without --force) → confirmation prompt includes "(including remote branch)" hint
- [ ] `trench remove nonexistent --force` → exit code 2, "not found" error

## Known Issues
None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a --prune option to the remove command to optionally delete the remote branch when removing a worktree.
  * Removal now reports whether the remote branch was pruned.

* **Bug Fixes / UX**
  * Prompts and output updated to mention remote pruning when requested; default behavior remains unchanged (no prune).
  * Non-fatal warnings shown if the remote branch is missing during pruning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->