### PR TITLE
feat: lazy adoption — unmanaged → managed on first interaction

### DIFF
--- a/src/adopt.rs
+++ b/src/adopt.rs
@@ -1,0 +1,131 @@
+use anyhow::Result;
+
+use crate::git::{self, RepoInfo};
+use crate::paths;
+use crate::state::{Database, Repo, Worktree};
+
+/// Ensure the repo exists in the DB, inserting it if needed.
+fn ensure_repo(db: &Database, repo_info: &RepoInfo) -> Result<Repo> {
+    let repo_path_str = repo_info
+        .path
+        .to_str()
+        .ok_or_else(|| anyhow::anyhow!("repo path is not valid UTF-8"))?;
+
+    if let Some(repo) = db.get_repo_by_path(repo_path_str)? {
+        return Ok(repo);
+    }
+
+    db.insert_repo(
+        &repo_info.name,
+        repo_path_str,
+        Some(&repo_info.default_branch),
+    )
+}
+
+/// Resolve a worktree by identifier, adopting it if unmanaged.
+///
+/// Tries the DB first (exact match, then sanitized fallback). If not found,
+/// falls back to git worktree discovery. If found via git, silently adopts
+/// the worktree (inserts into DB with `adopted_at` set).
+///
+/// Returns the repo and worktree records.
+pub fn resolve_or_adopt(
+    identifier: &str,
+    repo_info: &RepoInfo,
+    db: &Database,
+) -> Result<(Repo, Worktree)> {
+    let repo_path_str = repo_info
+        .path
+        .to_str()
+        .ok_or_else(|| anyhow::anyhow!("repo path is not valid UTF-8"))?;
+
+    // Try DB first
+    if let Some(repo) = db.get_repo_by_path(repo_path_str)? {
+        if let Some(wt) = db.find_worktree_by_identifier(repo.id, identifier)? {
+            return Ok((repo, wt));
+        }
+        let sanitized = paths::sanitize_branch(identifier);
+        if sanitized != identifier {
+            if let Some(wt) = db.find_worktree_by_identifier(repo.id, &sanitized)? {
+                return Ok((repo, wt));
+            }
+        }
+    }
+
+    // Fall back to git worktrees
+    let git_worktrees = git::list_worktrees(&repo_info.path)?;
+    let sanitized = paths::sanitize_branch(identifier);
+
+    for gw in &git_worktrees {
+        let branch_match = gw.branch.as_deref() == Some(identifier);
+        let name_match = gw.name == identifier || gw.name == sanitized;
+        let sanitized_branch_match = gw
+            .branch
+            .as_deref()
+            .is_some_and(|b| paths::sanitize_branch(b) == sanitized);
+
+        if branch_match || name_match || sanitized_branch_match {
+            let repo = ensure_repo(db, repo_info)?;
+            let branch = gw
+                .branch
+                .clone()
+                .unwrap_or_else(|| identifier.to_string());
+            let name = paths::sanitize_branch(&branch);
+            let path = gw.path.to_string_lossy();
+
+            let wt = db.adopt_worktree(repo.id, &name, &branch, &path, None)?;
+            return Ok((repo, wt));
+        }
+    }
+
+    anyhow::bail!("worktree not found: {identifier}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::Database;
+    use std::path::Path;
+
+    fn init_repo_with_commit(dir: &Path) -> git2::Repository {
+        let repo = git2::Repository::init(dir).expect("failed to init repo");
+        {
+            let sig = git2::Signature::now("Test", "test@test.com").unwrap();
+            let tree_id = repo.index().unwrap().write_tree().unwrap();
+            let tree = repo.find_tree(tree_id).unwrap();
+            repo.commit(Some("HEAD"), &sig, &sig, "initial commit", &tree, &[])
+                .unwrap();
+        }
+        repo
+    }
+
+    #[test]
+    fn resolve_or_adopt_returns_existing_managed_worktree() {
+        let repo_dir = tempfile::tempdir().unwrap();
+        let _repo = init_repo_with_commit(repo_dir.path());
+        let db = Database::open_in_memory().unwrap();
+
+        let repo_path = repo_dir.path().canonicalize().unwrap();
+        let repo_path_str = repo_path.to_str().unwrap();
+        let db_repo = db
+            .insert_repo("my-project", repo_path_str, Some("main"))
+            .unwrap();
+        let inserted = db
+            .insert_worktree(
+                db_repo.id,
+                "my-feature",
+                "my-feature",
+                "/wt/my-feature",
+                Some("main"),
+            )
+            .unwrap();
+
+        let repo_info = git::discover_repo(repo_dir.path()).unwrap();
+        let (repo, wt) =
+            resolve_or_adopt("my-feature", &repo_info, &db).expect("should resolve existing");
+
+        assert_eq!(repo.id, db_repo.id);
+        assert_eq!(wt.id, inserted.id);
+        assert!(wt.adopted_at.is_none(), "existing worktree should not be adopted");
+    }
+}

--- a/src/adopt.rs
+++ b/src/adopt.rs
@@ -176,4 +176,49 @@ mod tests {
             .unwrap();
         assert!(found.is_some(), "adopted worktree should be findable in DB");
     }
+
+    #[test]
+    fn resolve_or_adopt_creates_repo_when_not_in_db() {
+        let repo_dir = tempfile::tempdir().unwrap();
+        let git_repo = init_repo_with_commit(repo_dir.path());
+        let db = Database::open_in_memory().unwrap();
+
+        // Do NOT insert repo into DB — repo is completely unknown to trench
+
+        // Create a git worktree manually
+        let wt_dir = tempfile::tempdir().unwrap();
+        let wt_path = wt_dir.path().join("new-feature");
+        git_repo
+            .branch(
+                "new-feature",
+                &git_repo.head().unwrap().peel_to_commit().unwrap(),
+                false,
+            )
+            .unwrap();
+        let branch_ref = git_repo
+            .find_branch("new-feature", git2::BranchType::Local)
+            .unwrap();
+        let mut opts = git2::WorktreeAddOptions::new();
+        opts.reference(Some(branch_ref.get()));
+        git_repo
+            .worktree("new-feature", &wt_path, Some(&opts))
+            .unwrap();
+
+        let repo_info = git::discover_repo(repo_dir.path()).unwrap();
+        let (repo, wt) =
+            resolve_or_adopt("new-feature", &repo_info, &db).expect("should create repo and adopt");
+
+        // Repo should now exist in DB
+        assert!(repo.id > 0);
+        let repo_path_str = repo_dir.path().canonicalize().unwrap();
+        let found_repo = db
+            .get_repo_by_path(repo_path_str.to_str().unwrap())
+            .unwrap();
+        assert!(found_repo.is_some(), "repo should be created in DB");
+
+        // Worktree should be adopted
+        assert!(wt.adopted_at.is_some());
+        assert!(wt.managed);
+        assert_eq!(wt.branch, "new-feature");
+    }
 }

--- a/src/adopt.rs
+++ b/src/adopt.rs
@@ -221,4 +221,67 @@ mod tests {
         assert!(wt.managed);
         assert_eq!(wt.branch, "new-feature");
     }
