### PR TITLE
feat(status): summary + deep single-worktree view

### DIFF
--- a/src/cli/commands/mod.rs
+++ b/src/cli/commands/mod.rs
@@ -5,5 +5,6 @@ pub mod list;
 pub mod open;
 pub mod remove;
 pub mod shell_init;
+pub mod status;
 pub mod switch;
 pub mod tag;

--- a/src/cli/commands/status.rs
+++ b/src/cli/commands/status.rs
@@ -1,0 +1,17 @@
+use std::path::Path;
+
+use anyhow::Result;
+
+use crate::state::Database;
+
+pub fn execute(_cwd: &Path, _db: &Database, _branch: Option<&str>) -> Result<String> {
+    todo!()
+}
+
+pub fn execute_json(_cwd: &Path, _db: &Database, _branch: Option<&str>) -> Result<String> {
+    todo!()
+}
+
+pub fn execute_porcelain(_cwd: &Path, _db: &Database, _branch: Option<&str>) -> Result<String> {
+    todo!()
+}

--- a/src/cli/commands/status.rs
+++ b/src/cli/commands/status.rs
@@ -17,6 +17,8 @@ struct StatusEntry {
     path: String,
     base_branch: Option<String>,
     managed: bool,
+    /// DB worktree ID (None for unmanaged worktrees).
+    db_id: Option<i64>,
 }
 
 /// Fetch all worktrees (managed + unmanaged) for the repo at `cwd`.
@@ -47,6 +49,7 @@ fn fetch_all_worktrees(cwd: &Path, db: &Database) -> Result<(PathBuf, Vec<Status
             path: wt.path.clone(),
             base_branch: wt.base_branch.clone(),
             managed: true,
+            db_id: Some(wt.id),
         });
     }
 
@@ -59,6 +62,7 @@ fn fetch_all_worktrees(cwd: &Path, db: &Database) -> Result<(PathBuf, Vec<Status
                 path: gw.path.to_string_lossy().into_owned(),
                 base_branch: None,
                 managed: false,
+                db_id: None,
             });
         }
     }
@@ -195,6 +199,7 @@ fn resolve_worktree(
                     path: wt.path,
                     base_branch: wt.base_branch,
                     managed: true,
+                    db_id: Some(wt.id),
                 },
             ));
         }
@@ -214,6 +219,7 @@ fn resolve_worktree(
                     path: gw.path.to_string_lossy().into_owned(),
                     base_branch: None,
                     managed: false,
+                    db_id: None,
                 },
             ));
         }
@@ -255,6 +261,17 @@ fn render_deep(cwd: &Path, db: &Database, identifier: &str) -> Result<String> {
         out.push_str("\nRecent commits:\n");
         for c in &commits {
             out.push_str(&format!("  {} {}\n", c.hash, c.message));
+        }
+    }
+
+    // Hook history
+    if let Some(wt_id) = entry.db_id {
+        let events = db.list_events(wt_id, 10).unwrap_or_default();
+        if !events.is_empty() {
+            out.push_str("\nHook history:\n");
+            for ev in &events {
+                out.push_str(&format!("  {}\n", ev.event_type));
+            }
         }
     }
 
@@ -330,7 +347,7 @@ struct DeepJson {
     hook_history: Vec<String>,
 }
 
