### PR TITLE
feat(open): open worktree in $EDITOR

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1244,6 +1244,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1494,6 +1500,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serial_test",
+ "shell-words",
  "tempfile",
  "thiserror",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ dirs = "6"
 
 # Watch
 notify = "7"
+shell-words = "1.1.1"
 
 [dev-dependencies]
 serial_test = "3"

--- a/src/cli/commands/mod.rs
+++ b/src/cli/commands/mod.rs
@@ -1,6 +1,7 @@
 pub mod create;
 pub mod init;
 pub mod list;
+pub mod open;
 pub mod remove;
 pub mod switch;
 pub mod tag;

--- a/src/cli/commands/open.rs
+++ b/src/cli/commands/open.rs
@@ -13,6 +13,10 @@ pub struct OpenResult {
     pub path: String,
     /// Editor command that should be used to open the worktree.
     pub editor: String,
+    /// Repo ID (for deferred DB writes after editor launch).
+    pub repo_id: i64,
+    /// Worktree ID (for deferred DB writes after editor launch).
+    pub wt_id: i64,
 }
 
 /// Resolve the editor command from the fallback chain:
@@ -74,24 +78,29 @@ pub fn resolve(
 
     let editor = resolve_editor(config_editor)?;
 
-    // Update last_accessed timestamp
+    Ok(OpenResult {
+        name: wt.name.clone(),
+        path: wt.path.clone(),
+        editor,
+        repo_id: repo.id,
+        wt_id: wt.id,
+    })
+}
+
+/// Record a successful open: update last_accessed and insert an "opened" event.
+///
+/// Call this only after the editor has exited successfully.
+pub fn record_open(db: &Database, repo_id: i64, wt_id: i64) -> Result<()> {
     let now = crate::state::unix_epoch_secs() as i64;
     db.update_worktree(
-        wt.id,
+        wt_id,
         &crate::state::WorktreeUpdate {
             last_accessed: Some(Some(now)),
             ..Default::default()
         },
     )?;
-
-    // Record "opened" event
-    db.insert_event(repo.id, Some(wt.id), "opened", None)?;
-
-    Ok(OpenResult {
-        name: wt.name.clone(),
-        path: wt.path.clone(),
-        editor,
-    })
+    db.insert_event(repo_id, Some(wt_id), "opened", None)?;
+    Ok(())
 }
 
 #[cfg(test)]
@@ -238,7 +247,7 @@ mod tests {
     }
 
     #[test]
