### PR TITLE
feat(create): --json structured output for trench create

### DIFF
--- a/src/cli/commands/create.rs
+++ b/src/cli/commands/create.rs
@@ -86,25 +86,14 @@ pub struct CreateJsonOutput {
 
 /// Hook execution status included in JSON output.
 #[derive(Debug, serde::Serialize)]
-pub struct HooksStatus {
-    pub status: String,
-}
-
-impl HooksStatus {
+#[serde(tag = "status", rename_all = "lowercase")]
+pub enum HooksStatus {
     /// No hooks were configured for this operation.
-    pub fn none() -> Self {
-        Self { status: "none".to_string() }
-    }
-
+    None,
     /// Hooks were configured and executed successfully.
-    pub fn ran() -> Self {
-        Self { status: "ran".to_string() }
-    }
-
+    Ran,
     /// Hooks were configured but skipped (e.g. `--no-hooks`).
-    pub fn skipped() -> Self {
-        Self { status: "skipped".to_string() }
-    }
+    Skipped,
 }
 
 fn format_hook_def(f: &mut fmt::Formatter<'_>, hook: &crate::config::HookDef) -> fmt::Result {
@@ -840,7 +829,7 @@ mod tests {
             base_branch: "main".to_string(),
         };
 
-        let hooks = HooksStatus::none();
+        let hooks = HooksStatus::None;
         let json_output = result.to_json_output(hooks);
         let json_str = format_json_value(&json_output).expect("should serialize to JSON");
         let parsed: serde_json::Value = serde_json::from_str(&json_str).expect("should be valid JSON");
@@ -872,7 +861,7 @@ mod tests {
         )
         .expect("create should succeed");
 
-        let json_output = result.to_json_output(HooksStatus::none());
+        let json_output = result.to_json_output(HooksStatus::None);
         let json_str = format_json_value(&json_output).expect("should serialize");
         let parsed: serde_json::Value = serde_json::from_str(&json_str).expect("valid JSON");
 

--- a/src/cli/commands/create.rs
+++ b/src/cli/commands/create.rs
@@ -61,6 +61,52 @@ pub struct CreateResult {
     pub base_branch: String,
 }
 
+impl CreateResult {
+    /// Convert to a JSON-serializable output struct.
+    pub fn to_json_output(self, hooks: HooksStatus) -> CreateJsonOutput {
+        CreateJsonOutput {
+            worktree: self.name,
+            branch: self.branch,
+            path: self.path.to_string_lossy().to_string(),
+            base_branch: self.base_branch,
+            hooks,
+        }
+    }
+}
+
+/// JSON-serializable output for `trench create --json` (FR-35, US-4).
+#[derive(Debug, serde::Serialize)]
+pub struct CreateJsonOutput {
+    pub worktree: String,
+    pub branch: String,
+    pub path: String,
+    pub base_branch: String,
+    pub hooks: HooksStatus,
+}
+
+/// Hook execution status included in JSON output.
+#[derive(Debug, serde::Serialize)]
+pub struct HooksStatus {
+    pub status: String,
+}
+
+impl HooksStatus {
+    /// No hooks were configured for this operation.
+    pub fn none() -> Self {
+        Self { status: "none".to_string() }
+    }
+
+    /// Hooks were configured and executed successfully.
+    pub fn ran() -> Self {
+        Self { status: "ran".to_string() }
+    }
+
+    /// Hooks were configured but skipped (e.g. `--no-hooks`).
+    pub fn skipped() -> Self {
+        Self { status: "skipped".to_string() }
+    }
+}
+
 fn format_hook_def(f: &mut fmt::Formatter<'_>, hook: &crate::config::HookDef) -> fmt::Result {
     if let Some(copy) = &hook.copy {
         writeln!(f, "      copy: {}", copy.join(", "))?;
@@ -781,6 +827,29 @@ mod tests {
         assert_eq!(result.name, "my-feature");
         assert!(result.path.exists(), "worktree path should exist on disk");
         assert!(!result.base_branch.is_empty(), "base_branch should be set");
+    }
+
+    #[test]
+    fn create_result_serializes_to_json_with_all_required_fields() {
+        use crate::output::json::format_json_value;
+
+        let result = CreateResult {
+            name: "my-feature".to_string(),
+            branch: "my-feature".to_string(),
+            path: std::path::PathBuf::from("/home/.worktrees/repo/my-feature"),
+            base_branch: "main".to_string(),
+        };
+
+        let hooks = HooksStatus::none();
+        let json_output = result.to_json_output(hooks);
+        let json_str = format_json_value(&json_output).expect("should serialize to JSON");
+        let parsed: serde_json::Value = serde_json::from_str(&json_str).expect("should be valid JSON");
+
+        assert_eq!(parsed["worktree"], "my-feature");
+        assert_eq!(parsed["branch"], "my-feature");
+        assert_eq!(parsed["path"], "/home/.worktrees/repo/my-feature");
+        assert_eq!(parsed["base_branch"], "main");
+        assert_eq!(parsed["hooks"]["status"], "none");
     }
 
     #[test]

--- a/src/cli/commands/create.rs
+++ b/src/cli/commands/create.rs
@@ -853,6 +853,43 @@ mod tests {
     }
 
     #[test]
+    fn integration_create_json_output_matches_real_worktree() {
+        use crate::output::json::format_json_value;
+
+        let repo_dir = tempfile::tempdir().unwrap();
+        let _repo = init_repo_with_commit(repo_dir.path());
+        let wt_root = tempfile::tempdir().unwrap();
+        let db_dir = tempfile::tempdir().unwrap();
+        let db = Database::open(&db_dir.path().join("test.db")).unwrap();
+
+        let result = execute(
+            "json-test",
+            None,
+            repo_dir.path(),
+            wt_root.path(),
+            paths::DEFAULT_WORKTREE_TEMPLATE,
+            &db,
+        )
+        .expect("create should succeed");
+
+        let json_output = result.to_json_output(HooksStatus::none());
+        let json_str = format_json_value(&json_output).expect("should serialize");
+        let parsed: serde_json::Value = serde_json::from_str(&json_str).expect("valid JSON");
+
+        // worktree name is the sanitized branch name
+        assert_eq!(parsed["worktree"], "json-test");
+        // branch is the original branch name
+        assert_eq!(parsed["branch"], "json-test");
+        // path is a real path on disk that exists
+        let path_str = parsed["path"].as_str().unwrap();
+        assert!(std::path::Path::new(path_str).exists(), "path should exist on disk");
+        // base_branch is set to the repo's default
+        assert!(!parsed["base_branch"].as_str().unwrap().is_empty());
+        // hooks status reflects no hooks configured
+        assert_eq!(parsed["hooks"]["status"], "none");
+    }
+
+    #[test]
     fn dry_run_with_from_shows_custom_base() {
         let repo_dir = tempfile::tempdir().unwrap();
         let repo = init_repo_with_commit(repo_dir.path());

--- a/src/cli/commands/create.rs
+++ b/src/cli/commands/create.rs
@@ -48,6 +48,19 @@ impl fmt::Display for DryRunPlan {
     }
 }
 
+/// Result of a successful `trench create` operation.
+#[derive(Debug)]
+pub struct CreateResult {
+    /// Sanitized worktree name (e.g. `feature-auth` for branch `feature/auth`).
+    pub name: String,
+    /// Original branch name as provided by the user.
+    pub branch: String,
+    /// Absolute path to the created worktree on disk.
+    pub path: PathBuf,
+    /// Base branch the worktree was created from.
+    pub base_branch: String,
+}
+
 fn format_hook_def(f: &mut fmt::Formatter<'_>, hook: &crate::config::HookDef) -> fmt::Result {
     if let Some(copy) = &hook.copy {
         writeln!(f, "      copy: {}", copy.join(", "))?;
@@ -107,7 +120,7 @@ pub fn execute(
     worktree_root: &Path,
     template: &str,
     db: &Database,
-) -> Result<PathBuf> {
+) -> Result<CreateResult> {
     let repo_info = git::discover_repo(cwd)?;
     let relative_path = paths::render_worktree_path(template, &repo_info.name, branch)?;
     let worktree_path = worktree_root.join(relative_path);
@@ -132,7 +145,12 @@ pub fn execute(
 
     db.insert_event(repo.id, Some(wt.id), "created", None)?;
 
-    Ok(worktree_path)
+    Ok(CreateResult {
+        name: sanitized_name,
+        branch: branch.to_string(),
+        path: worktree_path,
+        base_branch: base.to_string(),
+    })
 }
 
 #[cfg(test)]
@@ -183,7 +201,7 @@ mod tests {
         let db_dir = tempfile::tempdir().unwrap();
         let db = Database::open(&db_dir.path().join("test.db")).unwrap();
 
-        let path = execute(
+        let result = execute(
             "my-feature",
             None,
             repo_dir.path(),
@@ -192,6 +210,8 @@ mod tests {
             &db,
         )
         .expect("create should succeed");
+
+        let path = &result.path;
 
         // Worktree exists on disk
         assert!(path.exists(), "worktree directory should exist on disk");
@@ -208,7 +228,7 @@ mod tests {
             .unwrap()
             .to_string();
         let expected_path = wt_root.path().join(&repo_name).join("my-feature");
-        assert_eq!(path, expected_path);
+        assert_eq!(*path, expected_path);
 
         // DB: repo record exists
         let repo_path_str = repo_dir
@@ -390,7 +410,7 @@ mod tests {
             .unwrap()
         };
 
-        let path = execute(
+        let result = execute(
             "my-feature",
             Some("develop"),
             repo_dir.path(),
@@ -401,7 +421,7 @@ mod tests {
         .expect("create with --from develop should succeed");
 
         // Open the worktree as a repo and verify its HEAD commit matches develop's tip
-        let wt_repo = git2::Repository::open(&path).unwrap();
+        let wt_repo = git2::Repository::open(&result.path).unwrap();
         let wt_head_oid = wt_repo.head().unwrap().peel_to_commit().unwrap().id();
         assert_eq!(
             wt_head_oid, develop_oid,
@@ -740,6 +760,30 @@ mod tests {
     }
 
     #[test]
+    fn execute_returns_create_result_with_correct_fields() {
+        let repo_dir = tempfile::tempdir().unwrap();
+        let _repo = init_repo_with_commit(repo_dir.path());
+        let wt_root = tempfile::tempdir().unwrap();
+        let db_dir = tempfile::tempdir().unwrap();
+        let db = Database::open(&db_dir.path().join("test.db")).unwrap();
+
+        let result = execute(
+            "my-feature",
+            None,
+            repo_dir.path(),
+            wt_root.path(),
+            paths::DEFAULT_WORKTREE_TEMPLATE,
+            &db,
+        )
+        .expect("create should succeed");
+
+        assert_eq!(result.branch, "my-feature");
+        assert_eq!(result.name, "my-feature");
+        assert!(result.path.exists(), "worktree path should exist on disk");
+        assert!(!result.base_branch.is_empty(), "base_branch should be set");
+    }
+
+    #[test]
     fn dry_run_with_from_shows_custom_base() {
         let repo_dir = tempfile::tempdir().unwrap();
         let repo = init_repo_with_commit(repo_dir.path());
@@ -777,7 +821,7 @@ mod tests {
         let head_commit = repo.head().unwrap().peel_to_commit().unwrap();
         repo.branch("develop", &head_commit, false).unwrap();
 
-        let _path = execute(
+        let _result = execute(
             "my-feature",
             Some("develop"),
             repo_dir.path(),

--- a/src/cli/commands/remove.rs
+++ b/src/cli/commands/remove.rs
@@ -125,7 +125,7 @@ mod tests {
         let db = Database::open(&db_dir.path().join("test.db")).unwrap();
 
         // Create a worktree first
-        let path = crate::cli::commands::create::execute(
+        let create_result = crate::cli::commands::create::execute(
             "my-feature",
             None,
             repo_dir.path(),
@@ -134,7 +134,7 @@ mod tests {
             &db,
         )
         .expect("create should succeed");
-        assert!(path.exists(), "worktree should exist after create");
+        assert!(create_result.path.exists(), "worktree should exist after create");
 
         // Capture the worktree ID before removal
         let repo_path_str = repo_dir.path().canonicalize().unwrap();
@@ -154,7 +154,7 @@ mod tests {
         assert_eq!(result.name, "my-feature");
 
         // Verify: directory is gone
-        assert!(!path.exists(), "worktree directory should be deleted");
+        assert!(!create_result.path.exists(), "worktree directory should be deleted");
 
         // Verify: DB record has removed_at set
         let wt = db
@@ -187,7 +187,7 @@ mod tests {
 
         // Create a simple worktree (no slashes) then rename its DB record
         // to simulate a worktree with a slashed branch name
-        let path = crate::cli::commands::create::execute(
+        let create_result = crate::cli::commands::create::execute(
             "feature-auth",
             None,
             repo_dir.path(),
@@ -211,7 +211,7 @@ mod tests {
         let result = execute("feature/auth", repo_dir.path(), &db, false)
             .expect("remove by branch name should succeed");
         assert_eq!(result.name, "feature-auth");
-        assert!(!path.exists(), "worktree directory should be deleted");
+        assert!(!create_result.path.exists(), "worktree directory should be deleted");
     }
 
     #[test]
@@ -222,7 +222,7 @@ mod tests {
         let db_dir = tempfile::tempdir().unwrap();
         let db = Database::open(&db_dir.path().join("test.db")).unwrap();
 
-        let path = crate::cli::commands::create::execute(
+        let create_result = crate::cli::commands::create::execute(
             "feature-auth",
             None,
             repo_dir.path(),
@@ -236,7 +236,7 @@ mod tests {
         let result = execute("feature-auth", repo_dir.path(), &db, false)
             .expect("remove by sanitized name should succeed");
         assert_eq!(result.name, "feature-auth");
-        assert!(!path.exists(), "worktree directory should be deleted");
+        assert!(!create_result.path.exists(), "worktree directory should be deleted");
     }
 
     /// Helper: create a bare remote, clone it, and return (clone_path, remote_dir).
@@ -267,7 +267,7 @@ mod tests {
         let db = Database::open(&db_dir.path().join("test.db")).unwrap();
 
         // Create a worktree
-        let path = crate::cli::commands::create::execute(
+        let create_result = crate::cli::commands::create::execute(
             "prune-me",
             None,
             clone_dir.path(),
@@ -276,7 +276,7 @@ mod tests {
             &db,
         )
         .expect("create should succeed");
-        assert!(path.exists());
+        assert!(create_result.path.exists());
 
         // Push the branch to the remote
         let clone = git2::Repository::open(clone_dir.path()).unwrap();
@@ -309,7 +309,7 @@ mod tests {
         assert!(result.pruned_remote, "should have pruned remote branch");
 
         // Verify: worktree directory is gone
-        assert!(!path.exists(), "worktree directory should be deleted");
+        assert!(!create_result.path.exists(), "worktree directory should be deleted");
 
         // Verify: remote branch is gone
         // Reopen the bare remote to get fresh state
@@ -328,7 +328,7 @@ mod tests {
         let db = Database::open(&db_dir.path().join("test.db")).unwrap();
 
         // Create a worktree (but DON'T push the branch to remote)
-        let path = crate::cli::commands::create::execute(
+        let create_result = crate::cli::commands::create::execute(
             "no-remote",
             None,
             clone_dir.path(),
@@ -337,7 +337,7 @@ mod tests {
             &db,
         )
         .expect("create should succeed");
-        assert!(path.exists());
+        assert!(create_result.path.exists());
 
         // Remove with prune — remote branch doesn't exist, should warn but succeed
         let result = execute("no-remote", clone_dir.path(), &db, true)
@@ -346,7 +346,7 @@ mod tests {
         assert!(!result.pruned_remote, "should NOT have pruned remote branch");
 
         // Verify: worktree directory is gone
-        assert!(!path.exists(), "worktree directory should be deleted");
+        assert!(!create_result.path.exists(), "worktree directory should be deleted");
     }
 
     #[test]

--- a/src/cli/commands/switch.rs
+++ b/src/cli/commands/switch.rs
@@ -239,7 +239,7 @@ mod tests {
         let db = Database::open(&db_dir.path().join("test.db")).unwrap();
 
         // Create a worktree end-to-end
-        let path = crate::cli::commands::create::execute(
+        let create_result = crate::cli::commands::create::execute(
             "my-feature",
             None,
             repo_dir.path(),
@@ -248,7 +248,7 @@ mod tests {
             &db,
         )
         .expect("create should succeed");
-        assert!(path.exists());
+        assert!(create_result.path.exists());
 
         // Verify last_accessed is None after create
         let repo_path = repo_dir.path().canonicalize().unwrap();
@@ -267,7 +267,7 @@ mod tests {
         let switch = execute("my-feature", repo_dir.path(), &db)
             .expect("switch should succeed");
         assert_eq!(switch.name, "my-feature");
-        assert_eq!(switch.path, path.to_str().unwrap());
+        assert_eq!(switch.path, create_result.path.to_str().unwrap());
 
         // Verify last_accessed is now set
         let wt_after = db.get_worktree(wt_before.id).unwrap().unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -248,7 +248,7 @@ fn run_create(branch: &str, from: Option<&str>, dry_run: bool, json: bool) -> an
     ) {
         Ok(result) => {
             if json {
-                let hooks_status = cli::commands::create::HooksStatus::none();
+                let hooks_status = cli::commands::create::HooksStatus::None;
                 let json_output = result.to_json_output(hooks_status);
                 println!("{}", output::json::format_json_value(&json_output)?);
             } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -246,8 +246,8 @@ fn run_create(branch: &str, from: Option<&str>, dry_run: bool, json: bool) -> an
         &resolved.worktrees.root,
         &db,
     ) {
-        Ok(path) => {
-            println!("{}", path.display());
+        Ok(result) => {
+            println!("{}", result.path.display());
             Ok(())
         }
         Err(e) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -247,7 +247,13 @@ fn run_create(branch: &str, from: Option<&str>, dry_run: bool, json: bool) -> an
         &db,
     ) {
         Ok(result) => {
-            println!("{}", result.path.display());
+            if json {
+                let hooks_status = cli::commands::create::HooksStatus::none();
+                let json_output = result.to_json_output(hooks_status);
+                println!("{}", output::json::format_json_value(&json_output)?);
+            } else {
+                println!("{}", result.path.display());
+            }
             Ok(())
         }
         Err(e) => {


### PR DESCRIPTION
Closes #30

## Summary
Wire the `--json` flag into `trench create` so AI agents and automation scripts can parse structured JSON output. Adds `CreateResult`, `CreateJsonOutput`, and `HooksStatus` types, using the shared `format_json_value()` formatter from the output module.

## User Stories Addressed
- US-4: AI agent can create a worktree and get JSON output with the path

## Automated Testing
- Total tests added: 3
- Tests passing: 3
- Tests failing: 0
- `cargo clippy`: pass
- `cargo test`: pass (331 pass, 2 pre-existing failures in git module unrelated to this PR)

## UAT Checklist
- [ ] `trench create my-feature --json` → valid JSON with worktree, branch, path, base_branch, hooks fields
- [ ] `trench create my-feature --json | jq .` → parses cleanly with jq
- [ ] `trench create my-feature` (without --json) → still prints bare path (backward compatible)
- [ ] `trench create my-feature --dry-run --json` → dry-run JSON still works as before
- [ ] JSON `hooks.status` field is `"none"` when no hooks configured
- [ ] `trench create existing-branch --json` → exits with code 3 (branch exists error preserved)

## Known Issues
- Hook execution is not yet wired into the create command (separate issue). The `hooks.status` field will always be `"none"` until hook execution is implemented. The `HooksStatus::ran()` and `HooksStatus::skipped()` constructors are provided for forward compatibility.
- 2 pre-existing test failures in `git::tests` module (`refs/heads/master` not found) — unrelated to this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Create now returns a structured result with worktree path, branch, base branch and sanitized name.
  * `--json` output expanded to include hooks execution status and full result fields.

* **Tests**
  * Test suite updated to validate the structured create result, JSON serialization, and integration with real worktrees.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->