+
+    #[test]
+    fn resolve_or_adopt_not_found_returns_error() {
+        let repo_dir = tempfile::tempdir().unwrap();
+        let _repo = init_repo_with_commit(repo_dir.path());
+        let db = Database::open_in_memory().unwrap();
+
+        let repo_path = repo_dir.path().canonicalize().unwrap();
+        let repo_path_str = repo_path.to_str().unwrap();
+        db.insert_repo("my-project", repo_path_str, Some("main"))
+            .unwrap();
+
+        let repo_info = git::discover_repo(repo_dir.path()).unwrap();
+        let result = resolve_or_adopt("nonexistent", &repo_info, &db);
+        let err = result.expect_err("should error for nonexistent worktree");
+        assert!(
+            err.to_string().contains("not found"),
+            "error should mention 'not found', got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn resolve_or_adopt_idempotent_on_already_adopted() {
+        let repo_dir = tempfile::tempdir().unwrap();
+        let git_repo = init_repo_with_commit(repo_dir.path());
+        let db = Database::open_in_memory().unwrap();
+
+        let repo_path = repo_dir.path().canonicalize().unwrap();
+        let repo_path_str = repo_path.to_str().unwrap();
+        db.insert_repo("my-project", repo_path_str, Some("main"))
+            .unwrap();
+
+        // Create a git worktree manually
+        let wt_dir = tempfile::tempdir().unwrap();
+        let wt_path = wt_dir.path().join("idempotent-wt");
+        git_repo
+            .branch(
+                "idempotent-wt",
+                &git_repo.head().unwrap().peel_to_commit().unwrap(),
+                false,
+            )
+            .unwrap();
+        let branch_ref = git_repo
+            .find_branch("idempotent-wt", git2::BranchType::Local)
+            .unwrap();
+        let mut opts = git2::WorktreeAddOptions::new();
+        opts.reference(Some(branch_ref.get()));
+        git_repo
+            .worktree("idempotent-wt", &wt_path, Some(&opts))
+            .unwrap();
+
+        let repo_info = git::discover_repo(repo_dir.path()).unwrap();
+
+        // First call: adopts
+        let (_, wt1) = resolve_or_adopt("idempotent-wt", &repo_info, &db).unwrap();
+        assert!(wt1.adopted_at.is_some());
+
+        // Second call: returns same DB record (no re-adoption)
+        let (_, wt2) = resolve_or_adopt("idempotent-wt", &repo_info, &db).unwrap();
+        assert_eq!(wt2.id, wt1.id, "should return same worktree");
+        assert_eq!(wt2.adopted_at, wt1.adopted_at, "adopted_at should not change");
+    }
 }

--- a/src/adopt.rs
+++ b/src/adopt.rs
@@ -128,4 +128,52 @@ mod tests {
         assert_eq!(wt.id, inserted.id);
         assert!(wt.adopted_at.is_none(), "existing worktree should not be adopted");
     }
+
+    #[test]
+    fn resolve_or_adopt_adopts_unmanaged_git_worktree() {
+        let repo_dir = tempfile::tempdir().unwrap();
+        let git_repo = init_repo_with_commit(repo_dir.path());
+        let db = Database::open_in_memory().unwrap();
+
+        // Register repo in DB but NOT the worktree
+        let repo_path = repo_dir.path().canonicalize().unwrap();
+        let repo_path_str = repo_path.to_str().unwrap();
+        db.insert_repo("my-project", repo_path_str, Some("main"))
+            .unwrap();
+
+        // Create a git worktree manually (not via trench)
+        let wt_dir = tempfile::tempdir().unwrap();
+        let wt_path = wt_dir.path().join("ext-feature");
+        git_repo
+            .branch(
+                "ext-feature",
+                &git_repo.head().unwrap().peel_to_commit().unwrap(),
+                false,
+            )
+            .unwrap();
+        let branch_ref = git_repo
+            .find_branch("ext-feature", git2::BranchType::Local)
+            .unwrap();
+        let mut opts = git2::WorktreeAddOptions::new();
+        opts.reference(Some(branch_ref.get()));
+        git_repo
+            .worktree("ext-feature", &wt_path, Some(&opts))
+            .unwrap();
+
+        // resolve_or_adopt should find via git and adopt
+        let repo_info = git::discover_repo(repo_dir.path()).unwrap();
+        let (_, wt) =
+            resolve_or_adopt("ext-feature", &repo_info, &db).expect("should adopt unmanaged");
+
+        assert!(wt.adopted_at.is_some(), "should have adopted_at set");
+        assert!(wt.managed, "should be marked as managed");
+        assert_eq!(wt.branch, "ext-feature");
+
+        // Verify it's now in the DB
+        let db_repo = db.get_repo_by_path(repo_path_str).unwrap().unwrap();
+        let found = db
+            .find_worktree_by_identifier(db_repo.id, "ext-feature")
+            .unwrap();
+        assert!(found.is_some(), "adopted worktree should be findable in DB");
+    }
 }

--- a/src/cli/commands/mod.rs
+++ b/src/cli/commands/mod.rs
@@ -7,4 +7,5 @@ pub mod remove;
 pub mod shell_init;
 pub mod status;
 pub mod switch;
+pub mod sync;
 pub mod tag;

--- a/src/cli/commands/remove.rs
+++ b/src/cli/commands/remove.rs
@@ -1,9 +1,8 @@
 use std::path::Path;
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result};
 
 use crate::git;
-use crate::paths;
 use crate::state::Database;
 
 /// Result of a worktree removal.