-    fn resolve_updates_last_accessed() {
+    fn resolve_does_not_write_db() {
         let repo_dir = tempfile::tempdir().unwrap();
         let _repo = init_repo_with_commit(repo_dir.path());
         let db = Database::open_in_memory().unwrap();
@@ -246,33 +255,34 @@ mod tests {
         let repo_path = repo_dir.path().canonicalize().unwrap();
         let repo_path_str = repo_path.to_str().unwrap();
         let db_repo = db.insert_repo("my-project", repo_path_str, Some("main")).unwrap();
+        let wt = db
+            .insert_worktree(db_repo.id, "my-feature", "my-feature", "/wt/my-feature", Some("main"))
+            .unwrap();
+
+        resolve("my-feature", repo_dir.path(), &db, Some("vim")).unwrap();
+
+        // resolve() must NOT touch the DB — no last_accessed update, no event
+        let unchanged = db.get_worktree(wt.id).unwrap().unwrap();
+        assert!(unchanged.last_accessed.is_none(), "resolve should not update last_accessed");
+        let event_count = db.count_events(wt.id, Some("opened")).unwrap();
+        assert_eq!(event_count, 0, "resolve should not insert events");
+    }
+
+    #[test]
+    fn record_open_updates_last_accessed_and_event() {
+        let db = Database::open_in_memory().unwrap();
+        let db_repo = db.insert_repo("my-project", "/tmp/fake", Some("main")).unwrap();
         let wt = db
             .insert_worktree(db_repo.id, "my-feature", "my-feature", "/wt/my-feature", Some("main"))
             .unwrap();
 
         assert!(wt.last_accessed.is_none());
 
-        resolve("my-feature", repo_dir.path(), &db, Some("vim")).unwrap();
+        record_open(&db, db_repo.id, wt.id).unwrap();
 
         let updated = db.get_worktree(wt.id).unwrap().unwrap();
         assert!(updated.last_accessed.is_some());
         assert!(updated.last_accessed.unwrap() > 0);
-    }
-
-    #[test]
-    fn resolve_records_opened_event() {
-        let repo_dir = tempfile::tempdir().unwrap();
-        let _repo = init_repo_with_commit(repo_dir.path());
-        let db = Database::open_in_memory().unwrap();
-
-        let repo_path = repo_dir.path().canonicalize().unwrap();
-        let repo_path_str = repo_path.to_str().unwrap();
-        let db_repo = db.insert_repo("my-project", repo_path_str, Some("main")).unwrap();
-        let wt = db
-            .insert_worktree(db_repo.id, "my-feature", "my-feature", "/wt/my-feature", Some("main"))
-            .unwrap();
-
-        resolve("my-feature", repo_dir.path(), &db, Some("vim")).unwrap();
 
         let event_count = db.count_events(wt.id, Some("opened")).unwrap();
         assert_eq!(event_count, 1, "exactly one 'opened' event should exist");

--- a/src/cli/commands/open.rs
+++ b/src/cli/commands/open.rs
@@ -1,0 +1,131 @@
+use std::path::Path;
+
+use anyhow::Result;
+
+use crate::state::Database;
+
+/// Result of resolving the open command (before actually launching the editor).
+#[derive(Debug)]
+pub struct OpenResult {
+    /// Sanitized name of the worktree.
+    pub name: String,
+    /// Absolute path to the worktree.
+    pub path: String,
+    /// Editor command that should be used to open the worktree.
+    pub editor: String,
+}
+
+/// Resolve the editor command from the fallback chain:
+/// config override → $EDITOR → $VISUAL → error.
+fn resolve_editor(config_editor: Option<&str>) -> Result<String> {
+    if let Some(cmd) = config_editor {
+        return Ok(cmd.to_string());
+    }
+    if let Ok(editor) = std::env::var("EDITOR") {
+        if !editor.is_empty() {
+            return Ok(editor);
+        }
+    }
+    if let Ok(visual) = std::env::var("VISUAL") {
+        if !visual.is_empty() {
+            return Ok(visual);
+        }
+    }
+    anyhow::bail!(
+        "no editor configured. Set $EDITOR, $VISUAL, or add [editor] command = \"...\" to your config"
+    )
+}
+
+/// Resolve the worktree and editor for `trench open <identifier>`.
+///
+/// Does NOT launch the editor — returns the resolved information so the
+/// caller (or tests) can decide what to do with it.
+pub fn resolve(
+    identifier: &str,
+    cwd: &Path,
+    db: &Database,
+    config_editor: Option<&str>,
+) -> Result<OpenResult> {
+    let repo_info = crate::git::discover_repo(cwd)?;
+    let repo_path_str = repo_info
+        .path
+        .to_str()
+        .ok_or_else(|| anyhow::anyhow!("repo path is not valid UTF-8"))?;
+
+    let repo = db
+        .get_repo_by_path(repo_path_str)?
+        .ok_or_else(|| anyhow::anyhow!("repository not tracked by trench"))?;
+
+    // Try the identifier as-is first, then try sanitizing it
+    let wt = match db.find_worktree_by_identifier(repo.id, identifier)? {
+        Some(wt) => wt,
+        None => {
+            let sanitized = crate::paths::sanitize_branch(identifier);
+            if sanitized != identifier {
+                db.find_worktree_by_identifier(repo.id, &sanitized)?
+            } else {
+                None
+            }
+            .ok_or_else(|| anyhow::anyhow!("worktree not found: {identifier}"))?
+        }
+    };
+
+    let editor = resolve_editor(config_editor)?;
+
+    // Update last_accessed timestamp
+    let now = crate::state::unix_epoch_secs() as i64;
+    db.update_worktree(
+        wt.id,
+        &crate::state::WorktreeUpdate {
+            last_accessed: Some(Some(now)),
+            ..Default::default()
+        },
+    )?;
+
+    // Record "opened" event
+    db.insert_event(repo.id, Some(wt.id), "opened", None)?;
+
+    Ok(OpenResult {
+        name: wt.name.clone(),
+        path: wt.path.clone(),
+        editor,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::Database;
+    use std::path::Path;
+
+    fn init_repo_with_commit(dir: &Path) -> git2::Repository {
+        let repo = git2::Repository::init(dir).expect("failed to init repo");
+        {
+            let sig = git2::Signature::now("Test", "test@test.com").unwrap();
+            let tree_id = repo.index().unwrap().write_tree().unwrap();
+            let tree = repo.find_tree(tree_id).unwrap();
+            repo.commit(Some("HEAD"), &sig, &sig, "initial commit", &tree, &[])
+                .unwrap();
+        }
+        repo
+    }
+
+    #[test]
+    fn resolve_returns_worktree_path_and_config_editor() {
+        let repo_dir = tempfile::tempdir().unwrap();
+        let _repo = init_repo_with_commit(repo_dir.path());
+        let db = Database::open_in_memory().unwrap();
+
+        let repo_path = repo_dir.path().canonicalize().unwrap();
+        let repo_path_str = repo_path.to_str().unwrap();
+        let db_repo = db.insert_repo("my-project", repo_path_str, Some("main")).unwrap();
+        db.insert_worktree(db_repo.id, "my-feature", "my-feature", "/wt/my-feature", Some("main"))
+            .unwrap();
+
+        let result = resolve("my-feature", repo_dir.path(), &db, Some("code")).unwrap();
+
+        assert_eq!(result.name, "my-feature");
+        assert_eq!(result.path, "/wt/my-feature");
+        assert_eq!(result.editor, "code");
+    }
+}

--- a/src/cli/commands/open.rs
+++ b/src/cli/commands/open.rs
@@ -18,17 +18,19 @@ pub struct OpenResult {
 /// Resolve the editor command from the fallback chain:
 /// config override → $EDITOR → $VISUAL → error.
 fn resolve_editor(config_editor: Option<&str>) -> Result<String> {
-    if let Some(cmd) = config_editor {
+    if let Some(cmd) = config_editor.map(str::trim).filter(|s| !s.is_empty()) {
         return Ok(cmd.to_string());
     }
     if let Ok(editor) = std::env::var("EDITOR") {
-        if !editor.is_empty() {
-            return Ok(editor);
+        let trimmed = editor.trim();
+        if !trimmed.is_empty() {
+            return Ok(trimmed.to_string());
         }
     }
     if let Ok(visual) = std::env::var("VISUAL") {
-        if !visual.is_empty() {
-            return Ok(visual);
+        let trimmed = visual.trim();
+        if !trimmed.is_empty() {
+            return Ok(trimmed.to_string());
         }
     }
     anyhow::bail!(
@@ -274,6 +276,79 @@ mod tests {
 
         let event_count = db.count_events(wt.id, Some("opened")).unwrap();
         assert_eq!(event_count, 1, "exactly one 'opened' event should exist");
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn resolve_editor_trims_whitespace_config() {
+        let repo_dir = tempfile::tempdir().unwrap();
+        let _repo = init_repo_with_commit(repo_dir.path());
+        let db = Database::open_in_memory().unwrap();
+
+        let repo_path = repo_dir.path().canonicalize().unwrap();
+        let repo_path_str = repo_path.to_str().unwrap();
+        let db_repo = db.insert_repo("my-project", repo_path_str, Some("main")).unwrap();
+        db.insert_worktree(db_repo.id, "my-feature", "my-feature", "/wt/my-feature", Some("main"))
+            .unwrap();
+
+        std::env::remove_var("EDITOR");
+        std::env::remove_var("VISUAL");
+
+        // Whitespace-only config should fall through → error
+        let err = resolve("my-feature", repo_dir.path(), &db, Some("   ")).unwrap_err();
+        assert!(
+            err.to_string().contains("no editor configured"),
+            "whitespace-only config should fall through, got: {}",
+            err
+        );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn resolve_editor_trims_empty_config() {
+        let repo_dir = tempfile::tempdir().unwrap();
+        let _repo = init_repo_with_commit(repo_dir.path());
+        let db = Database::open_in_memory().unwrap();
+
+        let repo_path = repo_dir.path().canonicalize().unwrap();
+        let repo_path_str = repo_path.to_str().unwrap();
+        let db_repo = db.insert_repo("my-project", repo_path_str, Some("main")).unwrap();
+        db.insert_worktree(db_repo.id, "my-feature", "my-feature", "/wt/my-feature", Some("main"))
+            .unwrap();
+
+        std::env::remove_var("EDITOR");
+        std::env::remove_var("VISUAL");
+
+        // Empty config should fall through → error
+        let err = resolve("my-feature", repo_dir.path(), &db, Some("")).unwrap_err();
+        assert!(
+            err.to_string().contains("no editor configured"),
+            "empty config should fall through, got: {}",
+            err
+        );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn resolve_editor_trims_whitespace_env() {
+        let repo_dir = tempfile::tempdir().unwrap();
+        let _repo = init_repo_with_commit(repo_dir.path());
+        let db = Database::open_in_memory().unwrap();
+
+        let repo_path = repo_dir.path().canonicalize().unwrap();
+        let repo_path_str = repo_path.to_str().unwrap();
+        let db_repo = db.insert_repo("my-project", repo_path_str, Some("main")).unwrap();
+        db.insert_worktree(db_repo.id, "my-feature", "my-feature", "/wt/my-feature", Some("main"))
+            .unwrap();
+
+        // Whitespace-only EDITOR should fall through to VISUAL
+        std::env::set_var("EDITOR", "  \t ");
+        std::env::set_var("VISUAL", "nano");
+        let result = resolve("my-feature", repo_dir.path(), &db, None).unwrap();
+        std::env::remove_var("EDITOR");
+        std::env::remove_var("VISUAL");
+
+        assert_eq!(result.editor, "nano");
     }
 
     #[test]

--- a/src/cli/commands/open.rs
+++ b/src/cli/commands/open.rs
@@ -216,4 +216,91 @@ mod tests {
 
         assert_eq!(result.editor, "code", "config should override env vars");
     }
+
+    #[test]
+    fn resolve_not_found_returns_error() {
+        let repo_dir = tempfile::tempdir().unwrap();
+        let _repo = init_repo_with_commit(repo_dir.path());
+        let db = Database::open_in_memory().unwrap();
+
+        let repo_path = repo_dir.path().canonicalize().unwrap();
+        let repo_path_str = repo_path.to_str().unwrap();
+        db.insert_repo("my-project", repo_path_str, Some("main")).unwrap();
+
+        let err = resolve("nonexistent", repo_dir.path(), &db, Some("vim")).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("not found"),
+            "error should mention 'not found', got: {msg}"
+        );
+    }
+
+    #[test]
+    fn resolve_updates_last_accessed() {
+        let repo_dir = tempfile::tempdir().unwrap();
+        let _repo = init_repo_with_commit(repo_dir.path());
+        let db = Database::open_in_memory().unwrap();
+
+        let repo_path = repo_dir.path().canonicalize().unwrap();
+        let repo_path_str = repo_path.to_str().unwrap();
+        let db_repo = db.insert_repo("my-project", repo_path_str, Some("main")).unwrap();
+        let wt = db
+            .insert_worktree(db_repo.id, "my-feature", "my-feature", "/wt/my-feature", Some("main"))
+            .unwrap();
+
+        assert!(wt.last_accessed.is_none());
+
+        resolve("my-feature", repo_dir.path(), &db, Some("vim")).unwrap();
+
+        let updated = db.get_worktree(wt.id).unwrap().unwrap();
+        assert!(updated.last_accessed.is_some());
+        assert!(updated.last_accessed.unwrap() > 0);
+    }
+
+    #[test]
+    fn resolve_records_opened_event() {
+        let repo_dir = tempfile::tempdir().unwrap();
+        let _repo = init_repo_with_commit(repo_dir.path());
+        let db = Database::open_in_memory().unwrap();
+
+        let repo_path = repo_dir.path().canonicalize().unwrap();
+        let repo_path_str = repo_path.to_str().unwrap();
+        let db_repo = db.insert_repo("my-project", repo_path_str, Some("main")).unwrap();
+        let wt = db
+            .insert_worktree(db_repo.id, "my-feature", "my-feature", "/wt/my-feature", Some("main"))
+            .unwrap();
+
+        resolve("my-feature", repo_dir.path(), &db, Some("vim")).unwrap();
+
+        let event_count = db.count_events(wt.id, Some("opened")).unwrap();
+        assert_eq!(event_count, 1, "exactly one 'opened' event should exist");
+    }
+
+    #[test]
+    fn resolve_by_branch_with_slash() {
+        let repo_dir = tempfile::tempdir().unwrap();
+        let _repo = init_repo_with_commit(repo_dir.path());
+        let db = Database::open_in_memory().unwrap();
+
+        let repo_path = repo_dir.path().canonicalize().unwrap();
+        let repo_path_str = repo_path.to_str().unwrap();
+        let db_repo = db.insert_repo("my-project", repo_path_str, Some("main")).unwrap();
+        db.insert_worktree(
+            db_repo.id,
+            "feature-auth",
+            "feature/auth",
+            "/wt/feature-auth",
+            Some("main"),
+        )
+        .unwrap();
+
+        // Resolve using original branch name (with slash)
+        let result = resolve("feature/auth", repo_dir.path(), &db, Some("vim")).unwrap();
+        assert_eq!(result.name, "feature-auth");
+        assert_eq!(result.path, "/wt/feature-auth");
+
+        // Resolve using sanitized name
+        let result = resolve("feature-auth", repo_dir.path(), &db, Some("vim")).unwrap();
+        assert_eq!(result.name, "feature-auth");
+    }
 }

--- a/src/cli/commands/open.rs
+++ b/src/cli/commands/open.rs
@@ -128,4 +128,92 @@ mod tests {
         assert_eq!(result.path, "/wt/my-feature");
         assert_eq!(result.editor, "code");
     }
+
+    #[test]
+    #[serial_test::serial]
+    fn resolve_uses_editor_env_when_no_config() {
+        let repo_dir = tempfile::tempdir().unwrap();
+        let _repo = init_repo_with_commit(repo_dir.path());
+        let db = Database::open_in_memory().unwrap();
+
+        let repo_path = repo_dir.path().canonicalize().unwrap();
+        let repo_path_str = repo_path.to_str().unwrap();
+        let db_repo = db.insert_repo("my-project", repo_path_str, Some("main")).unwrap();
+        db.insert_worktree(db_repo.id, "my-feature", "my-feature", "/wt/my-feature", Some("main"))
+            .unwrap();
+
+        std::env::set_var("EDITOR", "vim");
+        std::env::remove_var("VISUAL");
+        let result = resolve("my-feature", repo_dir.path(), &db, None).unwrap();
+        std::env::remove_var("EDITOR");
+
+        assert_eq!(result.editor, "vim");
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn resolve_uses_visual_env_when_no_editor() {
+        let repo_dir = tempfile::tempdir().unwrap();
+        let _repo = init_repo_with_commit(repo_dir.path());
+        let db = Database::open_in_memory().unwrap();
+
+        let repo_path = repo_dir.path().canonicalize().unwrap();
+        let repo_path_str = repo_path.to_str().unwrap();
+        let db_repo = db.insert_repo("my-project", repo_path_str, Some("main")).unwrap();
+        db.insert_worktree(db_repo.id, "my-feature", "my-feature", "/wt/my-feature", Some("main"))
+            .unwrap();
+
+        std::env::remove_var("EDITOR");
+        std::env::set_var("VISUAL", "nano");
+        let result = resolve("my-feature", repo_dir.path(), &db, None).unwrap();
+        std::env::remove_var("VISUAL");
+
+        assert_eq!(result.editor, "nano");
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn resolve_errors_when_no_editor_available() {
+        let repo_dir = tempfile::tempdir().unwrap();
+        let _repo = init_repo_with_commit(repo_dir.path());
+        let db = Database::open_in_memory().unwrap();
+
+        let repo_path = repo_dir.path().canonicalize().unwrap();
+        let repo_path_str = repo_path.to_str().unwrap();
+        let db_repo = db.insert_repo("my-project", repo_path_str, Some("main")).unwrap();
+        db.insert_worktree(db_repo.id, "my-feature", "my-feature", "/wt/my-feature", Some("main"))
+            .unwrap();
+
+        std::env::remove_var("EDITOR");
+        std::env::remove_var("VISUAL");
+        let err = resolve("my-feature", repo_dir.path(), &db, None).unwrap_err();
+        let msg = err.to_string();
+
+        assert!(
+            msg.contains("no editor configured"),
+            "error should mention 'no editor configured', got: {msg}"
+        );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn config_editor_overrides_env_vars() {
+        let repo_dir = tempfile::tempdir().unwrap();
+        let _repo = init_repo_with_commit(repo_dir.path());
+        let db = Database::open_in_memory().unwrap();
+
+        let repo_path = repo_dir.path().canonicalize().unwrap();
+        let repo_path_str = repo_path.to_str().unwrap();
+        let db_repo = db.insert_repo("my-project", repo_path_str, Some("main")).unwrap();
+        db.insert_worktree(db_repo.id, "my-feature", "my-feature", "/wt/my-feature", Some("main"))
+            .unwrap();
+
+        std::env::set_var("EDITOR", "vim");
+        std::env::set_var("VISUAL", "nano");
+        let result = resolve("my-feature", repo_dir.path(), &db, Some("code")).unwrap();
+        std::env::remove_var("EDITOR");
+        std::env::remove_var("VISUAL");
+
+        assert_eq!(result.editor, "code", "config should override env vars");
+    }
 }

--- a/src/cli/commands/open.rs
+++ b/src/cli/commands/open.rs
@@ -107,7 +107,34 @@ pub fn record_open(db: &Database, repo_id: i64, wt_id: i64) -> Result<()> {
 mod tests {
     use super::*;
     use crate::state::Database;
+    use std::ffi::OsString;
     use std::path::Path;
+
+    /// RAII guard that saves the current value of an env var and restores it on drop.
+    struct EnvGuard {
+        key: &'static str,
+        prev: Option<OsString>,
+    }
+
+    impl EnvGuard {
+        fn set(key: &'static str, value: Option<&str>) -> Self {
+            let prev = std::env::var_os(key);
+            match value {
+                Some(v) => std::env::set_var(key, v),
+                None => std::env::remove_var(key),
+            }
+            Self { key, prev }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match &self.prev {
+                Some(v) => std::env::set_var(self.key, v),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
 
     fn init_repo_with_commit(dir: &Path) -> git2::Repository {
         let repo = git2::Repository::init(dir).expect("failed to init repo");
@@ -153,10 +180,9 @@ mod tests {
         db.insert_worktree(db_repo.id, "my-feature", "my-feature", "/wt/my-feature", Some("main"))
             .unwrap();
 
-        std::env::set_var("EDITOR", "vim");
-        std::env::remove_var("VISUAL");
+        let _editor = EnvGuard::set("EDITOR", Some("vim"));
+        let _visual = EnvGuard::set("VISUAL", None);
         let result = resolve("my-feature", repo_dir.path(), &db, None).unwrap();
-        std::env::remove_var("EDITOR");
 
         assert_eq!(result.editor, "vim");
     }
@@ -174,10 +200,9 @@ mod tests {
         db.insert_worktree(db_repo.id, "my-feature", "my-feature", "/wt/my-feature", Some("main"))
             .unwrap();
 
-        std::env::remove_var("EDITOR");
-        std::env::set_var("VISUAL", "nano");
+        let _editor = EnvGuard::set("EDITOR", None);
+        let _visual = EnvGuard::set("VISUAL", Some("nano"));
         let result = resolve("my-feature", repo_dir.path(), &db, None).unwrap();
-        std::env::remove_var("VISUAL");
 
         assert_eq!(result.editor, "nano");
     }
@@ -195,8 +220,8 @@ mod tests {
         db.insert_worktree(db_repo.id, "my-feature", "my-feature", "/wt/my-feature", Some("main"))
             .unwrap();
 
-        std::env::remove_var("EDITOR");
-        std::env::remove_var("VISUAL");
+        let _editor = EnvGuard::set("EDITOR", None);
+        let _visual = EnvGuard::set("VISUAL", None);
         let err = resolve("my-feature", repo_dir.path(), &db, None).unwrap_err();
         let msg = err.to_string();
 
@@ -219,11 +244,9 @@ mod tests {
         db.insert_worktree(db_repo.id, "my-feature", "my-feature", "/wt/my-feature", Some("main"))
             .unwrap();
 
-        std::env::set_var("EDITOR", "vim");
-        std::env::set_var("VISUAL", "nano");
+        let _editor = EnvGuard::set("EDITOR", Some("vim"));
+        let _visual = EnvGuard::set("VISUAL", Some("nano"));
         let result = resolve("my-feature", repo_dir.path(), &db, Some("code")).unwrap();
-        std::env::remove_var("EDITOR");
-        std::env::remove_var("VISUAL");
 
         assert_eq!(result.editor, "code", "config should override env vars");
     }
@@ -301,8 +324,8 @@ mod tests {
         db.insert_worktree(db_repo.id, "my-feature", "my-feature", "/wt/my-feature", Some("main"))
             .unwrap();
 
-        std::env::remove_var("EDITOR");
-        std::env::remove_var("VISUAL");
+        let _editor = EnvGuard::set("EDITOR", None);
+        let _visual = EnvGuard::set("VISUAL", None);
 
         // Whitespace-only config should fall through → error
         let err = resolve("my-feature", repo_dir.path(), &db, Some("   ")).unwrap_err();
@@ -326,8 +349,8 @@ mod tests {
         db.insert_worktree(db_repo.id, "my-feature", "my-feature", "/wt/my-feature", Some("main"))
             .unwrap();
 
-        std::env::remove_var("EDITOR");
-        std::env::remove_var("VISUAL");
+        let _editor = EnvGuard::set("EDITOR", None);
+        let _visual = EnvGuard::set("VISUAL", None);
 
         // Empty config should fall through → error
         let err = resolve("my-feature", repo_dir.path(), &db, Some("")).unwrap_err();
@@ -352,11 +375,9 @@ mod tests {
             .unwrap();
 
         // Whitespace-only EDITOR should fall through to VISUAL
-        std::env::set_var("EDITOR", "  \t ");
-        std::env::set_var("VISUAL", "nano");
+        let _editor = EnvGuard::set("EDITOR", Some("  \t "));
+        let _visual = EnvGuard::set("VISUAL", Some("nano"));
         let result = resolve("my-feature", repo_dir.path(), &db, None).unwrap();
-        std::env::remove_var("EDITOR");
-        std::env::remove_var("VISUAL");
 
         assert_eq!(result.editor, "nano");
     }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -49,6 +49,7 @@ pub struct HooksConfig {
 pub struct GlobalConfig {
     pub ui: Option<UiConfig>,
     pub git: Option<GitConfig>,
+    pub editor: Option<EditorConfig>,
     pub worktrees: Option<WorktreesConfig>,
     pub hooks: Option<HooksConfig>,
 }
@@ -58,6 +59,7 @@ pub struct GlobalConfig {
 pub struct ProjectConfig {
     pub ui: Option<UiConfig>,
     pub git: Option<GitConfig>,
+    pub editor: Option<EditorConfig>,
     pub worktrees: Option<WorktreesConfig>,
     pub hooks: Option<HooksConfig>,
 }
@@ -75,6 +77,11 @@ pub struct GitConfig {
     pub default_base: Option<String>,
     pub auto_prune: Option<bool>,
     pub fetch_on_open: Option<bool>,
+}
+
+#[derive(Debug, Default, Deserialize, PartialEq)]
+pub struct EditorConfig {
+    pub command: Option<String>,
 }
 
 #[derive(Debug, Default, Deserialize, PartialEq)]
@@ -126,6 +133,7 @@ pub struct CliConfigOverrides {
 pub struct ResolvedConfig {
     pub ui: ResolvedUiConfig,
     pub git: ResolvedGitConfig,
+    pub editor_command: Option<String>,
     pub worktrees: ResolvedWorktreesConfig,
     pub hooks: Option<HooksConfig>,
 }
@@ -202,6 +210,13 @@ pub fn resolve_config(
     let g_git = global.git.as_ref();
     let g_wt = global.worktrees.as_ref();
 
+    // Editor: project > global (simple first-wins)
+    let p_editor = project.and_then(|p| p.editor.as_ref());
+    let g_editor = global.editor.as_ref();
+    let editor_command = p_editor
+        .and_then(|e| e.command.clone())
+        .or_else(|| g_editor.and_then(|e| e.command.clone()));
+
     // Hooks: project replaces global entirely (FR-2)
     let p_hooks = project.and_then(|p| p.hooks.as_ref());
     let hooks = p_hooks.or(global.hooks.as_ref()).cloned();
@@ -240,6 +255,7 @@ pub fn resolve_config(
                 .or_else(|| g_git.and_then(|g| g.fetch_on_open))
                 .unwrap_or(defaults_git.fetch_on_open),
         },
+        editor_command,
         worktrees: ResolvedWorktreesConfig {
             root: cli
                 .and_then(|c| c.worktree_root.clone())
@@ -660,7 +676,7 @@ run = ["bun install"]
                 root: Some("custom/{{ repo }}/{{ branch }}".to_string()),
                 scan: Some(vec!["/extra".to_string()]),
             }),
-            hooks: None,
+            ..GlobalConfig::default()
         };
 
         let resolved = resolve_config(None, None, &global);
@@ -696,8 +712,7 @@ run = ["bun install"]
                 auto_prune: Some(true),
                 fetch_on_open: None,
             }),
-            worktrees: None,
-            hooks: None,
+            ..GlobalConfig::default()
         };
 
         let project = ProjectConfig {
@@ -716,7 +731,7 @@ run = ["bun install"]
                 root: Some("proj/{{ repo }}/{{ branch }}".to_string()),
                 scan: None,
             }),
-            hooks: None,
+            ..ProjectConfig::default()
         };
 
         let resolved = resolve_config(None, Some(&project), &global);
@@ -1055,6 +1070,61 @@ run = ["make setup"]
             Some("custom/{{ repo }}/{{ branch | sanitize }}")
         );
         assert!(config.hooks.unwrap().post_create.is_some());
+    }
+
+    #[test]
+    fn editor_config_deserializes_from_global() {
+        let dir = TempDir::new().unwrap();
+        let path = write_config(
+            &dir,
+            r#"
+[editor]
+command = "code"
+"#,
+        );
+
+        let config = load_global_config_from(&path).unwrap();
+        let editor = config.editor.expect("editor section should be present");
+        assert_eq!(editor.command.as_deref(), Some("code"));
+    }
+
+    #[test]
+    fn editor_config_resolves_from_project_over_global() {
+        let global = GlobalConfig {
+            editor: Some(EditorConfig {
+                command: Some("vim".to_string()),
+            }),
+            ..GlobalConfig::default()
+        };
+
+        let project = ProjectConfig {
+            editor: Some(EditorConfig {
+                command: Some("code".to_string()),
+            }),
+            ..ProjectConfig::default()
+        };
+
+        let resolved = resolve_config(None, Some(&project), &global);
+        assert_eq!(resolved.editor_command.as_deref(), Some("code"));
+    }
+
+    #[test]
+    fn editor_config_falls_through_to_global() {
+        let global = GlobalConfig {
+            editor: Some(EditorConfig {
+                command: Some("vim".to_string()),
+            }),
+            ..GlobalConfig::default()
+        };
+
+        let resolved = resolve_config(None, None, &global);
+        assert_eq!(resolved.editor_command.as_deref(), Some("vim"));
+    }
+
+    #[test]
+    fn editor_config_none_when_not_set() {
+        let resolved = resolve_config(None, None, &GlobalConfig::default());
+        assert!(resolved.editor_command.is_none());
     }
 
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -145,6 +145,7 @@ fn main() -> anyhow::Result<()> {
         Some(Commands::Remove { branch, force, prune }) => run_remove(&branch, force, prune),
         Some(Commands::Switch { branch, print_path }) => run_switch(&branch, print_path),
         Some(Commands::Tag { branch, tags }) => run_tag(&branch, &tags),
+        Some(Commands::Open { branch }) => run_open(&branch),
         Some(Commands::List { tag }) => run_list(tag.as_deref(), json, porcelain),
         Some(Commands::Init { force }) => run_init(force),
         Some(_) => {
@@ -294,6 +295,44 @@ fn run_switch(identifier: &str, print_path: bool) -> anyhow::Result<()> {
                 println!("{}", result.path);
             } else {
                 println!("Switched to worktree '{}' at {}", result.name, result.path);
+            }
+            Ok(())
+        }
+        Err(e) => {
+            let msg = e.to_string();
+            if msg.contains("not found") || msg.contains("not tracked") {
+                eprintln!("error: {e}");
+                std::process::exit(2);
+            }
+            Err(e)
+        }
+    }
+}
+
+fn run_open(identifier: &str) -> anyhow::Result<()> {
+    let cwd = std::env::current_dir().context("failed to determine current directory")?;
+    let db_path = paths::data_dir()?.join("trench.db");
+    let db = state::Database::open(&db_path)?;
+
+    let repo_info = git::discover_repo(&cwd)?;
+    let project_config = config::load_project_config(&repo_info.path)?;
+    let global_config = config::load_global_config()?;
+    let resolved = config::resolve_config(None, project_config.as_ref(), &global_config);
+
+    match cli::commands::open::resolve(
+        identifier,
+        &cwd,
+        &db,
+        resolved.editor_command.as_deref(),
+    ) {
+        Ok(result) => {
+            let status = std::process::Command::new(&result.editor)
+                .arg(&result.path)
+                .status()
+                .with_context(|| format!("failed to launch editor '{}'", result.editor))?;
+
+            if !status.success() {
+                std::process::exit(status.code().unwrap_or(1));
             }
             Ok(())
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -334,6 +334,10 @@ fn run_open(identifier: &str) -> anyhow::Result<()> {
             if !status.success() {
                 std::process::exit(status.code().unwrap_or(1));
             }
+
+            // Record DB side-effects only after a successful launch
+            cli::commands::open::record_open(&db, result.repo_id, result.wt_id)?;
+
             Ok(())
         }
         Err(e) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -326,7 +326,14 @@ fn run_open(identifier: &str) -> anyhow::Result<()> {
         resolved.editor_command.as_deref(),
     ) {
         Ok(result) => {
-            let status = std::process::Command::new(&result.editor)
+            let parts = shell_words::split(&result.editor)
+                .with_context(|| format!("invalid editor command: '{}'", result.editor))?;
+            let (program, args) = parts
+                .split_first()
+                .ok_or_else(|| anyhow::anyhow!("editor command is empty after parsing"))?;
+
+            let status = std::process::Command::new(program)
+                .args(args)
                 .arg(&result.path)
                 .status()
                 .with_context(|| format!("failed to launch editor '{}'", result.editor))?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -88,7 +88,10 @@ enum Commands {
         tags: Vec<String>,
     },
     /// Open a worktree in $EDITOR
-    Open,
+    Open {
+        /// Branch name or sanitized name of the worktree
+        branch: String,
+    },
     /// List all worktrees
     List {
         /// Filter worktrees by tag
@@ -424,9 +427,9 @@ mod tests {
 
     #[test]
     fn all_subcommands_are_accepted() {
-        // switch and remove require a branch argument, so test them separately
+        // open, switch, and remove require a branch argument, so test them separately
         let subcommands = [
-            "open", "list", "status", "sync", "log", "init",
+            "list", "status", "sync", "log", "init",
         ];
         for sub in subcommands {
             let result = Cli::try_parse_from(["trench", sub]);
@@ -437,11 +440,31 @@ mod tests {
                 result.unwrap_err()
             );
         }
-        // remove and switch need a branch arg
+        // open, remove, and switch need a branch arg
+        let result = Cli::try_parse_from(["trench", "open", "my-feature"]);
+        assert!(result.is_ok(), "open with branch should be accepted");
         let result = Cli::try_parse_from(["trench", "remove", "my-feature"]);
         assert!(result.is_ok(), "remove with branch should be accepted");
         let result = Cli::try_parse_from(["trench", "switch", "my-feature"]);
         assert!(result.is_ok(), "switch with branch should be accepted");
+    }
+
+    #[test]
+    fn open_subcommand_requires_branch() {
+        let result = Cli::try_parse_from(["trench", "open"]);
+        assert!(result.is_err(), "open without branch should fail");
+    }
+
+    #[test]
+    fn open_subcommand_accepts_branch() {
+        let cli = Cli::try_parse_from(["trench", "open", "my-feature"])
+            .expect("open with branch should succeed");
+        match cli.command {
+            Some(Commands::Open { branch }) => {
+                assert_eq!(branch, "my-feature");
+            }
+            _ => panic!("expected Commands::Open"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
Closes #28

## Summary
Implement `trench open <branch-or-name>` which resolves a worktree path from the DB, determines the editor via a fallback chain (config `[editor] command` → `$EDITOR` → `$VISUAL` → error), updates `last_accessed`, records an "opened" event, and spawns the editor process with the worktree path as argument.

## User Stories Addressed
- US-9: Quick navigation to worktrees (open worktree directory in editor)

## Automated Testing
- Total tests added: 15
- Tests passing: 15
- Tests failing: 0
- `cargo clippy`: pass
- `cargo test`: pass (294 passed; 2 pre-existing failures in `git::tests::delete_remote_branch*` unrelated to this PR)

## UAT Checklist
- [ ] `trench create my-feature` → create a worktree, then `trench open my-feature` → editor opens at worktree path
- [ ] Set `[editor] command = "code"` in `~/.config/trench/config.toml` → `trench open my-feature` opens VS Code
- [ ] Unset `$EDITOR` and `$VISUAL`, remove config → `trench open my-feature` shows helpful error about configuring an editor
- [ ] `trench open nonexistent-branch` → error with exit code 2
- [ ] `trench open feature/auth` → resolves sanitized name `feature-auth` correctly
- [ ] After `trench open my-feature`, verify `last_accessed` is updated (visible in `trench list --json`)

## Known Issues
- 2 pre-existing test failures in `git::tests::create_worktree_succeeds_after_remote_branch_deleted` and `git::tests::delete_remote_branch_deletes_branch_on_remote` — these fail on the base branch as well and are unrelated to this PR (likely a local git config issue with default branch naming)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New "open" command to launch a worktree by branch/name (now requires a branch argument).
  * Editor configurable at project and global levels; resolved per-project then global then environment.
  * Opening a worktree records last-accessed info and logs an "opened" event.

* **Tests**
  * Expanded tests for editor resolution, open workflow, name resolution, and event/last-access behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->