### PR TITLE
feat(hooks): shell step — multiline script with env vars

### DIFF
--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -1,6 +1,7 @@
 pub mod copy;
 pub mod run;
 pub mod shell;
+pub mod stream;
 
 use std::collections::HashMap;
 use std::fmt;

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -1,5 +1,6 @@
 pub mod copy;
 pub mod run;
+pub mod shell;
 
 use std::collections::HashMap;
 use std::fmt;

--- a/src/hooks/run.rs
+++ b/src/hooks/run.rs
@@ -3,7 +3,8 @@ use std::path::Path;
 use std::process::Stdio;
 
 use anyhow::{Context, Result};
-use tokio::io::{AsyncBufReadExt, BufReader};
+
+use super::stream::stream_and_collect;
 
 /// Output from a single command execution.
 #[derive(Debug, Clone)]
@@ -62,42 +63,7 @@ pub async fn execute_run_step(
         let stdout = child.stdout.take().expect("stdout piped");
         let stderr = child.stderr.take().expect("stderr piped");
 
-        let mut stdout_reader = BufReader::new(stdout).lines();
-        let mut stderr_reader = BufReader::new(stderr).lines();
-
-        let mut stdout_buf = String::new();
-        let mut stderr_buf = String::new();
-        let mut stdout_done = false;
-        let mut stderr_done = false;
-
-        while !stdout_done || !stderr_done {
-            tokio::select! {
-                result = stdout_reader.next_line(), if !stdout_done => {
-                    match result? {
-                        Some(line) => {
-                            println!("{line}");
-                            if !stdout_buf.is_empty() {
-                                stdout_buf.push('\n');
-                            }
-                            stdout_buf.push_str(&line);
-                        }
-                        None => stdout_done = true,
-                    }
-                }
-                result = stderr_reader.next_line(), if !stderr_done => {
-                    match result? {
-                        Some(line) => {
-                            eprintln!("{line}");
-                            if !stderr_buf.is_empty() {
-                                stderr_buf.push('\n');
-                            }
-                            stderr_buf.push_str(&line);
-                        }
-                        None => stderr_done = true,
-                    }
-                }
-            }
-        }
+        let (stdout_buf, stderr_buf) = stream_and_collect(stdout, stderr).await?;
 
         let status = child
             .wait()

--- a/src/hooks/shell.rs
+++ b/src/hooks/shell.rs
@@ -3,7 +3,8 @@ use std::path::Path;
 use std::process::Stdio;
 
 use anyhow::{Context, Result};
-use tokio::io::{AsyncBufReadExt, BufReader};
+
+use super::stream::stream_and_collect;
 
 /// Output from executing the shell step.
 #[derive(Debug, Clone)]
@@ -49,42 +50,7 @@ pub async fn execute_shell_step(
     let stdout = child.stdout.take().expect("stdout piped");
     let stderr = child.stderr.take().expect("stderr piped");
 
-    let mut stdout_reader = BufReader::new(stdout).lines();
-    let mut stderr_reader = BufReader::new(stderr).lines();
-
-    let mut stdout_buf = String::new();
-    let mut stderr_buf = String::new();
-    let mut stdout_done = false;
-    let mut stderr_done = false;
-
-    while !stdout_done || !stderr_done {
-        tokio::select! {
-            result = stdout_reader.next_line(), if !stdout_done => {
-                match result? {
-                    Some(line) => {
-                        println!("{line}");
-                        if !stdout_buf.is_empty() {
-                            stdout_buf.push('\n');
-                        }
-                        stdout_buf.push_str(&line);
-                    }
-                    None => stdout_done = true,
-                }
-            }
-            result = stderr_reader.next_line(), if !stderr_done => {
-                match result? {
-                    Some(line) => {
-                        eprintln!("{line}");
-                        if !stderr_buf.is_empty() {
-                            stderr_buf.push('\n');
-                        }
-                        stderr_buf.push_str(&line);
-                    }
-                    None => stderr_done = true,
-                }
-            }
-        }
-    }
+    let (stdout_buf, stderr_buf) = stream_and_collect(stdout, stderr).await?;
 
     let status = child
         .wait()

--- a/src/hooks/shell.rs
+++ b/src/hooks/shell.rs
@@ -129,4 +129,130 @@ mod tests {
         assert_eq!(result.stdout.trim(), "hello");
         assert_eq!(result.exit_code, 0);
     }
+
+    #[tokio::test]
+    async fn env_vars_accessible_in_script() {
+        let dir = TempDir::new().unwrap();
+        let mut env = HashMap::new();
+        env.insert("TRENCH_BRANCH".to_string(), "feature/auth".to_string());
+        env.insert("TRENCH_EVENT".to_string(), "post_create".to_string());
+
+        let result = execute_shell_step(
+            "echo $TRENCH_BRANCH; echo $TRENCH_EVENT",
+            dir.path(),
+            &env,
+        )
+        .await
+        .unwrap();
+
+        let lines: Vec<&str> = result.stdout.lines().collect();
+        assert_eq!(lines[0], "feature/auth");
+        assert_eq!(lines[1], "post_create");
+    }
+
+    #[tokio::test]
+    async fn multiline_script_executes_all_lines() {
+        let dir = TempDir::new().unwrap();
+        let env = HashMap::new();
+
+        let script = "VAR=hello\necho $VAR\necho world";
+        let result = execute_shell_step(script, dir.path(), &env)
+            .await
+            .unwrap();
+
+        let lines: Vec<&str> = result.stdout.lines().collect();
+        assert_eq!(lines.len(), 2);
+        assert_eq!(lines[0], "hello");
+        assert_eq!(lines[1], "world");
+    }
+
+    #[tokio::test]
+    async fn cwd_set_to_specified_directory() {
+        let dir = TempDir::new().unwrap();
+        let env = HashMap::new();
+
+        let result = execute_shell_step("pwd", dir.path(), &env)
+            .await
+            .unwrap();
+
+        let expected = dir.path().canonicalize().unwrap();
+        let actual = std::path::PathBuf::from(result.stdout.trim())
+            .canonicalize()
+            .unwrap();
+        assert_eq!(actual, expected);
+    }
+
+    #[tokio::test]
+    async fn nonzero_exit_returns_error_with_output() {
+        let dir = TempDir::new().unwrap();
+        let env = HashMap::new();
+
+        let err = execute_shell_step("echo before_fail; exit 42", dir.path(), &env)
+            .await
+            .unwrap_err();
+
+        let msg = err.to_string();
+        assert!(msg.contains("42"), "error should contain exit code: {msg}");
+
+        let shell_err = err.downcast_ref::<ShellStepError>().unwrap();
+        assert_eq!(shell_err.exit_code, 42);
+        assert_eq!(shell_err.output.stdout.trim(), "before_fail");
+    }
+
+    #[tokio::test]
+    async fn stderr_captured_separately_from_stdout() {
+        let dir = TempDir::new().unwrap();
+        let env = HashMap::new();
+
+        let result = execute_shell_step(
+            "echo out_msg; echo err_msg >&2",
+            dir.path(),
+            &env,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.stdout.trim(), "out_msg");
+        assert_eq!(result.stderr.trim(), "err_msg");
+    }
+
+    #[tokio::test]
+    async fn integration_with_build_env_all_seven_vars() {
+        use crate::hooks::{build_env, HookEnvContext, HookEvent};
+
+        let dir = TempDir::new().unwrap();
+        let ctx = HookEnvContext {
+            worktree_path: "/tmp/wt".into(),
+            worktree_name: "feat-auth".into(),
+            branch: "feature/auth".into(),
+            repo_name: "myrepo".into(),
+            repo_path: "/tmp/repo".into(),
+            base_branch: "main".into(),
+        };
+        let env = build_env(&ctx, &HookEvent::PostCreate);
+
+        let script = r#"
+echo $TRENCH_WORKTREE_PATH
+echo $TRENCH_WORKTREE_NAME
+echo $TRENCH_BRANCH
+echo $TRENCH_REPO_NAME
+echo $TRENCH_REPO_PATH
+echo $TRENCH_BASE_BRANCH
+echo $TRENCH_EVENT
+"#;
+
+        let result = execute_shell_step(script, dir.path(), &env)
+            .await
+            .unwrap();
+
+        let lines: Vec<&str> = result.stdout.lines().collect();
+        assert_eq!(lines.len(), 7);
+        assert_eq!(lines[0], "/tmp/wt");
+        assert_eq!(lines[1], "feat-auth");
+        assert_eq!(lines[2], "feature/auth");
+        assert_eq!(lines[3], "myrepo");
+        assert_eq!(lines[4], "/tmp/repo");
+        assert_eq!(lines[5], "main");
+        assert_eq!(lines[6], "post_create");
+    }
 }

--- a/src/hooks/shell.rs
+++ b/src/hooks/shell.rs
@@ -1,0 +1,132 @@
+use std::collections::HashMap;
+use std::path::Path;
+use std::process::Stdio;
+
+use anyhow::{Context, Result};
+use tokio::io::{AsyncBufReadExt, BufReader};
+
+/// Output from executing the shell step.
+#[derive(Debug, Clone)]
+pub struct ShellOutput {
+    /// The script that was executed.
+    pub script: String,
+    /// Captured stdout.
+    pub stdout: String,
+    /// Captured stderr.
+    pub stderr: String,
+    /// Process exit code.
+    pub exit_code: i32,
+}
+
+/// Error returned when a shell script exits with a non-zero code.
+#[derive(Debug, thiserror::Error)]
+#[error("shell script failed with exit code {exit_code}")]
+pub struct ShellStepError {
+    pub exit_code: i32,
+    pub output: ShellOutput,
+}
+
+/// Execute the shell step of a hook: run a multiline script via `sh -c`.
+///
+/// The script runs with cwd set to `cwd` and TRENCH_* env vars from `env_vars`.
+/// stdout/stderr stream to the terminal in real time and are captured for logging.
+/// Returns error on non-zero exit (FR-20).
+pub async fn execute_shell_step(
+    script: &str,
+    cwd: &Path,
+    env_vars: &HashMap<String, String>,
+) -> Result<ShellOutput> {
+    let mut child = tokio::process::Command::new("sh")
+        .arg("-c")
+        .arg(script)
+        .current_dir(cwd)
+        .envs(env_vars.iter())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .context("failed to spawn shell script")?;
+
+    let stdout = child.stdout.take().expect("stdout piped");
+    let stderr = child.stderr.take().expect("stderr piped");
+
+    let mut stdout_reader = BufReader::new(stdout).lines();
+    let mut stderr_reader = BufReader::new(stderr).lines();
+
+    let mut stdout_buf = String::new();
+    let mut stderr_buf = String::new();
+    let mut stdout_done = false;
+    let mut stderr_done = false;
+
+    while !stdout_done || !stderr_done {
+        tokio::select! {
+            result = stdout_reader.next_line(), if !stdout_done => {
+                match result? {
+                    Some(line) => {
+                        println!("{line}");
+                        if !stdout_buf.is_empty() {
+                            stdout_buf.push('\n');
+                        }
+                        stdout_buf.push_str(&line);
+                    }
+                    None => stdout_done = true,
+                }
+            }
+            result = stderr_reader.next_line(), if !stderr_done => {
+                match result? {
+                    Some(line) => {
+                        eprintln!("{line}");
+                        if !stderr_buf.is_empty() {
+                            stderr_buf.push('\n');
+                        }
+                        stderr_buf.push_str(&line);
+                    }
+                    None => stderr_done = true,
+                }
+            }
+        }
+    }
+
+    let status = child
+        .wait()
+        .await
+        .context("failed to wait for shell script")?;
+
+    let exit_code = status.code().unwrap_or(-1);
+
+    let output = ShellOutput {
+        script: script.to_string(),
+        stdout: stdout_buf,
+        stderr: stderr_buf,
+        exit_code,
+    };
+
+    if !status.success() {
+        return Err(ShellStepError {
+            exit_code,
+            output,
+        }
+        .into());
+    }
+
+    Ok(output)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[tokio::test]
+    async fn simple_script_executes_and_captures_stdout() {
+        let dir = TempDir::new().unwrap();
+        let env = HashMap::new();
+
+        let result = execute_shell_step("echo hello", dir.path(), &env)
+            .await
+            .unwrap();
+
+        assert_eq!(result.script, "echo hello");
+        assert_eq!(result.stdout.trim(), "hello");
+        assert_eq!(result.exit_code, 0);
+    }
+}

--- a/src/hooks/stream.rs
+++ b/src/hooks/stream.rs
@@ -1,0 +1,98 @@
+use anyhow::Result;
+use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::process::{ChildStderr, ChildStdout};
+
+/// Stream stdout/stderr from a child process to the terminal in real time,
+/// capturing both into buffers. Returns `(stdout, stderr)` strings.
+pub async fn stream_and_collect(
+    stdout: ChildStdout,
+    stderr: ChildStderr,
+) -> Result<(String, String)> {
+    let mut stdout_reader = BufReader::new(stdout).lines();
+    let mut stderr_reader = BufReader::new(stderr).lines();
+
+    let mut stdout_buf = String::new();
+    let mut stderr_buf = String::new();
+    let mut stdout_done = false;
+    let mut stderr_done = false;
+
+    while !stdout_done || !stderr_done {
+        tokio::select! {
+            result = stdout_reader.next_line(), if !stdout_done => {
+                match result? {
+                    Some(line) => {
+                        println!("{line}");
+                        if !stdout_buf.is_empty() {
+                            stdout_buf.push('\n');
+                        }
+                        stdout_buf.push_str(&line);
+                    }
+                    None => stdout_done = true,
+                }
+            }
+            result = stderr_reader.next_line(), if !stderr_done => {
+                match result? {
+                    Some(line) => {
+                        eprintln!("{line}");
+                        if !stderr_buf.is_empty() {
+                            stderr_buf.push('\n');
+                        }
+                        stderr_buf.push_str(&line);
+                    }
+                    None => stderr_done = true,
+                }
+            }
+        }
+    }
+
+    Ok((stdout_buf, stderr_buf))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::process::Stdio;
+
+    #[tokio::test]
+    async fn captures_stdout_and_stderr_separately() {
+        let mut child = tokio::process::Command::new("sh")
+            .arg("-c")
+            .arg("echo out_line; echo err_line >&2")
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .unwrap();
+
+        let stdout = child.stdout.take().unwrap();
+        let stderr = child.stderr.take().unwrap();
+
+        let (out, err) = stream_and_collect(stdout, stderr).await.unwrap();
+
+        child.wait().await.unwrap();
+
+        assert_eq!(out.trim(), "out_line");
+        assert_eq!(err.trim(), "err_line");
+    }
+
+    #[tokio::test]
+    async fn captures_multiline_output() {
+        let mut child = tokio::process::Command::new("sh")
+            .arg("-c")
+            .arg("echo first; echo second; echo third")
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .unwrap();
+
+        let stdout = child.stdout.take().unwrap();
+        let stderr = child.stderr.take().unwrap();
+
+        let (out, err) = stream_and_collect(stdout, stderr).await.unwrap();
+
+        child.wait().await.unwrap();
+
+        let lines: Vec<&str> = out.lines().collect();
+        assert_eq!(lines, vec!["first", "second", "third"]);
+        assert!(err.is_empty());
+    }
+}


### PR DESCRIPTION
Closes #31

## Summary

Implement the hook `shell` step in `src/hooks/shell.rs` — the last of the three hook execution steps (copy → run → shell). Executes an arbitrary multiline shell script via `sh -c` with all TRENCH_* environment variables injected, cwd set to the worktree path, real-time stdout/stderr streaming, output capture for DB logging, and non-zero exit error handling.

## User Stories Addressed

- US-2: Complex setup scripts in hooks (e.g., multiline shell scripts for installing dependencies, generating configs)

## Automated Testing

- Total tests added: 7
- Tests passing: 7
- Tests failing: 0
- `cargo clippy`: pass (no warnings in new code; pre-existing warnings in other modules)
- `cargo test`: pass (7/7 new tests; 2 pre-existing failures in `git::tests` on `main`)

## UAT Checklist

- [ ] Add `shell = "echo $TRENCH_BRANCH && ls"` to a `.trench.toml` hook config → script executes as expected
- [ ] Add a multiline shell script with variable assignment and conditionals → all lines execute correctly
- [ ] Verify `TRENCH_WORKTREE_PATH`, `TRENCH_BRANCH`, and other TRENCH_* vars are accessible within the shell script
- [ ] Verify shell script runs in the worktree directory (not the repo root)
- [ ] Verify stdout and stderr from the script are visible in real time during execution
- [ ] Trigger a shell script that exits with non-zero code → hook reports failure and stops the hook chain
- [ ] Run `trench log --output` after a hook with a shell step → captured output is shown

## Known Issues

- 2 pre-existing test failures on `main` in `git::tests` (unrelated to this PR): `create_worktree_succeeds_after_remote_branch_deleted` and `delete_remote_branch_deletes_branch_on_remote` — both fail due to `refs/heads/master` not found

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shell script execution in hooks with environment-variable and working-directory support
  * Real-time streaming of stdout/stderr to the terminal while capturing outputs separately
  * Enhanced error reporting that includes exit codes and preserved output for failed steps

* **Tests**
  * Comprehensive unit and integration tests covering execution, env propagation, multiline output, working directory, and non-zero exits
<!-- end of auto-generated comment: release notes by coderabbit.ai -->