@@ -28,32 +27,7 @@ pub struct RemoveResult {
 pub fn execute(identifier: &str, cwd: &Path, db: &Database, prune: bool) -> Result<RemoveResult> {
     let repo_info = git::discover_repo(cwd)?;
 
-    let repo_path_str = repo_info
-        .path
-        .to_str()
-        .ok_or_else(|| anyhow::anyhow!("repo path is not valid UTF-8"))?;
-
-    let repo = db
-        .get_repo_by_path(repo_path_str)?
-        .ok_or_else(|| anyhow::anyhow!("repository not tracked by trench"))?;
-
-    // Try the identifier as-is first, then try sanitizing it
-    let wt = match db.find_worktree_by_identifier(repo.id, identifier)? {
-        Some(wt) => Some(wt),
-        None => {
-            let sanitized = paths::sanitize_branch(identifier);
-            if sanitized != identifier {
-                db.find_worktree_by_identifier(repo.id, &sanitized)?
-            } else {
-                None
-            }
-        }
-    };
-
-    let wt = match wt {
-        Some(wt) => wt,
-        None => bail!("worktree not found: {identifier}"),
-    };
+    let (repo, wt) = crate::adopt::resolve_or_adopt(identifier, &repo_info, db)?;
 
     let worktree_path = Path::new(&wt.path);
 
@@ -347,6 +321,64 @@ mod tests {
 
         // Verify: worktree directory is gone
         assert!(!create_result.path.exists(), "worktree directory should be deleted");
+    }
+
+    #[test]
+    fn remove_adopts_unmanaged_worktree_before_removing() {
+        let repo_dir = tempfile::tempdir().unwrap();
+        let git_repo = init_repo_with_commit(repo_dir.path());
+        let db_dir = tempfile::tempdir().unwrap();
+        let db = Database::open(&db_dir.path().join("test.db")).unwrap();
+
+        // Register repo in DB but NOT the worktree
+        let repo_path = repo_dir.path().canonicalize().unwrap();
+        let repo_path_str = repo_path.to_str().unwrap();
+        db.insert_repo("my-project", repo_path_str, Some("main"))
+            .unwrap();
+
+        // Create a git worktree manually
+        let wt_dir = tempfile::tempdir().unwrap();
+        let wt_path = wt_dir.path().join("unmanaged-rm");
+        git_repo
+            .branch(
+                "unmanaged-rm",
+                &git_repo.head().unwrap().peel_to_commit().unwrap(),
+                false,
+            )
+            .unwrap();
+        let branch_ref = git_repo
+            .find_branch("unmanaged-rm", git2::BranchType::Local)
+            .unwrap();
+        let mut opts = git2::WorktreeAddOptions::new();
+        opts.reference(Some(branch_ref.get()));
+        git_repo
+            .worktree("unmanaged-rm", &wt_path, Some(&opts))
+            .unwrap();
+        assert!(wt_path.exists(), "worktree should exist on disk");
+
+        // Remove the unmanaged worktree — should adopt then remove
+        let result = execute("unmanaged-rm", repo_dir.path(), &db, false)
+            .expect("remove of unmanaged worktree should succeed");
+        assert_eq!(result.name, "unmanaged-rm");
+
+        // Verify worktree was adopted (has adopted_at) and removed (has removed_at)
+        let db_repo = db.get_repo_by_path(repo_path_str).unwrap().unwrap();
+        // Check via raw query since find_worktree_by_identifier excludes removed
+        let wt_count: i64 = db.conn_for_test().query_row(
+            "SELECT COUNT(*) FROM worktrees WHERE repo_id = ?1 AND name = 'unmanaged-rm'",
+            rusqlite::params![db_repo.id],
+            |row| row.get(0),
+        ).unwrap();
+        assert_eq!(wt_count, 1, "worktree should exist in DB");
+
+        // Check adopted_at and removed_at via raw query
+        let (adopted_at, removed_at): (Option<i64>, Option<i64>) = db.conn_for_test().query_row(
+            "SELECT adopted_at, removed_at FROM worktrees WHERE repo_id = ?1 AND name = 'unmanaged-rm'",
+            rusqlite::params![db_repo.id],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        ).unwrap();
+        assert!(adopted_at.is_some(), "adopted_at should be set");
+        assert!(removed_at.is_some(), "removed_at should be set");
     }
 
     #[test]

--- a/src/cli/commands/remove.rs
+++ b/src/cli/commands/remove.rs
@@ -2,8 +2,8 @@ use std::path::Path;
 
 use anyhow::{Context, Result};
 
-use crate::git;
-use crate::state::Database;
+use crate::git::{self, RepoInfo};
+use crate::state::{Database, Repo, Worktree};
 
 /// Result of a worktree removal.
 #[derive(Debug)]
@@ -26,9 +26,21 @@ pub struct RemoveResult {
 /// branch was not found (non-fatal).
 pub fn execute(identifier: &str, cwd: &Path, db: &Database, prune: bool) -> Result<RemoveResult> {
     let repo_info = git::discover_repo(cwd)?;
-
     let (repo, wt) = crate::adopt::resolve_or_adopt(identifier, &repo_info, db)?;
+    execute_resolved(&repo, &wt, &repo_info, db, prune)
+}
 
+/// Execute removal with pre-resolved worktree data.
+///
+/// Use this when the caller has already resolved the worktree (e.g. for
+/// the confirmation prompt) to avoid a redundant DB/git round-trip.
+pub fn execute_resolved(
+    repo: &Repo,
+    wt: &Worktree,
+    repo_info: &RepoInfo,
+    db: &Database,
+    prune: bool,
+) -> Result<RemoveResult> {
     let worktree_path = Path::new(&wt.path);
 
     // Remove worktree from disk and prune git references
@@ -108,7 +120,10 @@ mod tests {
             &db,
         )
         .expect("create should succeed");
-        assert!(create_result.path.exists(), "worktree should exist after create");
+        assert!(
+            create_result.path.exists(),
+            "worktree should exist after create"
+        );
 
         // Capture the worktree ID before removal
         let repo_path_str = repo_dir.path().canonicalize().unwrap();
@@ -123,26 +138,30 @@ mod tests {
         let wt_id = wt_before.id;
 
         // Remove it
-        let result = execute("my-feature", repo_dir.path(), &db, false)
-            .expect("remove should succeed");
+        let result =
+            execute("my-feature", repo_dir.path(), &db, false).expect("remove should succeed");
         assert_eq!(result.name, "my-feature");
 
         // Verify: directory is gone
-        assert!(!create_result.path.exists(), "worktree directory should be deleted");
+        assert!(
+            !create_result.path.exists(),
+            "worktree directory should be deleted"
+        );
 
         // Verify: DB record has removed_at set
         let wt = db
             .get_worktree(wt_id)
             .unwrap()
             .expect("worktree record should still exist in DB");
-        assert!(
-            wt.removed_at.is_some(),
-            "removed_at should be set"
-        );
+        assert!(wt.removed_at.is_some(), "removed_at should be set");
 
         // list_worktrees should no longer include the removed worktree
         let worktrees = db.list_worktrees(db_repo.id).unwrap();
-        assert_eq!(worktrees.len(), 0, "removed worktree should not appear in list");
+        assert_eq!(
+            worktrees.len(),
+            0,
+            "removed worktree should not appear in list"
+        );
 
         // Verify: "removed" event was inserted
         let event_count = db.count_events(wt_id, Some("removed")).unwrap();
@@ -173,19 +192,27 @@ mod tests {
 
         // Update the DB branch to have a slash (simulating feature/auth → feature-auth mapping)
         let repo_path_str = repo_dir.path().canonicalize().unwrap();
-        let db_repo = db.get_repo_by_path(repo_path_str.to_str().unwrap()).unwrap().unwrap();
+        let db_repo = db
+            .get_repo_by_path(repo_path_str.to_str().unwrap())
+            .unwrap()
+            .unwrap();
         let worktrees = db.list_worktrees(db_repo.id).unwrap();
         // Directly update branch in DB to simulate slashed branch
-        db.conn_for_test().execute(
-            "UPDATE worktrees SET branch = 'feature/auth' WHERE id = ?1",
-            rusqlite::params![worktrees[0].id],
-        ).unwrap();
+        db.conn_for_test()
+            .execute(
+                "UPDATE worktrees SET branch = 'feature/auth' WHERE id = ?1",
+                rusqlite::params![worktrees[0].id],
+            )
+            .unwrap();
 
         // Remove using the original branch name (feature/auth)
         let result = execute("feature/auth", repo_dir.path(), &db, false)
             .expect("remove by branch name should succeed");
         assert_eq!(result.name, "feature-auth");
-        assert!(!create_result.path.exists(), "worktree directory should be deleted");
+        assert!(
+            !create_result.path.exists(),
+            "worktree directory should be deleted"
+        );
     }
 
     #[test]
@@ -210,7 +237,10 @@ mod tests {
         let result = execute("feature-auth", repo_dir.path(), &db, false)
             .expect("remove by sanitized name should succeed");
         assert_eq!(result.name, "feature-auth");
-        assert!(!create_result.path.exists(), "worktree directory should be deleted");
+        assert!(
+            !create_result.path.exists(),
+            "worktree directory should be deleted"
+        );
     }
 
     /// Helper: create a bare remote, clone it, and return (clone_path, remote_dir).
@@ -257,10 +287,7 @@ mod tests {
         {
             let mut origin = clone.find_remote("origin").unwrap();
             origin
-                .push(
-                    &["refs/heads/prune-me:refs/heads/prune-me"],
-                    None,
-                )
+                .push(&["refs/heads/prune-me:refs/heads/prune-me"], None)
                 .unwrap();
         }
         // Fetch to update remote-tracking refs
@@ -272,7 +299,9 @@ mod tests {
         // Verify the remote branch exists on the bare remote
         let remote_repo = git2::Repository::open_bare(remote_dir.path()).unwrap();
         assert!(
-            remote_repo.find_branch("prune-me", git2::BranchType::Local).is_ok(),
+            remote_repo
+                .find_branch("prune-me", git2::BranchType::Local)
+                .is_ok(),
             "branch should exist on remote before prune"
         );
 
@@ -283,13 +312,18 @@ mod tests {
         assert!(result.pruned_remote, "should have pruned remote branch");
 
         // Verify: worktree directory is gone
-        assert!(!create_result.path.exists(), "worktree directory should be deleted");
+        assert!(
+            !create_result.path.exists(),
+            "worktree directory should be deleted"
+        );
 
         // Verify: remote branch is gone
         // Reopen the bare remote to get fresh state
         let remote_repo = git2::Repository::open_bare(remote_dir.path()).unwrap();
         assert!(
-            remote_repo.find_branch("prune-me", git2::BranchType::Local).is_err(),
+            remote_repo
+                .find_branch("prune-me", git2::BranchType::Local)
+                .is_err(),
             "branch should be deleted on remote after prune"
         );
     }
@@ -317,10 +351,16 @@ mod tests {
         let result = execute("no-remote", clone_dir.path(), &db, true)
             .expect("remove with prune should succeed even without remote branch");
         assert_eq!(result.name, "no-remote");
-        assert!(!result.pruned_remote, "should NOT have pruned remote branch");
+        assert!(
+            !result.pruned_remote,
+            "should NOT have pruned remote branch"
+        );
 
         // Verify: worktree directory is gone
-        assert!(!create_result.path.exists(), "worktree directory should be deleted");
+        assert!(
+            !create_result.path.exists(),
+            "worktree directory should be deleted"
+        );
     }
 
     #[test]
@@ -364,11 +404,14 @@ mod tests {
         // Verify worktree was adopted (has adopted_at) and removed (has removed_at)
         let db_repo = db.get_repo_by_path(repo_path_str).unwrap().unwrap();
         // Check via raw query since find_worktree_by_identifier excludes removed
-        let wt_count: i64 = db.conn_for_test().query_row(
-            "SELECT COUNT(*) FROM worktrees WHERE repo_id = ?1 AND name = 'unmanaged-rm'",
-            rusqlite::params![db_repo.id],
-            |row| row.get(0),
-        ).unwrap();
+        let wt_count: i64 = db
+            .conn_for_test()
+            .query_row(
+                "SELECT COUNT(*) FROM worktrees WHERE repo_id = ?1 AND name = 'unmanaged-rm'",
+                rusqlite::params![db_repo.id],
+                |row| row.get(0),
+            )
+            .unwrap();
         assert_eq!(wt_count, 1, "worktree should exist in DB");
 
         // Check adopted_at and removed_at via raw query
@@ -379,6 +422,37 @@ mod tests {
         ).unwrap();
         assert!(adopted_at.is_some(), "adopted_at should be set");
         assert!(removed_at.is_some(), "removed_at should be set");
+    }
+
+    #[test]
+    fn execute_resolved_removes_with_preresolved_data() {
+        let repo_dir = tempfile::tempdir().unwrap();
+        let _repo = init_repo_with_commit(repo_dir.path());
+        let wt_root = tempfile::tempdir().unwrap();
+        let db_dir = tempfile::tempdir().unwrap();
+        let db = Database::open(&db_dir.path().join("test.db")).unwrap();
+
+        // Create a worktree via the normal path
+        let create_result = crate::cli::commands::create::execute(
+            "pre-resolved",
+            None,
+            repo_dir.path(),
+            wt_root.path(),
+            crate::paths::DEFAULT_WORKTREE_TEMPLATE,
+            &db,
+        )
+        .expect("create should succeed");
+        assert!(create_result.path.exists());
+
+        // Resolve the worktree manually (simulating what run_remove does for the prompt)
+        let repo_info = git::discover_repo(repo_dir.path()).unwrap();
+        let (repo, wt) = crate::adopt::resolve_or_adopt("pre-resolved", &repo_info, &db).unwrap();
+
+        // Call execute_resolved with the pre-resolved data
+        let result =
+            execute_resolved(&repo, &wt, &repo_info, &db, false).expect("should succeed");
+        assert_eq!(result.name, "pre-resolved");
+        assert!(!create_result.path.exists(), "worktree dir should be gone");
     }
 
     #[test]

--- a/src/cli/commands/status.rs
+++ b/src/cli/commands/status.rs
@@ -184,14 +184,10 @@ fn resolve_worktree(
     identifier: &str,
 ) -> Result<(PathBuf, StatusEntry)> {
     let repo_info = git::discover_repo(cwd)?;
-    let repo_path_str = repo_info
-        .path
-        .to_str()
-        .ok_or_else(|| anyhow::anyhow!("repo path is not valid UTF-8"))?;
 
-    // Try DB first
-    if let Some(repo) = db.get_repo_by_path(repo_path_str)? {
-        if let Some(wt) = db.find_worktree_by_identifier(repo.id, identifier)? {
+    // Use resolve_or_adopt for lazy adoption on detail view
+    match crate::adopt::resolve_or_adopt(identifier, &repo_info, db) {
+        Ok((_repo, wt)) => {
             return Ok((
                 repo_info.path,
                 StatusEntry {
@@ -204,9 +200,13 @@ fn resolve_worktree(
                 },
             ));
         }
+        Err(_) => {
+            // Fall through to git-only lookup for edge cases
+            // (e.g. main worktree with detached HEAD)
+        }
     }
 
-    // Fall back to git-discovered worktrees
+    // Final fallback: git-discovered worktrees without adoption
     let git_worktrees = git::list_worktrees(&repo_info.path)?;
     for gw in git_worktrees {
         let branch_match = gw.branch.as_deref() == Some(identifier);

--- a/src/cli/commands/switch.rs
+++ b/src/cli/commands/switch.rs
@@ -262,6 +262,68 @@ mod tests {
     }
 
     #[test]
+    fn integration_manual_git_worktree_add_then_switch_adopts_and_lists_managed() {
+        // Full integration test per acceptance criteria:
+        // git worktree add manually → trench switch → verify in DB → shows managed
+        let repo_dir = tempfile::tempdir().unwrap();
+        let git_repo = init_repo_with_commit(repo_dir.path());
+        let db_dir = tempfile::tempdir().unwrap();
+        let db = Database::open(&db_dir.path().join("test.db")).unwrap();
+
+        // Step 1: Register repo in DB (as trench create would)
+        let repo_path = repo_dir.path().canonicalize().unwrap();
+        let repo_path_str = repo_path.to_str().unwrap();
+        let db_repo = db
+            .insert_repo("my-project", repo_path_str, Some("main"))
+            .unwrap();
+
+        // Step 2: Manually create a git worktree (simulating `git worktree add`)
+        let wt_dir = tempfile::tempdir().unwrap();
+        let wt_path = wt_dir.path().join("manual-feature");
+        git_repo
+            .branch(
+                "manual-feature",
+                &git_repo.head().unwrap().peel_to_commit().unwrap(),
+                false,
+            )
+            .unwrap();
+        let branch_ref = git_repo
+            .find_branch("manual-feature", git2::BranchType::Local)
+            .unwrap();
+        let mut opts = git2::WorktreeAddOptions::new();
+        opts.reference(Some(branch_ref.get()));
+        git_repo
+            .worktree("manual-feature", &wt_path, Some(&opts))
+            .unwrap();
+
+        // Step 3: Verify it's NOT in DB yet
+        let found = db
+            .find_worktree_by_identifier(db_repo.id, "manual-feature")
+            .unwrap();
+        assert!(found.is_none(), "worktree should NOT be in DB before switch");
+
+        // Step 4: Switch to the manually-created worktree
+        let switch = execute("manual-feature", repo_dir.path(), &db)
+            .expect("switch to manually-created worktree should succeed");
+        assert_eq!(switch.name, "manual-feature");
+
+        // Step 5: Verify worktree IS in DB with adopted_at set
+        let wt = db
+            .find_worktree_by_identifier(db_repo.id, "manual-feature")
+            .unwrap()
+            .expect("worktree should be in DB after switch");
+        assert!(wt.adopted_at.is_some(), "adopted_at should be set");
+        assert!(wt.managed, "should be managed after adoption");
+        assert!(wt.last_accessed.is_some(), "last_accessed should be set");
+
+        // Step 6: Verify it appears in list_worktrees (i.e. shows as managed)
+        let worktrees = db.list_worktrees(db_repo.id).unwrap();
+        assert_eq!(worktrees.len(), 1);
+        assert_eq!(worktrees[0].name, "manual-feature");
+        assert!(worktrees[0].managed);
+    }
+
+    #[test]
     fn create_then_switch_updates_last_accessed_and_session() {
         let repo_dir = tempfile::tempdir().unwrap();
         let _repo = init_repo_with_commit(repo_dir.path());

--- a/src/cli/commands/switch.rs
+++ b/src/cli/commands/switch.rs
@@ -17,30 +17,11 @@ pub struct SwitchResult {
 ///
 /// Resolves the worktree by sanitized name or branch name, updates
 /// `last_accessed` and session state, and returns the worktree path.
+/// If the worktree is unmanaged (not in DB), it is silently adopted.
 pub fn execute(identifier: &str, cwd: &Path, db: &Database) -> Result<SwitchResult> {
     let repo_info = crate::git::discover_repo(cwd)?;
-    let repo_path_str = repo_info
-        .path
-        .to_str()
-        .ok_or_else(|| anyhow::anyhow!("repo path is not valid UTF-8"))?;
 
-    let repo = db
-        .get_repo_by_path(repo_path_str)?
-        .ok_or_else(|| anyhow::anyhow!("repository not tracked by trench"))?;
-
-    // Try the identifier as-is first, then try sanitizing it
-    let wt = match db.find_worktree_by_identifier(repo.id, identifier)? {
-        Some(wt) => wt,
-        None => {
-            let sanitized = crate::paths::sanitize_branch(identifier);
-            if sanitized != identifier {
-                db.find_worktree_by_identifier(repo.id, &sanitized)?
-            } else {
-                None
-            }
-            .ok_or_else(|| anyhow::anyhow!("worktree not found: {identifier}"))?
-        }
-    };
+    let (repo, wt) = crate::adopt::resolve_or_adopt(identifier, &repo_info, db)?;
 
     // Update last_accessed timestamp
     let now = crate::state::unix_epoch_secs() as i64;
@@ -208,6 +189,56 @@ mod tests {
             current.as_deref(),
             Some("my-feature"),
             "session should track current worktree name"
+        );
+    }
+
+    #[test]
+    fn switch_adopts_unmanaged_worktree() {
+        let repo_dir = tempfile::tempdir().unwrap();
+        let git_repo = init_repo_with_commit(repo_dir.path());
+        let db = Database::open_in_memory().unwrap();
+
+        // Register repo in DB but NOT the worktree
+        let repo_path = repo_dir.path().canonicalize().unwrap();
+        let repo_path_str = repo_path.to_str().unwrap();
+        let db_repo = db
+            .insert_repo("my-project", repo_path_str, Some("main"))
+            .unwrap();
+
+        // Create a git worktree manually (not via trench)
+        let wt_dir = tempfile::tempdir().unwrap();
+        let wt_path = wt_dir.path().join("unmanaged-feat");
+        git_repo
+            .branch(
+                "unmanaged-feat",
+                &git_repo.head().unwrap().peel_to_commit().unwrap(),
+                false,
+            )
+            .unwrap();
+        let branch_ref = git_repo
+            .find_branch("unmanaged-feat", git2::BranchType::Local)
+            .unwrap();
+        let mut opts = git2::WorktreeAddOptions::new();
+        opts.reference(Some(branch_ref.get()));
+        git_repo
+            .worktree("unmanaged-feat", &wt_path, Some(&opts))
+            .unwrap();
+
+        // Switch to the unmanaged worktree — should trigger adoption
+        let result = execute("unmanaged-feat", repo_dir.path(), &db);
+        let switch = result.expect("switch to unmanaged worktree should succeed");
+        assert_eq!(switch.name, "unmanaged-feat");
+
+        // Verify worktree was adopted in DB
+        let wt = db
+            .find_worktree_by_identifier(db_repo.id, "unmanaged-feat")
+            .unwrap()
+            .expect("adopted worktree should be in DB");
+        assert!(wt.adopted_at.is_some(), "adopted_at should be set");
+        assert!(wt.managed, "should be managed after adoption");
+        assert!(
+            wt.last_accessed.is_some(),
+            "last_accessed should be set after switch"
         );
     }
 

--- a/src/cli/commands/sync.rs
+++ b/src/cli/commands/sync.rs
@@ -1,0 +1,90 @@
+use std::path::Path;
+
+use anyhow::Result;
+
+use crate::state::Database;
+
+/// Result of a sync operation.
+#[derive(Debug)]
+pub struct SyncResult {
+    /// Name of the worktree that was resolved.
+    pub name: String,
+}
+
+/// Execute the `trench sync <identifier>` command.
+///
+/// Resolves the worktree (adopting it if unmanaged), then reports
+/// that sync is not yet fully implemented.
+pub fn execute(identifier: &str, cwd: &Path, db: &Database) -> Result<SyncResult> {
+    let repo_info = crate::git::discover_repo(cwd)?;
+    let (_repo, wt) = crate::adopt::resolve_or_adopt(identifier, &repo_info, db)?;
+
+    // TODO: implement actual sync (rebase/merge with base branch)
+
+    Ok(SyncResult {
+        name: wt.name.clone(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::Database;
+
+    fn init_repo_with_commit(dir: &Path) -> git2::Repository {
+        let repo = git2::Repository::init(dir).expect("failed to init repo");
+        {
+            let sig = git2::Signature::now("Test", "test@test.com").unwrap();
+            let tree_id = repo.index().unwrap().write_tree().unwrap();
+            let tree = repo.find_tree(tree_id).unwrap();
+            repo.commit(Some("HEAD"), &sig, &sig, "initial commit", &tree, &[])
+                .unwrap();
+        }
+        repo
+    }
+
+    #[test]
+    fn sync_adopts_unmanaged_worktree() {
+        let repo_dir = tempfile::tempdir().unwrap();
+        let git_repo = init_repo_with_commit(repo_dir.path());
+        let db = Database::open_in_memory().unwrap();
+
+        let repo_path = repo_dir.path().canonicalize().unwrap();
+        let repo_path_str = repo_path.to_str().unwrap();
+        db.insert_repo("my-project", repo_path_str, Some("main"))
+            .unwrap();
+
+        // Create a git worktree manually
+        let wt_dir = tempfile::tempdir().unwrap();
+        let wt_path = wt_dir.path().join("sync-feat");
+        git_repo
+            .branch(
+                "sync-feat",
+                &git_repo.head().unwrap().peel_to_commit().unwrap(),
+                false,
+            )
+            .unwrap();
+        let branch_ref = git_repo
+            .find_branch("sync-feat", git2::BranchType::Local)
+            .unwrap();
+        let mut opts = git2::WorktreeAddOptions::new();
+        opts.reference(Some(branch_ref.get()));
+        git_repo
+            .worktree("sync-feat", &wt_path, Some(&opts))
+            .unwrap();
+
+        // Sync the unmanaged worktree — should trigger adoption
+        let result = execute("sync-feat", repo_dir.path(), &db)
+            .expect("sync should succeed");
+        assert_eq!(result.name, "sync-feat");
+
+        // Verify worktree was adopted in DB
+        let db_repo = db.get_repo_by_path(repo_path_str).unwrap().unwrap();
+        let wt = db
+            .find_worktree_by_identifier(db_repo.id, "sync-feat")
+            .unwrap()
+            .expect("adopted worktree should be in DB");
+        assert!(wt.adopted_at.is_some(), "adopted_at should be set");
+        assert!(wt.managed, "should be managed after adoption");
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -293,30 +293,27 @@ fn run_remove(identifier: &str, force: bool, prune: bool) -> anyhow::Result<()> 
     let db_path = paths::data_dir()?.join("trench.db");
     let db = state::Database::open(&db_path)?;
 
-    // If not forced, look up the worktree to show details in the confirmation prompt
+    // If not forced, resolve the worktree (adopting if unmanaged) for the prompt
     if !force {
         let repo_info = git::discover_repo(&cwd)?;
-        let repo_path_str = repo_info.path.to_str().unwrap_or("");
-        if let Some(repo) = db.get_repo_by_path(repo_path_str)? {
-            if let Some(wt) = db.find_worktree_by_identifier(repo.id, identifier)? {
-                let prune_hint = if prune {
-                    " (including remote branch)"
-                } else {
-                    ""
-                };
-                eprint!(
-                    "Remove worktree '{}' at {}{}? [y/N] ",
-                    wt.name, wt.path, prune_hint
-                );
-                let mut input = String::new();
-                if std::io::stdin().read_line(&mut input).is_err() {
-                    eprintln!("error: failed to read input");
-                    return Ok(());
-                }
-                if !input.trim().eq_ignore_ascii_case("y") {
-                    eprintln!("Cancelled.");
-                    return Ok(());
-                }
+        if let Ok((_repo, wt)) = adopt::resolve_or_adopt(identifier, &repo_info, &db) {
+            let prune_hint = if prune {
+                " (including remote branch)"
+            } else {
+                ""
+            };
+            eprint!(
+                "Remove worktree '{}' at {}{}? [y/N] ",
+                wt.name, wt.path, prune_hint
+            );
+            let mut input = String::new();
+            if std::io::stdin().read_line(&mut input).is_err() {
+                eprintln!("error: failed to read input");
+                return Ok(());
+            }
+            if !input.trim().eq_ignore_ascii_case("y") {
+                eprintln!("Cancelled.");
+                return Ok(());
             }
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -304,9 +304,9 @@ fn run_remove(identifier: &str, force: bool, prune: bool) -> anyhow::Result<()> 
     let db = state::Database::open(&db_path)?;
 
     // If not forced, resolve the worktree (adopting if unmanaged) for the prompt
-    if !force {
+    let resolved = if !force {
         let repo_info = git::discover_repo(&cwd)?;
-        if let Ok((_repo, wt)) = adopt::resolve_or_adopt(identifier, &repo_info, &db) {
+        if let Ok((repo, wt)) = adopt::resolve_or_adopt(identifier, &repo_info, &db) {
             let prune_hint = if prune {
                 " (including remote branch)"
             } else {
@@ -324,10 +324,22 @@ fn run_remove(identifier: &str, force: bool, prune: bool) -> anyhow::Result<()> 
                 eprintln!("Cancelled.");
                 return Ok(());
             }
+            Some((repo, wt, repo_info))
+        } else {
+            None
         }
-    }
+    } else {
+        None
+    };
 
-    match cli::commands::remove::execute(identifier, &cwd, &db, prune) {
+    let remove_result = match resolved {
+        Some((repo, wt, repo_info)) => {
+            cli::commands::remove::execute_resolved(&repo, &wt, &repo_info, &db, prune)
+        }
+        None => cli::commands::remove::execute(identifier, &cwd, &db, prune),
+    };
+
+    match remove_result {
         Ok(result) => {
             if result.pruned_remote {
                 eprintln!("Removed worktree '{}' and remote branch", result.name);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+mod adopt;
 mod cli;
 mod config;
 mod git;

--- a/src/main.rs
+++ b/src/main.rs
@@ -106,7 +106,10 @@ enum Commands {
         branch: Option<String>,
     },
     /// Sync worktree with base branch
-    Sync,
+    Sync {
+        /// Branch name or sanitized name of the worktree to sync
+        branch: Option<String>,
+    },
     /// View event log
     Log,
     /// Initialize .trench.toml in current directory
@@ -201,8 +204,9 @@ fn main() -> anyhow::Result<()> {
             cli::commands::completions::generate::<Cli>(shell, &mut std::io::stdout());
             Ok(())
         }
-        Some(_) => {
-            // Other commands not yet implemented
+        Some(Commands::Sync { branch }) => run_sync(branch.as_deref()),
+        Some(Commands::Log) => {
+            // Log command not yet implemented
             Ok(())
         }
         None => {
@@ -477,6 +481,34 @@ fn run_status(
         Err(e) => {
             let msg = e.to_string();
             if msg.contains("not found") {
+                eprintln!("error: {e}");
+                std::process::exit(2);
+            }
+            Err(e)
+        }
+    }
+}
+
+fn run_sync(branch: Option<&str>) -> anyhow::Result<()> {
+    let identifier = match branch {
+        Some(b) => b,
+        None => {
+            eprintln!("error: sync requires a branch argument (or --all, not yet implemented)");
+            std::process::exit(8);
+        }
+    };
+    let cwd = std::env::current_dir().context("failed to determine current directory")?;
+    let db_path = paths::data_dir()?.join("trench.db");
+    let db = state::Database::open(&db_path)?;
+
+    match cli::commands::sync::execute(identifier, &cwd, &db) {
+        Ok(result) => {
+            eprintln!("Resolved worktree '{}' (sync not yet implemented)", result.name);
+            Ok(())
+        }
+        Err(e) => {
+            let msg = e.to_string();
+            if msg.contains("not found") || msg.contains("not tracked") {
                 eprintln!("error: {e}");
                 std::process::exit(2);
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -109,7 +109,7 @@ enum Commands {
         /// Omit for summary of all worktrees.
         branch: Option<String>,
     },
-    /// Sync worktree with base branch
+    /// Resolve/adopt a worktree (sync not yet implemented)
     Sync {
         /// Branch name or sanitized name of the worktree to sync
         branch: String,

--- a/src/main.rs
+++ b/src/main.rs
@@ -317,10 +317,9 @@ fn run_remove(identifier: &str, force: bool, prune: bool) -> anyhow::Result<()> 
                 wt.name, wt.path, prune_hint
             );
             let mut input = String::new();
-            if std::io::stdin().read_line(&mut input).is_err() {
-                eprintln!("error: failed to read input");
-                return Ok(());
-            }
+            std::io::stdin()
+                .read_line(&mut input)
+                .context("failed to read confirmation input")?;
             if !input.trim().eq_ignore_ascii_case("y") {
                 eprintln!("Cancelled.");
                 return Ok(());

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,11 @@ use std::io::IsTerminal;
 use output::OutputConfig;
 
 #[derive(Parser, Debug)]
-#[command(name = "trench", version, about = "A fast, ergonomic, headless-first Git worktree manager")]
+#[command(
+    name = "trench",
+    version,
+    about = "A fast, ergonomic, headless-first Git worktree manager"
+)]
 struct Cli {
     #[command(subcommand)]
     command: Option<Commands>,
@@ -108,7 +112,7 @@ enum Commands {
     /// Sync worktree with base branch
     Sync {
         /// Branch name or sanitized name of the worktree to sync
-        branch: Option<String>,
+        branch: String,
     },
     /// View event log
     Log,
@@ -156,7 +160,6 @@ pub(crate) enum ShellType {
     Fish,
 }
 
-
 impl Cli {
     fn output_config(&self) -> OutputConfig {
         let is_tty = std::io::stdout().is_terminal();
@@ -187,14 +190,21 @@ fn main() -> anyhow::Result<()> {
         Some(Commands::Create { branch, from }) => {
             run_create(&branch, from.as_deref(), dry_run, json)
         }
-        Some(Commands::Remove { branch, force, prune }) => run_remove(&branch, force, prune),
+        Some(Commands::Remove {
+            branch,
+            force,
+            prune,
+        }) => run_remove(&branch, force, prune),
         Some(Commands::Switch { branch, print_path }) => run_switch(&branch, print_path),
         Some(Commands::Tag { branch, tags }) => run_tag(&branch, &tags),
         Some(Commands::Open { branch }) => run_open(&branch),
         Some(Commands::List { tag }) => run_list(tag.as_deref(), json, porcelain),
-        Some(Commands::Status { branch }) => {
-            run_status(branch.as_deref(), json, porcelain, output_config.should_color())
-        }
+        Some(Commands::Status { branch }) => run_status(
+            branch.as_deref(),
+            json,
+            porcelain,
+            output_config.should_color(),
+        ),
         Some(Commands::Init { force }) => run_init(force),
         Some(Commands::ShellInit { shell }) => {
             print!("{}", cli::commands::shell_init::generate(shell));
@@ -204,7 +214,7 @@ fn main() -> anyhow::Result<()> {
             cli::commands::completions::generate::<Cli>(shell, &mut std::io::stdout());
             Ok(())
         }
-        Some(Commands::Sync { branch }) => run_sync(branch.as_deref()),
+        Some(Commands::Sync { branch }) => run_sync(&branch),
         Some(Commands::Log) => {
             // Log command not yet implemented
             Ok(())
@@ -379,12 +389,7 @@ fn run_open(identifier: &str) -> anyhow::Result<()> {
     let global_config = config::load_global_config()?;
     let resolved = config::resolve_config(None, project_config.as_ref(), &global_config);
 
-    match cli::commands::open::resolve(
-        identifier,
-        &cwd,
-        &db,
-        resolved.editor_command.as_deref(),
-    ) {
+    match cli::commands::open::resolve(identifier, &cwd, &db, resolved.editor_command.as_deref()) {
         Ok(result) => {
             let parts = shell_words::split(&result.editor)
                 .with_context(|| format!("invalid editor command: '{}'", result.editor))?;
@@ -486,21 +491,17 @@ fn run_status(
     }
 }
 
-fn run_sync(branch: Option<&str>) -> anyhow::Result<()> {
-    let identifier = match branch {
-        Some(b) => b,
-        None => {
-            eprintln!("error: sync requires a branch argument (or --all, not yet implemented)");
-            std::process::exit(8);
-        }
-    };
+fn run_sync(identifier: &str) -> anyhow::Result<()> {
     let cwd = std::env::current_dir().context("failed to determine current directory")?;
     let db_path = paths::data_dir()?.join("trench.db");
     let db = state::Database::open(&db_path)?;
 
     match cli::commands::sync::execute(identifier, &cwd, &db) {
         Ok(result) => {
-            eprintln!("Resolved worktree '{}' (sync not yet implemented)", result.name);
+            eprintln!(
+                "Resolved worktree '{}' (sync not yet implemented)",
+                result.name
+            );
             Ok(())
         }
         Err(e) => {
@@ -554,7 +555,12 @@ mod tests {
     #[test]
     fn global_flags_are_accepted() {
         let cli = Cli::try_parse_from([
-            "trench", "--json", "--no-color", "--quiet", "--verbose", "--dry-run",
+            "trench",
+            "--json",
+            "--no-color",
+            "--quiet",
+            "--verbose",
+            "--dry-run",
         ])
         .expect("all global flags should be accepted");
 
@@ -604,9 +610,7 @@ mod tests {
     #[test]
     fn all_subcommands_are_accepted() {
         // open, switch, and remove require a branch argument, so test them separately
-        let subcommands = [
-            "list", "status", "sync", "log", "init",
-        ];
+        let subcommands = ["list", "status", "log", "init"];
         // shell-init and completions require a shell argument
         for sub in ["shell-init", "completions"] {
             let result = Cli::try_parse_from(["trench", sub, "bash"]);
@@ -632,6 +636,8 @@ mod tests {
         assert!(result.is_ok(), "remove with branch should be accepted");
         let result = Cli::try_parse_from(["trench", "switch", "my-feature"]);
         assert!(result.is_ok(), "switch with branch should be accepted");
+        let result = Cli::try_parse_from(["trench", "sync", "my-feature"]);
+        assert!(result.is_ok(), "sync with branch should be accepted");
     }
 
     #[test]
@@ -769,9 +775,8 @@ mod tests {
 
     #[test]
     fn dry_run_and_json_flags_work_together_with_create() {
-        let cli =
-            Cli::try_parse_from(["trench", "--dry-run", "--json", "create", "my-feature"])
-                .expect("--dry-run --json with create should parse");
+        let cli = Cli::try_parse_from(["trench", "--dry-run", "--json", "create", "my-feature"])
+            .expect("--dry-run --json with create should parse");
         assert!(cli.dry_run);
         assert!(cli.json);
     }
@@ -787,7 +792,11 @@ mod tests {
         let cli = Cli::try_parse_from(["trench", "remove", "my-feature"])
             .expect("remove with branch should succeed");
         match cli.command {
-            Some(Commands::Remove { branch, force, prune }) => {
+            Some(Commands::Remove {
+                branch,
+                force,
+                prune,
+            }) => {
                 assert_eq!(branch, "my-feature");
                 assert!(!force);
                 assert!(!prune);
@@ -801,7 +810,11 @@ mod tests {
         let cli = Cli::try_parse_from(["trench", "remove", "my-feature", "--force"])
             .expect("remove with --force should succeed");
         match cli.command {
-            Some(Commands::Remove { branch, force, prune }) => {
+            Some(Commands::Remove {
+                branch,
+                force,
+                prune,
+            }) => {
                 assert_eq!(branch, "my-feature");
                 assert!(force);
                 assert!(!prune);
@@ -888,8 +901,7 @@ mod tests {
 
     #[test]
     fn init_subcommand_defaults_force_to_false() {
-        let cli = Cli::try_parse_from(["trench", "init"])
-            .expect("init should parse");
+        let cli = Cli::try_parse_from(["trench", "init"]).expect("init should parse");
         match cli.command {
             Some(Commands::Init { force }) => {
                 assert!(!force, "force should default to false");
@@ -900,8 +912,8 @@ mod tests {
 
     #[test]
     fn init_subcommand_accepts_force_flag() {
-        let cli = Cli::try_parse_from(["trench", "init", "--force"])
-            .expect("init --force should parse");
+        let cli =
+            Cli::try_parse_from(["trench", "init", "--force"]).expect("init --force should parse");
         match cli.command {
             Some(Commands::Init { force }) => {
                 assert!(force, "force should be true");
@@ -915,7 +927,11 @@ mod tests {
         let cli = Cli::try_parse_from(["trench", "remove", "my-feature", "--prune"])
             .expect("remove with --prune should succeed");
         match cli.command {
-            Some(Commands::Remove { branch, force, prune }) => {
+            Some(Commands::Remove {
+                branch,
+                force,
+                prune,
+            }) => {
                 assert_eq!(branch, "my-feature");
                 assert!(!force);
                 assert!(prune);
@@ -929,7 +945,11 @@ mod tests {
         let cli = Cli::try_parse_from(["trench", "remove", "my-feature", "--force", "--prune"])
             .expect("remove with --force --prune should succeed");
         match cli.command {
-            Some(Commands::Remove { branch, force, prune }) => {
+            Some(Commands::Remove {
+                branch,
+                force,
+                prune,
+            }) => {
                 assert_eq!(branch, "my-feature");
                 assert!(force);
                 assert!(prune);
@@ -1064,8 +1084,8 @@ mod tests {
 
     #[test]
     fn cli_produces_output_config() {
-        let cli = Cli::try_parse_from(["trench", "--no-color", "--quiet"])
-            .expect("flags should parse");
+        let cli =
+            Cli::try_parse_from(["trench", "--no-color", "--quiet"]).expect("flags should parse");
         let config = cli.output_config();
         assert!(!config.should_color());
         assert!(config.is_quiet());

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -749,6 +749,34 @@ mod tests {
     }
 
     #[test]
+    fn adopt_worktree_sets_adopted_at_and_managed() {
+        let db = Database::open_in_memory().unwrap();
+        let repo = db.insert_repo("r", "/r", Some("main")).unwrap();
+
+        let wt = db
+            .adopt_worktree(repo.id, "ext-wt", "ext-branch", "/ext/wt", None)
+            .expect("adopt_worktree should succeed");
+
+        assert!(wt.managed, "adopted worktree should be managed");
+        assert!(
+            wt.adopted_at.is_some(),
+            "adopted_at should be set on adoption"
+        );
+        assert!(
+            wt.adopted_at.unwrap() > 0,
+            "adopted_at should be a positive timestamp"
+        );
+        assert_eq!(wt.name, "ext-wt");
+        assert_eq!(wt.branch, "ext-branch");
+        assert_eq!(wt.path, "/ext/wt");
+
+        // Verify round-trip from DB
+        let fetched = db.get_worktree(wt.id).unwrap().unwrap();
+        assert_eq!(fetched.adopted_at, wt.adopted_at);
+        assert!(fetched.managed);
+    }
+
+    #[test]
     fn get_repo_by_path_returns_existing_repo() {
         let db = Database::open_in_memory().unwrap();
         let repo = db.insert_repo("my-project", "/home/user/my-project", Some("main")).unwrap();

--- a/src/state/queries.rs
+++ b/src/state/queries.rs
@@ -79,6 +79,44 @@ impl Database {
         Ok(repo)
     }
 
+    /// Adopt an externally-created worktree by inserting it with `adopted_at` set.
+    ///
+    /// Like `insert_worktree`, but marks the worktree as adopted (sets
+    /// `adopted_at` to the current timestamp). Used for lazy adoption of
+    /// unmanaged worktrees on first interaction.
+    pub fn adopt_worktree(
+        &self,
+        repo_id: i64,
+        name: &str,
+        branch: &str,
+        path: &str,
+        base_branch: Option<&str>,
+    ) -> Result<Worktree> {
+        let created_at = now();
+        self.conn
+            .execute(
+                "INSERT INTO worktrees (repo_id, name, branch, path, base_branch, managed, adopted_at, created_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, 1, ?6, ?6)",
+                rusqlite::params![repo_id, name, branch, path, base_branch, created_at],
+            )
+            .context("failed to adopt worktree")?;
+
+        let id = self.conn.last_insert_rowid();
+        Ok(Worktree {
+            id,
+            repo_id,
+            name: name.to_string(),
+            branch: branch.to_string(),
+            path: path.to_string(),
+            base_branch: base_branch.map(String::from),
+            managed: true,
+            adopted_at: Some(created_at),
+            last_accessed: None,
+            removed_at: None,
+            created_at,
+        })
+    }
+
     /// Insert a new worktree and return the populated struct.
     pub fn insert_worktree(
         &self,

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -201,7 +201,17 @@ impl App {
     fn handle_list_key(&mut self, key: KeyEvent) {
         match key.code {
             KeyCode::Enter => {
+                let identity = self
+                    .list_state
+                    .rows
+                    .get(self.list_state.selected)
+                    .map(|r| r.name.clone());
                 self.adopt_selected_if_unmanaged();
+                if let Some(name) = identity {
+                    if let Some(idx) = self.list_state.rows.iter().position(|r| r.name == name) {
+                        self.list_state.selected = idx;
+                    }
+                }
                 self.push_screen(Screen::Detail);
             }
             KeyCode::Char('n') => self.push_screen(Screen::Create),

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -51,7 +51,10 @@ pub fn run() -> Result<()> {
 
 fn install_panic_hook() {
     let original: Arc<PanicHook> = Arc::from(std::panic::take_hook());
-    PREV_PANIC_HOOK.lock().unwrap().replace(Arc::clone(&original));
+    PREV_PANIC_HOOK
+        .lock()
+        .unwrap()
+        .replace(Arc::clone(&original));
     std::panic::set_hook(Box::new(move |info| {
         ratatui::restore();
         original(info);
@@ -85,7 +88,10 @@ impl App {
     }
 
     pub fn active_screen(&self) -> Screen {
-        *self.nav_stack.last().expect("nav stack must never be empty")
+        *self
+            .nav_stack
+            .last()
+            .expect("nav stack must never be empty")
     }
 
     pub fn nav_stack_depth(&self) -> usize {
@@ -100,8 +106,8 @@ impl App {
         match self.active_screen() {
             Screen::List => screens::list::render(&self.list_state, frame, frame.area()),
             _ => {
-                let placeholder = Paragraph::new("trench TUI — press q to quit")
-                    .alignment(Alignment::Center);
+                let placeholder =
+                    Paragraph::new("trench TUI — press q to quit").alignment(Alignment::Center);
                 frame.render_widget(placeholder, frame.area());
             }
         }
@@ -166,7 +172,11 @@ impl App {
             Some(r) if !r.managed => r,
             _ => return,
         };
-        let branch = row.branch.clone();
+        let identifier = if row.branch == "(detached)" {
+            row.name.clone()
+        } else {
+            row.branch.clone()
+        };
 
         let cwd = match std::env::current_dir() {
             Ok(p) => p,
@@ -184,7 +194,7 @@ impl App {
             Ok(r) => r,
             Err(_) => return,
         };
-        let _ = crate::adopt::resolve_or_adopt(&branch, &repo_info, &db);
+        let _ = crate::adopt::resolve_or_adopt(&identifier, &repo_info, &db);
         self.refresh_list();
     }
 
@@ -271,7 +281,10 @@ mod tests {
             "Esc should pop back to List"
         );
         assert_eq!(app.nav_stack_depth(), 1);
-        assert!(app.is_running(), "app should still be running after popping");
+        assert!(
+            app.is_running(),
+            "app should still be running after popping"
+        );
     }
 
     #[test]
@@ -306,10 +319,7 @@ mod tests {
             Screen::List,
             "q on non-root should pop back to List"
         );
-        assert!(
-            app.is_running(),
-            "q on non-root should not quit the app"
-        );
+        assert!(app.is_running(), "q on non-root should not quit the app");
     }
 
     #[test]
@@ -527,11 +537,7 @@ mod tests {
         let mut terminal = ratatui::Terminal::new(backend).unwrap();
         terminal.draw(|frame| app.ui(frame)).unwrap();
         let buffer = terminal.backend().buffer().clone();
-        let content: String = buffer
-            .content()
-            .iter()
-            .map(|cell| cell.symbol())
-            .collect();
+        let content: String = buffer.content().iter().map(|cell| cell.symbol()).collect();
         assert!(
             content.contains("No worktrees"),
             "empty list should show 'No worktrees' message, got: {:?}",
@@ -547,11 +553,7 @@ mod tests {
         let mut terminal = ratatui::Terminal::new(backend).unwrap();
         terminal.draw(|frame| app.ui(frame)).unwrap();
         let buffer = terminal.backend().buffer().clone();
-        let content: String = buffer
-            .content()
-            .iter()
-            .map(|cell| cell.symbol())
-            .collect();
+        let content: String = buffer.content().iter().map(|cell| cell.symbol()).collect();
         assert!(
             content.contains("trench TUI"),
             "non-list screens should show placeholder, got: {:?}",

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -160,9 +160,40 @@ impl App {
         }
     }
 
+    /// If the selected worktree is unmanaged, silently adopt it into the DB.
+    fn adopt_selected_if_unmanaged(&mut self) {
+        let row = match self.list_state.rows.get(self.list_state.selected) {
+            Some(r) if !r.managed => r,
+            _ => return,
+        };
+        let branch = row.branch.clone();
+
+        let cwd = match std::env::current_dir() {
+            Ok(p) => p,
+            Err(_) => return,
+        };
+        let db_path = match paths::data_dir() {
+            Ok(p) => p.join("trench.db"),
+            Err(_) => return,
+        };
+        let db = match Database::open(&db_path) {
+            Ok(d) => d,
+            Err(_) => return,
+        };
+        let repo_info = match crate::git::discover_repo(&cwd) {
+            Ok(r) => r,
+            Err(_) => return,
+        };
+        let _ = crate::adopt::resolve_or_adopt(&branch, &repo_info, &db);
+        self.refresh_list();
+    }
+
     fn handle_list_key(&mut self, key: KeyEvent) {
         match key.code {
-            KeyCode::Enter => self.push_screen(Screen::Detail),
+            KeyCode::Enter => {
+                self.adopt_selected_if_unmanaged();
+                self.push_screen(Screen::Detail);
+            }
             KeyCode::Char('n') => self.push_screen(Screen::Create),
             KeyCode::Down | KeyCode::Char('j') => self.list_state.select_next(),
             KeyCode::Up | KeyCode::Char('k') => self.list_state.select_previous(),


### PR DESCRIPTION
Closes #34

## Summary
Implements lazy adoption of unmanaged worktrees (FR-29). When a user performs any trench action (switch, sync, remove, status detail, TUI detail) on an unmanaged worktree, it is silently inserted into the SQLite database with `adopted_at` timestamp set. A new `resolve_or_adopt()` function centralizes this logic, bridging git worktree discovery with DB state.

## User Stories Addressed
- US-5: Seamless handling of manually-created worktrees — all worktrees (including those created outside trench) are adopted on first interaction

## Automated Testing
- Total tests added: 10
- Tests passing: 10
- Tests failing: 0
- `cargo clippy`: pass (warnings only, all pre-existing)
- `cargo test`: 382 passed, 2 failed (pre-existing failures unrelated to this PR — `refs/heads/master` not found due to system git default branch config)

## UAT Checklist
- [ ] Create a worktree manually with `git worktree add ../test-wt -b test-lazy` outside of trench
- [ ] Run `trench list` → the manually-created worktree should appear with `[unmanaged]` badge
- [ ] Run `trench switch test-lazy` → should succeed silently
- [ ] Run `trench list` → the worktree should now appear WITHOUT the `[unmanaged]` badge (it's managed)
- [ ] Run `trench status test-lazy` → should show deep status for the adopted worktree
- [ ] Create another manual worktree, run `trench remove --force <name>` → should adopt then remove
- [ ] Create another manual worktree, run `trench sync <name>` → should adopt (sync itself is a stub)
- [ ] Open TUI (`trench`), navigate to an unmanaged worktree, press Enter → should adopt silently
- [ ] Verify no user-visible messages about adoption appear during any of these operations

## Known Issues
- The `sync` command is a stub — it resolves and adopts the worktree but does not perform actual sync (rebase/merge). Full sync implementation is out of scope for this issue.
- TUI detail screen is a placeholder — adoption is triggered on Enter but the detail view itself is not yet implemented.
- The 2 pre-existing test failures (`create_worktree_succeeds_after_remote_branch_deleted`, `delete_remote_branch_deletes_branch_on_remote`) are caused by the system's git default branch being `main` while tests expect `master`. These are unrelated to this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a sync command (accepts branch) and automatic adoption of unmanaged Git worktrees into management.
  * UI: adopt an unmanaged worktree from the list view.

* **Improvements**
  * Unified adoption-based resolution across remove, status, and switch flows, enabling silent adoption during operations.
  * Repository/worktree records now reflect adoption state and timestamps.

* **Tests**
  * Expanded tests covering adoption, idempotency, DB state, removal workflows, and CLI sync behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->