### PR TITLE
fix(shell-init): handle empty path and DRY syntax tests

### DIFF
--- a/src/cli/commands/shell_init.rs
+++ b/src/cli/commands/shell_init.rs
@@ -21,11 +21,14 @@ fn generate_posix() -> &'static str {
         local dir
         dir="$(command trench switch --print-path "$@")"
         local exit_code=$?
-        if [ "$exit_code" -eq 0 ] && [ -n "$dir" ]; then
-            cd "$dir" || return 1
-        else
+        if [ "$exit_code" -ne 0 ]; then
             return "$exit_code"
         fi
+        if [ -z "$dir" ]; then
+            echo "trench: switch returned empty path" >&2
+            return 1
+        fi
+        cd -- "$dir" || return 1
     else
         command trench "$@"
     fi
@@ -39,11 +42,14 @@ fn generate_fish() -> &'static str {
         set -l rest $argv[2..-1]
         set -l dir (command trench switch --print-path $rest)
         set -l exit_code $status
-        if test $exit_code -eq 0 -a -n "$dir"
-            cd $dir
-        else
+        if test $exit_code -ne 0
             return $exit_code
         end
+        if test -z "$dir"
+            echo "trench: switch returned empty path" >&2
+            return 1
+        end
+        cd -- "$dir"
     else
         command trench $argv
     end
@@ -157,6 +163,24 @@ mod tests {
         let fish = generate(ShellType::Fish);
         let bash = generate(ShellType::Bash);
         assert_ne!(fish, bash, "fish syntax differs from bash/zsh");
+    }
+
+    #[test]
+    fn posix_output_reports_error_on_empty_path() {
+        let output = generate(ShellType::Bash);
+        assert!(
+            output.contains("switch returned empty path"),
+            "posix output should report error when switch returns empty path"
+        );
+    }
+
+    #[test]
+    fn fish_output_reports_error_on_empty_path() {
+        let output = generate(ShellType::Fish);
+        assert!(
+            output.contains("switch returned empty path"),
+            "fish output should report error when switch returns empty path"
+        );
     }
 
     #[test]

--- a/src/cli/commands/shell_init.rs
+++ b/src/cli/commands/shell_init.rs
@@ -183,71 +183,38 @@ mod tests {
         );
     }
 
-    #[test]
-    fn bash_output_is_valid_shell_syntax() {
-        let result = std::process::Command::new("bash")
-            .arg("-n")
-            .arg("-c")
-            .arg(&generate(ShellType::Bash))
+    fn assert_valid_shell_syntax(shell: &str, args: &[&str], script: &str) {
+        let result = std::process::Command::new(shell)
+            .args(args)
+            .arg(script)
             .output();
         match result {
             Ok(output) => {
                 assert!(
                     output.status.success(),
-                    "bash syntax check failed: {}",
+                    "{shell} syntax check failed: {}",
                     String::from_utf8_lossy(&output.stderr)
                 );
             }
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-                eprintln!("bash not found, skipping syntax check");
+                eprintln!("{shell} not found, skipping syntax check");
             }
-            Err(e) => panic!("failed to run bash: {e}"),
+            Err(e) => panic!("failed to run {shell}: {e}"),
         }
+    }
+
+    #[test]
+    fn bash_output_is_valid_shell_syntax() {
+        assert_valid_shell_syntax("bash", &["-n", "-c"], generate(ShellType::Bash));
     }
 
     #[test]
     fn zsh_output_is_valid_shell_syntax() {
-        let result = std::process::Command::new("zsh")
-            .arg("-n")
-            .arg("-c")
-            .arg(&generate(ShellType::Zsh))
-            .output();
-        match result {
-            Ok(output) => {
-                assert!(
-                    output.status.success(),
-                    "zsh syntax check failed: {}",
-                    String::from_utf8_lossy(&output.stderr)
-                );
-            }
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-                eprintln!("zsh not found, skipping syntax check");
-            }
-            Err(e) => panic!("failed to run zsh: {e}"),
-        }
+        assert_valid_shell_syntax("zsh", &["-n", "-c"], generate(ShellType::Zsh));
     }
 
     #[test]
     fn fish_output_is_valid_shell_syntax() {
-        // fish --no-execute parses without executing
-        let result = std::process::Command::new("fish")
-            .arg("--no-execute")
-            .arg("-c")
-            .arg(&generate(ShellType::Fish))
-            .output();
-        match result {
-            Ok(output) => {
-                assert!(
-                    output.status.success(),
-                    "fish syntax check failed: {}",
-                    String::from_utf8_lossy(&output.stderr)
-                );
-            }
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-                // fish not installed — skip gracefully
-                eprintln!("fish not found, skipping syntax check");
-            }
-            Err(e) => panic!("failed to run fish: {e}"),
-        }
+        assert_valid_shell_syntax("fish", &["--no-execute", "-c"], generate(ShellType::Fish));
     }
 }

--- a/src/cli/commands/shell_init.rs
+++ b/src/cli/commands/shell_init.rs
@@ -169,8 +169,8 @@ mod tests {
     fn posix_output_reports_error_on_empty_path() {
         let output = generate(ShellType::Bash);
         assert!(
-            output.contains("switch returned empty path"),
-            "posix output should report error when switch returns empty path"
+            output.contains("switch returned empty path\" >&2\n            return 1"),
+            "posix output should report error and return non-zero when switch returns empty path"
         );
     }
 
@@ -178,8 +178,8 @@ mod tests {
     fn fish_output_reports_error_on_empty_path() {
         let output = generate(ShellType::Fish);
         assert!(
-            output.contains("switch returned empty path"),
-            "fish output should report error when switch returns empty path"
+            output.contains("switch returned empty path\" >&2\n            return 1"),
+            "fish output should report error and return non-zero when switch returns empty path"
         );
     }
 


### PR DESCRIPTION
## Summary
- Treat empty `--print-path` output as explicit failure (error message + return 1) instead of silently succeeding without `cd`
- Use `cd --` to safely handle paths starting with a hyphen
- Extract `assert_valid_shell_syntax` helper to DRY the three shell syntax tests

Addresses review feedback from #88 ([review](https://github.com/sadiksaifi/trench/pull/88#pullrequestreview-3878895584)).

## Test plan
- [x] `cargo test commands::shell_init` — all 17 tests pass
- [x] `cargo clippy` — no errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling in shell initialization with explicit error messaging when path operations fail or return empty results.

* **Tests**
  * Expanded test coverage for edge cases in shell initialization and added validation tests across supported shells.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->