-fn build_deep_json(entry: &StatusEntry, status: GitStatus) -> DeepJson {
+fn build_deep_json(entry: &StatusEntry, status: GitStatus, db: &Database) -> DeepJson {
     let wt_path = Path::new(&entry.path);
     let changed = git::changed_files(wt_path)
         .unwrap_or_default()
@@ -341,6 +358,13 @@ fn build_deep_json(entry: &StatusEntry, status: GitStatus) -> DeepJson {
         .unwrap_or_default()
         .into_iter()
         .map(|c| format!("{} {}", c.hash, c.message))
+        .collect();
+    let hook_history = entry
+        .db_id
+        .and_then(|id| db.list_events(id, 10).ok())
+        .unwrap_or_default()
+        .into_iter()
+        .map(|ev| ev.event_type)
         .collect();
 
     DeepJson {
@@ -355,7 +379,7 @@ fn build_deep_json(entry: &StatusEntry, status: GitStatus) -> DeepJson {
         managed: entry.managed,
         changed_files: changed,
         recent_commits: commits,
-        hook_history: Vec::new(),
+        hook_history,
     }
 }
 
@@ -364,7 +388,7 @@ pub fn execute_json(cwd: &Path, db: &Database, branch: Option<&str>) -> Result<S
         Some(id) => {
             let (repo_path, entry) = resolve_worktree(cwd, db, id)?;
             let status = compute_git_status(&repo_path, &entry);
-            let json_obj = build_deep_json(&entry, status);
+            let json_obj = build_deep_json(&entry, status, db);
             format_json_value(&json_obj)
         }
         None => {
@@ -626,6 +650,52 @@ mod tests {
         assert!(
             output.contains("add file.txt for testing"),
             "should show commit message, got:\n{output}"
+        );
+    }
+
+    #[test]
+    fn deep_view_includes_hook_history() {
+        let repo_dir = tempfile::tempdir().unwrap();
+        let _repo = init_repo_with_commit(repo_dir.path());
+        let db = Database::open_in_memory().unwrap();
+
+        let repo_path = repo_dir.path().canonicalize().unwrap();
+        let repo_name = repo_path.file_name().unwrap().to_str().unwrap();
+        let db_repo = db
+            .insert_repo(repo_name, repo_path.to_str().unwrap(), Some("main"))
+            .unwrap();
+
+        let wt = db
+            .insert_worktree(
+                db_repo.id,
+                "feature-auth",
+                "feature/auth",
+                "/tmp/wt/feature-auth",
+                Some("main"),
+            )
+            .unwrap();
+
+        // Insert some events
+        let payload = serde_json::json!({"status": "success"});
+        db.insert_event(db_repo.id, Some(wt.id), "post_create", Some(&payload))
+            .unwrap();
+        db.insert_event(db_repo.id, Some(wt.id), "post_sync", None)
+            .unwrap();
+
+        let output =
+            render_deep(repo_dir.path(), &db, "feature-auth").expect("deep should succeed");
+
+        assert!(
+            output.contains("Hook history"),
+            "should have Hook history section, got:\n{output}"
+        );
+        assert!(
+            output.contains("post_create"),
+            "should show post_create event, got:\n{output}"
+        );
+        assert!(
+            output.contains("post_sync"),
+            "should show post_sync event, got:\n{output}"
         );
     }
 

--- a/src/cli/commands/status.rs
+++ b/src/cli/commands/status.rs
@@ -2,8 +2,11 @@ use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
 use anyhow::Result;
+use serde::Serialize;
 
 use crate::git;
+use crate::output::json::{format_json, format_json_value};
+use crate::output::porcelain::{format_porcelain, PorcelainRecord};
 use crate::output::table::Table;
 use crate::state::{Database, Worktree};
 
@@ -250,12 +253,123 @@ pub fn execute(cwd: &Path, db: &Database, branch: Option<&str>) -> Result<String
     }
 }
 
-pub fn execute_json(_cwd: &Path, _db: &Database, _branch: Option<&str>) -> Result<String> {
-    todo!()
+/// JSON output for summary mode.
+#[derive(Serialize)]
+struct SummaryJson {
+    name: String,
+    branch: String,
+    path: String,
+    status: String,
+    ahead: Option<usize>,
+    behind: Option<usize>,
+    dirty: usize,
+    managed: bool,
 }
 
-pub fn execute_porcelain(_cwd: &Path, _db: &Database, _branch: Option<&str>) -> Result<String> {
-    todo!()
+impl PorcelainRecord for SummaryJson {
+    fn porcelain_fields(&self) -> Vec<String> {
+        vec![
+            self.name.clone(),
+            self.branch.clone(),
+            self.path.clone(),
+            self.status.clone(),
+            self.ahead.map_or("-".to_string(), |v| v.to_string()),
+            self.behind.map_or("-".to_string(), |v| v.to_string()),
+            self.dirty.to_string(),
+            self.managed.to_string(),
+        ]
+    }
+}
+
+fn build_summary_json(entry: &StatusEntry, status: GitStatus) -> SummaryJson {
+    SummaryJson {
+        name: entry.name.clone(),
+        branch: entry.branch.clone(),
+        path: entry.path.clone(),
+        status: format_dirty(status.dirty),
+        ahead: status.ahead,
+        behind: status.behind,
+        dirty: status.dirty,
+        managed: entry.managed,
+    }
+}
+
+/// JSON output for deep mode.
+#[derive(Serialize)]
+struct DeepJson {
+    name: String,
+    branch: String,
+    path: String,
+    base_branch: Option<String>,
+    ahead: Option<usize>,
+    behind: Option<usize>,
+    dirty: usize,
+    status: String,
+    managed: bool,
+    changed_files: Vec<String>,
+    recent_commits: Vec<String>,
+    hook_history: Vec<String>,
+}
+
+fn build_deep_json(entry: &StatusEntry, status: GitStatus) -> DeepJson {
+    DeepJson {
+        name: entry.name.clone(),
+        branch: entry.branch.clone(),
+        path: entry.path.clone(),
+        base_branch: entry.base_branch.clone(),
+        ahead: status.ahead,
+        behind: status.behind,
+        dirty: status.dirty,
+        status: format_dirty(status.dirty),
+        managed: entry.managed,
+        changed_files: Vec::new(),
+        recent_commits: Vec::new(),
+        hook_history: Vec::new(),
+    }
+}
+
+pub fn execute_json(cwd: &Path, db: &Database, branch: Option<&str>) -> Result<String> {
+    match branch {
+        Some(id) => {
+            let (repo_path, entry) = resolve_worktree(cwd, db, id)?;
+            let status = compute_git_status(&repo_path, &entry);
+            let json_obj = build_deep_json(&entry, status);
+            format_json_value(&json_obj)
+        }
+        None => {
+            let (repo_path, entries) = fetch_all_worktrees(cwd, db)?;
+            let items: Vec<SummaryJson> = entries
+                .iter()
+                .map(|e| {
+                    let status = compute_git_status(&repo_path, e);
+                    build_summary_json(e, status)
+                })
+                .collect();
+            format_json(&items)
+        }
+    }
+}
+
+pub fn execute_porcelain(cwd: &Path, db: &Database, branch: Option<&str>) -> Result<String> {
+    match branch {
+        Some(id) => {
+            let (repo_path, entry) = resolve_worktree(cwd, db, id)?;
+            let status = compute_git_status(&repo_path, &entry);
+            let item = build_summary_json(&entry, status);
+            Ok(format_porcelain(&[item]))
+        }
+        None => {
+            let (repo_path, entries) = fetch_all_worktrees(cwd, db)?;
+            let items: Vec<SummaryJson> = entries
+                .iter()
+                .map(|e| {
+                    let status = compute_git_status(&repo_path, e);
+                    build_summary_json(e, status)
+                })
+                .collect();
+            Ok(format_porcelain(&items))
+        }
+    }
 }
 
 #[cfg(test)]
@@ -311,6 +425,80 @@ mod tests {
         assert!(output.contains("Branch"), "should have Branch header");
         assert!(output.contains("feature-auth"), "should show first worktree");
         assert!(output.contains("fix-bug"), "should show second worktree");
+    }
+
+    #[test]
+    fn summary_json_returns_array_of_worktrees() {
+        let repo_dir = tempfile::tempdir().unwrap();
+        let _repo = init_repo_with_commit(repo_dir.path());
+        let db = Database::open_in_memory().unwrap();
+
+        let repo_path = repo_dir.path().canonicalize().unwrap();
+        let repo_name = repo_path.file_name().unwrap().to_str().unwrap();
+        let db_repo = db
+            .insert_repo(repo_name, repo_path.to_str().unwrap(), Some("main"))
+            .unwrap();
+
+        db.insert_worktree(
+            db_repo.id,
+            "feature-auth",
+            "feature/auth",
+            "/tmp/wt/feature-auth",
+            Some("main"),
+        )
+        .unwrap();
+
+        let output =
+            execute_json(repo_dir.path(), &db, None).expect("summary json should succeed");
+        let parsed: serde_json::Value = serde_json::from_str(&output).unwrap();
+        let arr = parsed.as_array().expect("should be array");
+
+        // At least the managed worktree + main worktree
+        assert!(arr.len() >= 2, "should have at least 2 entries, got {}", arr.len());
+
+        // Find the managed worktree
+        let wt = arr
+            .iter()
+            .find(|v| v["name"] == "feature-auth")
+            .expect("should contain feature-auth");
+        assert_eq!(wt["branch"], "feature/auth");
+        assert_eq!(wt["managed"], true);
+        assert!(wt["path"].is_string());
+    }
+
+    #[test]
+    fn deep_json_returns_single_object() {
+        let repo_dir = tempfile::tempdir().unwrap();
+        let _repo = init_repo_with_commit(repo_dir.path());
+        let db = Database::open_in_memory().unwrap();
+
+        let repo_path = repo_dir.path().canonicalize().unwrap();
+        let repo_name = repo_path.file_name().unwrap().to_str().unwrap();
+        let db_repo = db
+            .insert_repo(repo_name, repo_path.to_str().unwrap(), Some("main"))
+            .unwrap();
+
+        db.insert_worktree(
+            db_repo.id,
+            "feature-auth",
+            "feature/auth",
+            "/tmp/wt/feature-auth",
+            Some("main"),
+        )
+        .unwrap();
+
+        let output = execute_json(repo_dir.path(), &db, Some("feature-auth"))
+            .expect("deep json should succeed");
+        let parsed: serde_json::Value = serde_json::from_str(&output).unwrap();
+
+        assert!(parsed.is_object(), "should be a single JSON object");
+        assert_eq!(parsed["name"], "feature-auth");
+        assert_eq!(parsed["branch"], "feature/auth");
+        assert_eq!(parsed["base_branch"], "main");
+        assert_eq!(parsed["managed"], true);
+        assert!(parsed["changed_files"].is_array());
+        assert!(parsed["recent_commits"].is_array());
+        assert!(parsed["hook_history"].is_array());
     }
 
     #[test]

--- a/src/cli/commands/status.rs
+++ b/src/cli/commands/status.rs
@@ -124,6 +124,7 @@ fn render_summary_table(
     cwd: &Path,
     db: &Database,
     max_width: Option<usize>,
+    use_color: bool,
 ) -> Result<String> {
     let (repo_path, entries) = fetch_all_worktrees(cwd, db)?;
 
@@ -162,7 +163,7 @@ fn render_summary_table(
         out.push('\n');
     }
     for (i, line) in lines.iter().skip(1).enumerate() {
-        if i < unmanaged_rows.len() && unmanaged_rows[i] {
+        if use_color && i < unmanaged_rows.len() && unmanaged_rows[i] {
             out.push_str("\x1b[2m");
             out.push_str(line);
             out.push_str("\x1b[0m");
@@ -278,13 +279,14 @@ fn render_deep(cwd: &Path, db: &Database, identifier: &str) -> Result<String> {
     Ok(out)
 }
 
-pub fn execute(cwd: &Path, db: &Database, branch: Option<&str>) -> Result<String> {
+pub fn execute(cwd: &Path, db: &Database, branch: Option<&str>, use_color: bool) -> Result<String> {
     match branch {
         Some(id) => render_deep(cwd, db, id),
         None => render_summary_table(
             cwd,
             db,
             crossterm::terminal::size().ok().map(|(c, _)| c as usize),
+            use_color,
         ),
     }
 }
@@ -474,12 +476,28 @@ mod tests {
         .unwrap();
 
         let output =
-            render_summary_table(repo_dir.path(), &db, None).expect("summary should succeed");
+            render_summary_table(repo_dir.path(), &db, None, false).expect("summary should succeed");
 
         assert!(output.contains("Name"), "should have Name header");
         assert!(output.contains("Branch"), "should have Branch header");
         assert!(output.contains("feature-auth"), "should show first worktree");
         assert!(output.contains("fix-bug"), "should show second worktree");
+    }
+
+    #[test]
+    fn summary_table_no_ansi_when_color_disabled() {
+        let repo_dir = tempfile::tempdir().unwrap();
+        let _repo = init_repo_with_commit(repo_dir.path());
+        let db = Database::open_in_memory().unwrap();
+
+        // The main worktree is unmanaged (no DB entry), so it will be dimmed
+        // only when color is enabled.
+        let output =
+            render_summary_table(repo_dir.path(), &db, None, false).expect("should succeed");
+        assert!(
+            !output.contains("\x1b"),
+            "should not contain ANSI escape codes when color is disabled, got:\n{output}"
+        );
     }
 
     #[test]

--- a/src/cli/commands/status.rs
+++ b/src/cli/commands/status.rs
@@ -239,6 +239,16 @@ fn render_deep(cwd: &Path, db: &Database, identifier: &str) -> Result<String> {
         out.push_str("Managed:      no [unmanaged]\n");
     }
 
+    // Changed files
+    let wt_path = Path::new(&entry.path);
+    let changed = git::changed_files(wt_path).unwrap_or_default();
+    if !changed.is_empty() {
+        out.push_str("\nChanged files:\n");
+        for f in &changed {
+            out.push_str(&format!("  {} {}\n", f.status, f.path));
+        }
+    }
+
     Ok(out)
 }
 
@@ -312,6 +322,13 @@ struct DeepJson {
 }
 
 fn build_deep_json(entry: &StatusEntry, status: GitStatus) -> DeepJson {
+    let wt_path = Path::new(&entry.path);
+    let changed = git::changed_files(wt_path)
+        .unwrap_or_default()
+        .into_iter()
+        .map(|f| format!("{} {}", f.status, f.path))
+        .collect();
+
     DeepJson {
         name: entry.name.clone(),
         branch: entry.branch.clone(),
@@ -322,7 +339,7 @@ fn build_deep_json(entry: &StatusEntry, status: GitStatus) -> DeepJson {
         dirty: status.dirty,
         status: format_dirty(status.dirty),
         managed: entry.managed,
-        changed_files: Vec::new(),
+        changed_files: changed,
         recent_commits: Vec::new(),
         hook_history: Vec::new(),
     }
@@ -464,6 +481,62 @@ mod tests {
         assert_eq!(wt["branch"], "feature/auth");
         assert_eq!(wt["managed"], true);
         assert!(wt["path"].is_string());
+    }
+
+    #[test]
+    fn deep_view_includes_changed_files() {
+        let repo_dir = tempfile::tempdir().unwrap();
+        let repo = init_repo_with_commit(repo_dir.path());
+
+        // Create a worktree with a modified file
+        let wt_parent = tempfile::tempdir().unwrap();
+        let wt_path = wt_parent.path().join("test-changes");
+        let head = repo.head().unwrap().shorthand().unwrap().to_string();
+        let head_commit = repo
+            .find_branch(&head, git2::BranchType::Local)
+            .unwrap()
+            .get()
+            .peel_to_commit()
+            .unwrap();
+        repo.branch("test-changes", &head_commit, false).unwrap();
+        let mut opts = git2::WorktreeAddOptions::new();
+        let branch_ref = repo
+            .find_branch("test-changes", git2::BranchType::Local)
+            .unwrap();
+        opts.reference(Some(branch_ref.get()));
+        repo.worktree("test-changes", &wt_path, Some(&opts))
+            .unwrap();
+
+        // Create a new file in the worktree
+        std::fs::write(wt_path.join("new-file.txt"), "hello").unwrap();
+
+        let db = Database::open_in_memory().unwrap();
+        let repo_path = repo_dir.path().canonicalize().unwrap();
+        let repo_name = repo_path.file_name().unwrap().to_str().unwrap();
+        let db_repo = db
+            .insert_repo(repo_name, repo_path.to_str().unwrap(), Some(&head))
+            .unwrap();
+        let wt_canonical = wt_path.canonicalize().unwrap();
+        db.insert_worktree(
+            db_repo.id,
+            "test-changes",
+            "test-changes",
+            wt_canonical.to_str().unwrap(),
+            Some(&head),
+        )
+        .unwrap();
+
+        let output =
+            render_deep(repo_dir.path(), &db, "test-changes").expect("deep should succeed");
+
+        assert!(
+            output.contains("Changed files"),
+            "should have Changed files section, got:\n{output}"
+        );
+        assert!(
+            output.contains("new-file.txt"),
+            "should list the changed file, got:\n{output}"
+        );
     }
 
     #[test]

--- a/src/cli/commands/status.rs
+++ b/src/cli/commands/status.rs
@@ -168,15 +168,86 @@ fn render_summary_table(
     Ok(out)
 }
 
-pub fn execute(cwd: &Path, db: &Database, branch: Option<&str>) -> Result<String> {
-    if branch.is_some() {
-        todo!("deep status not yet implemented")
+/// Resolve a worktree by identifier (sanitized name or branch) from the DB.
+/// Falls back to git-discovered worktrees for unmanaged entries.
+fn resolve_worktree(
+    cwd: &Path,
+    db: &Database,
+    identifier: &str,
+) -> Result<(PathBuf, StatusEntry)> {
+    let repo_info = git::discover_repo(cwd)?;
+    let repo_path_str = repo_info
+        .path
+        .to_str()
+        .ok_or_else(|| anyhow::anyhow!("repo path is not valid UTF-8"))?;
+
+    // Try DB first
+    if let Some(repo) = db.get_repo_by_path(repo_path_str)? {
+        if let Some(wt) = db.find_worktree_by_identifier(repo.id, identifier)? {
+            return Ok((
+                repo_info.path,
+                StatusEntry {
+                    name: wt.name,
+                    branch: wt.branch,
+                    path: wt.path,
+                    base_branch: wt.base_branch,
+                    managed: true,
+                },
+            ));
+        }
     }
-    render_summary_table(
-        cwd,
-        db,
-        crossterm::terminal::size().ok().map(|(c, _)| c as usize),
-    )
+
+    // Fall back to git-discovered worktrees
+    let git_worktrees = git::list_worktrees(&repo_info.path)?;
+    for gw in git_worktrees {
+        let branch_match = gw.branch.as_deref() == Some(identifier);
+        let name_match = gw.name == identifier;
+        if branch_match || name_match {
+            return Ok((
+                repo_info.path,
+                StatusEntry {
+                    name: gw.name,
+                    branch: gw.branch.unwrap_or_else(|| "(detached)".to_string()),
+                    path: gw.path.to_string_lossy().into_owned(),
+                    base_branch: None,
+                    managed: false,
+                },
+            ));
+        }
+    }
+
+    anyhow::bail!("worktree not found: {identifier}")
+}
+
+fn render_deep(cwd: &Path, db: &Database, identifier: &str) -> Result<String> {
+    let (repo_path, entry) = resolve_worktree(cwd, db, identifier)?;
+    let status = compute_git_status(&repo_path, &entry);
+
+    let mut out = String::new();
+    out.push_str(&format!("Branch:       {}\n", entry.branch));
+    out.push_str(&format!("Path:         {}\n", entry.path));
+    if let Some(ref base) = entry.base_branch {
+        out.push_str(&format!("Base:         {base}\n"));
+    }
+    let ab = format_ahead_behind(status.ahead, status.behind);
+    out.push_str(&format!("Ahead/Behind: {ab}\n"));
+    out.push_str(&format!("Status:       {}\n", format_dirty(status.dirty)));
+    if !entry.managed {
+        out.push_str("Managed:      no [unmanaged]\n");
+    }
+
+    Ok(out)
+}
+
+pub fn execute(cwd: &Path, db: &Database, branch: Option<&str>) -> Result<String> {
+    match branch {
+        Some(id) => render_deep(cwd, db, id),
+        None => render_summary_table(
+            cwd,
+            db,
+            crossterm::terminal::size().ok().map(|(c, _)| c as usize),
+        ),
+    }
 }
 
 pub fn execute_json(_cwd: &Path, _db: &Database, _branch: Option<&str>) -> Result<String> {
@@ -240,5 +311,57 @@ mod tests {
         assert!(output.contains("Branch"), "should have Branch header");
         assert!(output.contains("feature-auth"), "should show first worktree");
         assert!(output.contains("fix-bug"), "should show second worktree");
+    }
+
+    #[test]
+    fn deep_mode_errors_for_nonexistent_worktree() {
+        let repo_dir = tempfile::tempdir().unwrap();
+        let _repo = init_repo_with_commit(repo_dir.path());
+        let db = Database::open_in_memory().unwrap();
+
+        let repo_path = repo_dir.path().canonicalize().unwrap();
+        let repo_name = repo_path.file_name().unwrap().to_str().unwrap();
+        db.insert_repo(repo_name, repo_path.to_str().unwrap(), Some("main"))
+            .unwrap();
+
+        let result = render_deep(repo_dir.path(), &db, "nonexistent");
+        assert!(result.is_err(), "should error for nonexistent worktree");
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("not found"),
+            "error should mention 'not found', got: {msg}"
+        );
+    }
+
+    #[test]
+    fn deep_mode_shows_detail_for_managed_worktree() {
+        let repo_dir = tempfile::tempdir().unwrap();
+        let _repo = init_repo_with_commit(repo_dir.path());
+        let db = Database::open_in_memory().unwrap();
+
+        let repo_path = repo_dir.path().canonicalize().unwrap();
+        let repo_name = repo_path.file_name().unwrap().to_str().unwrap();
+        let db_repo = db
+            .insert_repo(repo_name, repo_path.to_str().unwrap(), Some("main"))
+            .unwrap();
+
+        db.insert_worktree(
+            db_repo.id,
+            "feature-auth",
+            "feature/auth",
+            "/tmp/wt/feature-auth",
+            Some("main"),
+        )
+        .unwrap();
+
+        let output =
+            render_deep(repo_dir.path(), &db, "feature-auth").expect("deep should succeed");
+
+        assert!(output.contains("Branch:"), "should show Branch label");
+        assert!(output.contains("feature/auth"), "should show branch name");
+        assert!(output.contains("Path:"), "should show Path label");
+        assert!(output.contains("/tmp/wt/feature-auth"), "should show path");
+        assert!(output.contains("Base:"), "should show Base label");
+        assert!(output.contains("main"), "should show base branch");
     }
 }

--- a/src/cli/commands/status.rs
+++ b/src/cli/commands/status.rs
@@ -249,6 +249,15 @@ fn render_deep(cwd: &Path, db: &Database, identifier: &str) -> Result<String> {
         }
     }
 
+    // Recent commits
+    let commits = git::recent_commits(wt_path, 10).unwrap_or_default();
+    if !commits.is_empty() {
+        out.push_str("\nRecent commits:\n");
+        for c in &commits {
+            out.push_str(&format!("  {} {}\n", c.hash, c.message));
+        }
+    }
+
     Ok(out)
 }
 
@@ -328,6 +337,11 @@ fn build_deep_json(entry: &StatusEntry, status: GitStatus) -> DeepJson {
         .into_iter()
         .map(|f| format!("{} {}", f.status, f.path))
         .collect();
+    let commits = git::recent_commits(wt_path, 10)
+        .unwrap_or_default()
+        .into_iter()
+        .map(|c| format!("{} {}", c.hash, c.message))
+        .collect();
 
     DeepJson {
         name: entry.name.clone(),
@@ -340,7 +354,7 @@ fn build_deep_json(entry: &StatusEntry, status: GitStatus) -> DeepJson {
         status: format_dirty(status.dirty),
         managed: entry.managed,
         changed_files: changed,
-        recent_commits: Vec::new(),
+        recent_commits: commits,
         hook_history: Vec::new(),
     }
 }
@@ -536,6 +550,82 @@ mod tests {
         assert!(
             output.contains("new-file.txt"),
             "should list the changed file, got:\n{output}"
+        );
+    }
+
+    #[test]
+    fn deep_view_includes_recent_commits() {
+        let repo_dir = tempfile::tempdir().unwrap();
+        let repo = init_repo_with_commit(repo_dir.path());
+
+        // Create a branch with an extra commit
+        let wt_parent = tempfile::tempdir().unwrap();
+        let wt_path = wt_parent.path().join("test-commits");
+        let head = repo.head().unwrap().shorthand().unwrap().to_string();
+        let head_commit = repo
+            .find_branch(&head, git2::BranchType::Local)
+            .unwrap()
+            .get()
+            .peel_to_commit()
+            .unwrap();
+        repo.branch("test-commits", &head_commit, false).unwrap();
+        let mut opts = git2::WorktreeAddOptions::new();
+        let branch_ref = repo
+            .find_branch("test-commits", git2::BranchType::Local)
+            .unwrap();
+        opts.reference(Some(branch_ref.get()));
+        repo.worktree("test-commits", &wt_path, Some(&opts))
+            .unwrap();
+
+        // Make a commit in the worktree
+        let wt_repo = git2::Repository::open(&wt_path).unwrap();
+        std::fs::write(wt_path.join("file.txt"), "content").unwrap();
+        let mut index = wt_repo.index().unwrap();
+        index
+            .add_path(std::path::Path::new("file.txt"))
+            .unwrap();
+        index.write().unwrap();
+        let tree_id = index.write_tree().unwrap();
+        let tree = wt_repo.find_tree(tree_id).unwrap();
+        let sig = git2::Signature::now("Test", "test@test.com").unwrap();
+        let parent = wt_repo.head().unwrap().peel_to_commit().unwrap();
+        wt_repo
+            .commit(
+                Some("HEAD"),
+                &sig,
+                &sig,
+                "add file.txt for testing",
+                &tree,
+                &[&parent],
+            )
+            .unwrap();
+
+        let db = Database::open_in_memory().unwrap();
+        let repo_path = repo_dir.path().canonicalize().unwrap();
+        let repo_name = repo_path.file_name().unwrap().to_str().unwrap();
+        let db_repo = db
+            .insert_repo(repo_name, repo_path.to_str().unwrap(), Some(&head))
+            .unwrap();
+        let wt_canonical = wt_path.canonicalize().unwrap();
+        db.insert_worktree(
+            db_repo.id,
+            "test-commits",
+            "test-commits",
+            wt_canonical.to_str().unwrap(),
+            Some(&head),
+        )
+        .unwrap();
+
+        let output =
+            render_deep(repo_dir.path(), &db, "test-commits").expect("deep should succeed");
+
+        assert!(
+            output.contains("Recent commits"),
+            "should have Recent commits section, got:\n{output}"
+        );
+        assert!(
+            output.contains("add file.txt for testing"),
+            "should show commit message, got:\n{output}"
         );
     }
 

--- a/src/cli/commands/status.rs
+++ b/src/cli/commands/status.rs
@@ -1,11 +1,182 @@
-use std::path::Path;
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
 
 use anyhow::Result;
 
-use crate::state::Database;
+use crate::git;
+use crate::output::table::Table;
+use crate::state::{Database, Worktree};
 
-pub fn execute(_cwd: &Path, _db: &Database, _branch: Option<&str>) -> Result<String> {
-    todo!()
+/// A unified worktree entry for status output.
+struct StatusEntry {
+    name: String,
+    branch: String,
+    path: String,
+    base_branch: Option<String>,
+    managed: bool,
+}
+
+/// Fetch all worktrees (managed + unmanaged) for the repo at `cwd`.
+fn fetch_all_worktrees(cwd: &Path, db: &Database) -> Result<(PathBuf, Vec<StatusEntry>)> {
+    let repo_info = git::discover_repo(cwd)?;
+    let repo_path_str = repo_info
+        .path
+        .to_str()
+        .ok_or_else(|| anyhow::anyhow!("repo path is not valid UTF-8"))?;
+
+    let repo = db.get_repo_by_path(repo_path_str)?;
+    let db_worktrees: Vec<Worktree> = match repo {
+        Some(ref r) => db.list_worktrees(r.id)?,
+        None => Vec::new(),
+    };
+
+    let managed_paths: HashSet<PathBuf> = db_worktrees
+        .iter()
+        .filter_map(|wt| Path::new(&wt.path).canonicalize().ok())
+        .collect();
+
+    let mut entries: Vec<StatusEntry> = Vec::new();
+
+    for wt in &db_worktrees {
+        entries.push(StatusEntry {
+            name: wt.name.clone(),
+            branch: wt.branch.clone(),
+            path: wt.path.clone(),
+            base_branch: wt.base_branch.clone(),
+            managed: true,
+        });
+    }
+
+    let git_worktrees = git::list_worktrees(&repo_info.path)?;
+    for gw in git_worktrees {
+        if !managed_paths.contains(&gw.path) {
+            entries.push(StatusEntry {
+                name: gw.name.clone(),
+                branch: gw.branch.unwrap_or_else(|| "(detached)".to_string()),
+                path: gw.path.to_string_lossy().into_owned(),
+                base_branch: None,
+                managed: false,
+            });
+        }
+    }
+
+    Ok((repo_info.path, entries))
+}
+
+/// Git status metadata for a worktree.
+struct GitStatus {
+    ahead: Option<usize>,
+    behind: Option<usize>,
+    dirty: usize,
+}
+
+fn compute_git_status(repo_path: &Path, entry: &StatusEntry) -> GitStatus {
+    let wt_path = Path::new(&entry.path);
+
+    let (ahead, behind) =
+        match git::ahead_behind(repo_path, &entry.branch, entry.base_branch.as_deref()) {
+            Ok(Some((a, b))) => (Some(a), Some(b)),
+            Ok(None) => (None, None),
+            Err(e) => {
+                eprintln!("warning: ahead/behind for '{}': {e}", entry.branch);
+                (None, None)
+            }
+        };
+
+    let dirty = match git::dirty_count(wt_path) {
+        Ok(n) => n,
+        Err(e) => {
+            eprintln!("warning: dirty count for '{}': {e}", wt_path.display());
+            0
+        }
+    };
+
+    GitStatus {
+        ahead,
+        behind,
+        dirty,
+    }
+}
+
+fn format_ahead_behind(ahead: Option<usize>, behind: Option<usize>) -> String {
+    match (ahead, behind) {
+        (Some(a), Some(b)) => format!("+{a}/-{b}"),
+        _ => "-".to_string(),
+    }
+}
+
+fn format_dirty(dirty: usize) -> String {
+    if dirty == 0 {
+        "clean".to_string()
+    } else {
+        format!("~{dirty}")
+    }
+}
+
+fn render_summary_table(
+    cwd: &Path,
+    db: &Database,
+    max_width: Option<usize>,
+) -> Result<String> {
+    let (repo_path, entries) = fetch_all_worktrees(cwd, db)?;
+
+    if entries.is_empty() {
+        return Ok("No worktrees.\n".to_string());
+    }
+
+    let mut table = Table::new(vec![
+        "Name", "Branch", "Status", "Ahead/Behind",
+    ]);
+    let mut unmanaged_rows: Vec<bool> = Vec::new();
+
+    for entry in &entries {
+        let status = compute_git_status(&repo_path, entry);
+        let dirty_str = format_dirty(status.dirty);
+        let ab_str = format_ahead_behind(status.ahead, status.behind);
+        let display_name = if entry.managed {
+            entry.name.clone()
+        } else {
+            format!("{} [unmanaged]", entry.name)
+        };
+        table = table.row(vec![&display_name, &entry.branch, &dirty_str, &ab_str]);
+        unmanaged_rows.push(!entry.managed);
+    }
+
+    if let Some(width) = max_width {
+        table = table.max_width(width);
+    }
+
+    let rendered = table.render();
+
+    let lines: Vec<&str> = rendered.lines().collect();
+    let mut out = String::new();
+    if let Some(header) = lines.first() {
+        out.push_str(header);
+        out.push('\n');
+    }
+    for (i, line) in lines.iter().skip(1).enumerate() {
+        if i < unmanaged_rows.len() && unmanaged_rows[i] {
+            out.push_str("\x1b[2m");
+            out.push_str(line);
+            out.push_str("\x1b[0m");
+        } else {
+            out.push_str(line);
+        }
+        out.push('\n');
+    }
+
+    Ok(out)
+}
+
+pub fn execute(cwd: &Path, db: &Database, branch: Option<&str>) -> Result<String> {
+    if branch.is_some() {
+        todo!("deep status not yet implemented")
+    }
+    render_summary_table(
+        cwd,
+        db,
+        crossterm::terminal::size().ok().map(|(c, _)| c as usize),
+    )
 }
 
 pub fn execute_json(_cwd: &Path, _db: &Database, _branch: Option<&str>) -> Result<String> {
@@ -14,4 +185,60 @@ pub fn execute_json(_cwd: &Path, _db: &Database, _branch: Option<&str>) -> Resul
 
 pub fn execute_porcelain(_cwd: &Path, _db: &Database, _branch: Option<&str>) -> Result<String> {
     todo!()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    fn init_repo_with_commit(dir: &Path) -> git2::Repository {
+        let repo = git2::Repository::init(dir).expect("failed to init repo");
+        {
+            let sig = git2::Signature::now("Test", "test@test.com").unwrap();
+            let tree_id = repo.index().unwrap().write_tree().unwrap();
+            let tree = repo.find_tree(tree_id).unwrap();
+            repo.commit(Some("HEAD"), &sig, &sig, "initial commit", &tree, &[])
+                .unwrap();
+        }
+        repo
+    }
+
+    #[test]
+    fn summary_shows_all_worktrees() {
+        let repo_dir = tempfile::tempdir().unwrap();
+        let _repo = init_repo_with_commit(repo_dir.path());
+        let db = Database::open_in_memory().unwrap();
+
+        let repo_path = repo_dir.path().canonicalize().unwrap();
+        let repo_name = repo_path.file_name().unwrap().to_str().unwrap();
+        let db_repo = db
+            .insert_repo(repo_name, repo_path.to_str().unwrap(), Some("main"))
+            .unwrap();
+
+        db.insert_worktree(
+            db_repo.id,
+            "feature-auth",
+            "feature/auth",
+            "/tmp/wt/feature-auth",
+            Some("main"),
+        )
+        .unwrap();
+        db.insert_worktree(
+            db_repo.id,
+            "fix-bug",
+            "fix/bug",
+            "/tmp/wt/fix-bug",
+            Some("main"),
+        )
+        .unwrap();
+
+        let output =
+            render_summary_table(repo_dir.path(), &db, None).expect("summary should succeed");
+
+        assert!(output.contains("Name"), "should have Name header");
+        assert!(output.contains("Branch"), "should have Branch header");
+        assert!(output.contains("feature-auth"), "should show first worktree");
+        assert!(output.contains("fix-bug"), "should show second worktree");
+    }
 }

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -75,6 +75,55 @@ pub fn changed_files(worktree_path: &Path) -> Result<Vec<ChangedFile>, GitError>
     Ok(files)
 }
 
+/// A recent commit entry.
+#[derive(Debug, Clone, PartialEq)]
+pub struct CommitInfo {
+    pub hash: String,
+    pub message: String,
+}
+
+/// List recent commits on a branch, most recent first.
+///
+/// Opens the repository at `worktree_path` and walks HEAD to collect
+/// up to `limit` commits.
+pub fn recent_commits(worktree_path: &Path, limit: usize) -> Result<Vec<CommitInfo>, GitError> {
+    let repo = git2::Repository::open(worktree_path)
+        .map_err(|e| map_repo_open_error(e, worktree_path))?;
+
+    let head = match repo.head() {
+        Ok(h) => h,
+        Err(_) => return Ok(Vec::new()),
+    };
+    let oid = match head.target() {
+        Some(oid) => oid,
+        None => return Ok(Vec::new()),
+    };
+
+    let mut revwalk = repo.revwalk()?;
+    revwalk.push(oid)?;
+    revwalk.set_sorting(git2::Sort::TIME)?;
+
+    let mut commits = Vec::new();
+    for (i, rev_oid) in revwalk.enumerate() {
+        if i >= limit {
+            break;
+        }
+        let rev_oid = rev_oid?;
+        let commit = repo.find_commit(rev_oid)?;
+        let short_hash = &rev_oid.to_string()[..7];
+        let message = commit
+            .summary()
+            .unwrap_or("(no message)")
+            .to_string();
+        commits.push(CommitInfo {
+            hash: short_hash.to_string(),
+            message,
+        });
+    }
+
+    Ok(commits)
+}
+
 /// Calculate commits ahead/behind for a branch relative to its upstream.
 ///
 /// Checks for an upstream tracking branch first, then falls back to

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -27,6 +27,54 @@ pub fn dirty_count(worktree_path: &Path) -> Result<usize, GitError> {
     Ok(statuses.len())
 }
 
+/// A file with changed status in a worktree.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ChangedFile {
+    pub path: String,
+    pub status: &'static str,
+}
+
+/// List changed files in a worktree with their status labels.
+///
+/// Returns files that are modified, staged, new, deleted, renamed, or
+/// typechanged. Each entry includes the file path and a human-readable
+/// status string.
+pub fn changed_files(worktree_path: &Path) -> Result<Vec<ChangedFile>, GitError> {
+    let repo = git2::Repository::open(worktree_path)
+        .map_err(|e| map_repo_open_error(e, worktree_path))?;
+
+    let statuses = repo.statuses(Some(
+        git2::StatusOptions::new()
+            .include_untracked(true)
+            .recurse_untracked_dirs(true),
+    ))?;
+
+    let mut files = Vec::with_capacity(statuses.len());
+    for entry in statuses.iter() {
+        let path = entry.path().unwrap_or("(unknown)").to_string();
+        let s = entry.status();
+        let label = if s.is_index_new() || s.is_wt_new() {
+            "new"
+        } else if s.is_index_deleted() || s.is_wt_deleted() {
+            "deleted"
+        } else if s.is_index_renamed() || s.is_wt_renamed() {
+            "renamed"
+        } else if s.is_index_modified() || s.is_wt_modified() {
+            "modified"
+        } else if s.is_index_typechange() || s.is_wt_typechange() {
+            "typechange"
+        } else {
+            "unknown"
+        };
+        files.push(ChangedFile {
+            path,
+            status: label,
+        });
+    }
+
+    Ok(files)
+}
+
 /// Calculate commits ahead/behind for a branch relative to its upstream.
 ///
 /// Checks for an upstream tracking branch first, then falls back to

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -110,7 +110,8 @@ pub fn recent_commits(worktree_path: &Path, limit: usize) -> Result<Vec<CommitIn
         }
         let rev_oid = rev_oid?;
         let commit = repo.find_commit(rev_oid)?;
-        let short_hash = &rev_oid.to_string()[..7];
+        let oid_str = rev_oid.to_string();
+        let short_hash = &oid_str[..oid_str.len().min(7)];
         let message = commit
             .summary()
             .unwrap_or("(no message)")

--- a/src/main.rs
+++ b/src/main.rs
@@ -166,7 +166,7 @@ impl Cli {
 
 fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
-    let _output_config = cli.output_config();
+    let output_config = cli.output_config();
 
     if cli.should_launch_tui(
         std::io::stdin().is_terminal(),
@@ -188,7 +188,9 @@ fn main() -> anyhow::Result<()> {
         Some(Commands::Tag { branch, tags }) => run_tag(&branch, &tags),
         Some(Commands::Open { branch }) => run_open(&branch),
         Some(Commands::List { tag }) => run_list(tag.as_deref(), json, porcelain),
-        Some(Commands::Status { branch }) => run_status(branch.as_deref(), json, porcelain),
+        Some(Commands::Status { branch }) => {
+            run_status(branch.as_deref(), json, porcelain, output_config.should_color())
+        }
         Some(Commands::Init { force }) => run_init(force),
         Some(Commands::ShellInit { shell }) => {
             print!("{}", cli::commands::shell_init::generate(shell));
@@ -444,7 +446,12 @@ fn run_list(tag: Option<&str>, json: bool, porcelain: bool) -> anyhow::Result<()
     Ok(())
 }
 
-fn run_status(branch: Option<&str>, json: bool, porcelain: bool) -> anyhow::Result<()> {
+fn run_status(
+    branch: Option<&str>,
+    json: bool,
+    porcelain: bool,
+    use_color: bool,
+) -> anyhow::Result<()> {
     let cwd = std::env::current_dir().context("failed to determine current directory")?;
     let db_path = paths::data_dir()?.join("trench.db");
     let db = state::Database::open(&db_path)?;
@@ -454,7 +461,7 @@ fn run_status(branch: Option<&str>, json: bool, porcelain: bool) -> anyhow::Resu
     } else if porcelain {
         cli::commands::status::execute_porcelain(&cwd, &db, branch)
     } else {
-        cli::commands::status::execute(&cwd, &db, branch)
+        cli::commands::status::execute(&cwd, &db, branch, use_color)
     };
 
     match result {

--- a/src/main.rs
+++ b/src/main.rs
@@ -449,19 +449,32 @@ fn run_status(branch: Option<&str>, json: bool, porcelain: bool) -> anyhow::Resu
     let db_path = paths::data_dir()?.join("trench.db");
     let db = state::Database::open(&db_path)?;
 
-    let output = if json {
-        cli::commands::status::execute_json(&cwd, &db, branch)?
+    let result = if json {
+        cli::commands::status::execute_json(&cwd, &db, branch)
     } else if porcelain {
-        cli::commands::status::execute_porcelain(&cwd, &db, branch)?
+        cli::commands::status::execute_porcelain(&cwd, &db, branch)
     } else {
-        cli::commands::status::execute(&cwd, &db, branch)?
+        cli::commands::status::execute(&cwd, &db, branch)
     };
-    if output.ends_with('\n') {
-        print!("{output}");
-    } else {
-        println!("{output}");
+
+    match result {
+        Ok(output) => {
+            if output.ends_with('\n') {
+                print!("{output}");
+            } else {
+                println!("{output}");
+            }
+            Ok(())
+        }
+        Err(e) => {
+            let msg = e.to_string();
+            if msg.contains("not found") {
+                eprintln!("error: {e}");
+                std::process::exit(2);
+            }
+            Err(e)
+        }
     }
-    Ok(())
 }
 
 fn run_init(force: bool) -> anyhow::Result<()> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -616,6 +616,27 @@ mod tests {
     }
 
     #[test]
+    fn status_subcommand_accepts_optional_branch() {
+        // No branch → summary mode
+        let cli = Cli::try_parse_from(["trench", "status"])
+            .expect("status without branch should succeed");
+        match cli.command {
+            Some(Commands::Status { branch }) => assert!(branch.is_none()),
+            _ => panic!("expected Commands::Status"),
+        }
+
+        // With branch → deep mode
+        let cli = Cli::try_parse_from(["trench", "status", "my-feature"])
+            .expect("status with branch should succeed");
+        match cli.command {
+            Some(Commands::Status { branch }) => {
+                assert_eq!(branch.as_deref(), Some("my-feature"));
+            }
+            _ => panic!("expected Commands::Status"),
+        }
+    }
+
+    #[test]
     fn create_subcommand_requires_branch() {
         let result = Cli::try_parse_from(["trench", "create"]);
         assert!(result.is_err(), "create without branch should fail");

--- a/src/main.rs
+++ b/src/main.rs
@@ -99,7 +99,11 @@ enum Commands {
         tag: Option<String>,
     },
     /// Show worktree status
-    Status,
+    Status {
+        /// Branch name or sanitized name for deep status view.
+        /// Omit for summary of all worktrees.
+        branch: Option<String>,
+    },
     /// Sync worktree with base branch
     Sync,
     /// View event log
@@ -184,6 +188,7 @@ fn main() -> anyhow::Result<()> {
         Some(Commands::Tag { branch, tags }) => run_tag(&branch, &tags),
         Some(Commands::Open { branch }) => run_open(&branch),
         Some(Commands::List { tag }) => run_list(tag.as_deref(), json, porcelain),
+        Some(Commands::Status { branch }) => run_status(branch.as_deref(), json, porcelain),
         Some(Commands::Init { force }) => run_init(force),
         Some(Commands::ShellInit { shell }) => {
             print!("{}", cli::commands::shell_init::generate(shell));
@@ -430,6 +435,26 @@ fn run_list(tag: Option<&str>, json: bool, porcelain: bool) -> anyhow::Result<()
         cli::commands::list::execute_porcelain(&cwd, &db, tag)?
     } else {
         cli::commands::list::execute(&cwd, &db, tag)?
+    };
+    if output.ends_with('\n') {
+        print!("{output}");
+    } else {
+        println!("{output}");
+    }
+    Ok(())
+}
+
+fn run_status(branch: Option<&str>, json: bool, porcelain: bool) -> anyhow::Result<()> {
+    let cwd = std::env::current_dir().context("failed to determine current directory")?;
+    let db_path = paths::data_dir()?.join("trench.db");
+    let db = state::Database::open(&db_path)?;
+
+    let output = if json {
+        cli::commands::status::execute_json(&cwd, &db, branch)?
+    } else if porcelain {
+        cli::commands::status::execute_porcelain(&cwd, &db, branch)?
+    } else {
+        cli::commands::status::execute(&cwd, &db, branch)?
     };
     if output.ends_with('\n') {
         print!("{output}");

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -60,6 +60,15 @@ pub struct WorktreeUpdate {
     pub removed_at: Option<Option<i64>>,
 }
 
+/// An event record from the events table.
+#[derive(Debug, Clone)]
+pub struct Event {
+    pub id: i64,
+    pub event_type: String,
+    pub payload: Option<String>,
+    pub created_at: i64,
+}
+
 /// Core database handle wrapping a SQLite connection with migrations applied.
 #[derive(Debug)]
 pub struct Database {

--- a/src/state/queries.rs
+++ b/src/state/queries.rs
@@ -1,7 +1,7 @@
 use anyhow::{bail, Context, Result};
 use rusqlite::OptionalExtension;
 
-use super::{unix_epoch_secs, Database, Repo, Worktree, WorktreeUpdate};
+use super::{unix_epoch_secs, Database, Event, Repo, Worktree, WorktreeUpdate};
 
 fn now() -> i64 {
     unix_epoch_secs() as i64
@@ -408,5 +408,33 @@ impl Database {
             .query_row(sql, param_refs.as_slice(), |row| row.get(0))
             .context("failed to count events")?;
         Ok(count)
+    }
+
+    /// List events for a worktree, most recent first, up to `limit`.
+    pub fn list_events(&self, worktree_id: i64, limit: usize) -> Result<Vec<Event>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id, event_type, payload, created_at
+             FROM events
+             WHERE worktree_id = ?1
+             ORDER BY created_at DESC
+             LIMIT ?2",
+        ).context("failed to prepare list_events query")?;
+
+        let rows = stmt
+            .query_map(rusqlite::params![worktree_id, limit as i64], |row| {
+                Ok(Event {
+                    id: row.get(0)?,
+                    event_type: row.get(1)?,
+                    payload: row.get(2)?,
+                    created_at: row.get(3)?,
+                })
+            })
+            .context("failed to list events")?;
+
+        let mut events = Vec::new();
+        for row in rows {
+            events.push(row.context("failed to read event row")?);
+        }
+        Ok(events)
     }
 }


### PR DESCRIPTION
Closes #32

## Summary
Implements `trench status` command with two modes: summary mode showing all worktrees in a compact table with branch, status, and ahead/behind info, and deep mode (`trench status <branch>`) showing detailed view of a single worktree including changed files, recent commits, and hook execution history. Both modes support `--json` and `--porcelain` output formats.

## User Stories Addressed
- US-5: See all worktrees (including manually-created ones) with ahead/behind counts

## Automated Testing
- Total tests added: 9
- Tests passing: 9
- Tests failing: 0
- `cargo clippy`: pass (no new warnings)
- `cargo test`: pass (349 pass, 2 pre-existing remote branch test failures unrelated to this PR)

## UAT Checklist
- [ ] `trench status` → compact table with all worktrees, status, ahead/behind
- [ ] `trench status <existing-branch>` → deep view with branch, path, base, ahead/behind, changed files, recent commits, hook history
- [ ] `trench status nonexistent` → error message with exit code 2
- [ ] `trench status --json` → JSON array of worktree objects
- [ ] `trench status <branch> --json` → single JSON object with changed_files, recent_commits, hook_history arrays
- [ ] `trench status --porcelain` → colon-separated lines for piping
- [ ] Unmanaged worktrees (created outside trench) appear with `[unmanaged]` badge and dimmed styling
- [ ] Create a worktree, modify files, then `trench status <branch>` → changed files section lists modifications
- [ ] Create a worktree, make commits, then `trench status <branch>` → recent commits section shows commit messages

## Known Issues
- Two pre-existing test failures in `git::tests::delete_remote_branch_deletes_branch_on_remote` and `git::tests::create_worktree_succeeds_after_remote_branch_deleted` — these test remote git operations and fail in CI environments without remote access. Not related to this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `status` command with summary and detailed views for worktrees.
  * Detailed view shows changed files, recent commits, and hook/event history.
  * Shows git sync info (ahead/behind) and dirty counts per worktree.
  * Supports standard, JSON, and porcelain output modes, plus an optional branch argument.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->