### PR TITLE
feat(hooks): hook runner — copy→run→shell orchestration + timeout + failure

### DIFF
--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -8,6 +8,17 @@ use std::fmt;
 
 use crate::config::{HookDef, HooksConfig};
 
+/// How a hook failure should be treated by the calling operation (FR-24).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FailureSeverity {
+    /// Operation must be cancelled (pre_create, pre_sync, pre_remove, post_create).
+    HardStop,
+    /// Error reported but operation already completed (post_sync).
+    Report,
+    /// Warning only, operation already completed (post_remove).
+    WarnOnly,
+}
+
 /// Re-export HookDef as HookConfig for the hooks module public API.
 /// This is the per-hook configuration with copy, run, shell, timeout_secs fields.
 pub type HookConfig = HookDef;
@@ -32,6 +43,19 @@ impl HookEvent {
             Self::PostSync => "post_sync",
             Self::PreRemove => "pre_remove",
             Self::PostRemove => "post_remove",
+        }
+    }
+}
+
+impl HookEvent {
+    /// Return the failure severity for this hook event per FR-24.
+    pub fn failure_severity(&self) -> FailureSeverity {
+        match self {
+            Self::PreCreate | Self::PreSync | Self::PreRemove | Self::PostCreate => {
+                FailureSeverity::HardStop
+            }
+            Self::PostSync => FailureSeverity::Report,
+            Self::PostRemove => FailureSeverity::WarnOnly,
         }
     }
 }
@@ -204,6 +228,39 @@ timeout_secs = 60
         assert!(get_hook_config(&hooks, &HookEvent::PreSync).is_none());
         assert!(get_hook_config(&hooks, &HookEvent::PostSync).is_none());
         assert!(get_hook_config(&hooks, &HookEvent::PostRemove).is_none());
+    }
+
+    #[test]
+    fn failure_severity_matches_fr24() {
+        // pre_create / pre_sync / pre_remove / post_create → HardStop
+        assert_eq!(
+            HookEvent::PreCreate.failure_severity(),
+            FailureSeverity::HardStop
+        );
+        assert_eq!(
+            HookEvent::PostCreate.failure_severity(),
+            FailureSeverity::HardStop
+        );
+        assert_eq!(
+            HookEvent::PreSync.failure_severity(),
+            FailureSeverity::HardStop
+        );
+        assert_eq!(
+            HookEvent::PreRemove.failure_severity(),
+            FailureSeverity::HardStop
+        );
+
+        // post_sync → Report
+        assert_eq!(
+            HookEvent::PostSync.failure_severity(),
+            FailureSeverity::Report
+        );
+
+        // post_remove → WarnOnly
+        assert_eq!(
+            HookEvent::PostRemove.failure_severity(),
+            FailureSeverity::WarnOnly
+        );
     }
 
     #[test]

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -1,5 +1,6 @@
 pub mod copy;
 pub mod run;
+pub mod runner;
 pub mod shell;
 pub mod stream;
 

--- a/src/hooks/runner.rs
+++ b/src/hooks/runner.rs
@@ -515,4 +515,89 @@ mod tests {
             .expect("error should be HookTimeoutError");
         assert_eq!(timeout_err.timeout_secs, 2);
     }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn event_payload_contains_duration_and_exit_code() {
+        let source = TempDir::new().unwrap();
+        let work = TempDir::new().unwrap();
+        let (db, repo_id, wt_id) = setup_db();
+
+        let config = HookDef {
+            copy: None,
+            run: Some(vec!["echo hello".to_string()]),
+            shell: None,
+            timeout_secs: Some(30),
+        };
+
+        let env_ctx = test_env_ctx(source.path(), work.path());
+
+        let result = execute_hook(
+            &HookEvent::PreSync,
+            &config,
+            &env_ctx,
+            source.path(),
+            work.path(),
+            &db,
+            repo_id,
+            Some(wt_id),
+        )
+        .await
+        .unwrap();
+
+        let events = db.list_events(wt_id, 10).unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].event_type, "hook:pre_sync");
+
+        let payload: serde_json::Value =
+            serde_json::from_str(events[0].payload.as_deref().unwrap()).unwrap();
+        assert_eq!(payload["hook"], "pre_sync");
+        assert_eq!(payload["exit_code"], 0);
+        assert!(payload["duration_secs"].as_f64().unwrap() >= 0.0);
+
+        // Verify event_id matches
+        assert_eq!(result.event_id, events[0].id);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn log_lines_numbered_sequentially_with_stream_labels() {
+        let source = TempDir::new().unwrap();
+        let work = TempDir::new().unwrap();
+        let (db, repo_id, wt_id) = setup_db();
+
+        let config = HookDef {
+            copy: None,
+            run: Some(vec!["echo out1; echo err1 >&2".to_string()]),
+            shell: Some("echo out2; echo err2 >&2".to_string()),
+            timeout_secs: Some(30),
+        };
+
+        let env_ctx = test_env_ctx(source.path(), work.path());
+
+        let result = execute_hook(
+            &HookEvent::PostCreate,
+            &config,
+            &env_ctx,
+            source.path(),
+            work.path(),
+            &db,
+            repo_id,
+            Some(wt_id),
+        )
+        .await
+        .unwrap();
+
+        let logs = db.get_logs(result.event_id).unwrap();
+
+        // Should have 4 lines: out1, err1 from run + out2, err2 from shell
+        assert_eq!(logs.len(), 4, "expected 4 log lines, got: {logs:?}");
+
+        // Line numbers should be sequential 1-4
+        let line_numbers: Vec<i64> = logs.iter().map(|(_, _, n)| *n).collect();
+        assert_eq!(line_numbers, vec![1, 2, 3, 4]);
+
+        // Verify stream labels
+        let streams: Vec<&str> = logs.iter().map(|(s, _, _)| s.as_str()).collect();
+        assert!(streams.contains(&"stdout"));
+        assert!(streams.contains(&"stderr"));
+    }
 }

--- a/src/hooks/runner.rs
+++ b/src/hooks/runner.rs
@@ -439,4 +439,80 @@ mod tests {
         assert!(lines.contains(&"run_ok"));
         assert!(lines.contains(&"shell_before"));
     }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn timeout_returns_hook_timeout_error() {
+        let source = TempDir::new().unwrap();
+        let work = TempDir::new().unwrap();
+        let (db, repo_id, wt_id) = setup_db();
+
+        let config = HookDef {
+            copy: None,
+            run: Some(vec!["sleep 10".to_string()]),
+            shell: None,
+            timeout_secs: Some(1),
+        };
+
+        let env_ctx = test_env_ctx(source.path(), work.path());
+
+        let err = execute_hook(
+            &HookEvent::PostCreate,
+            &config,
+            &env_ctx,
+            source.path(),
+            work.path(),
+            &db,
+            repo_id,
+            Some(wt_id),
+        )
+        .await
+        .expect_err("hook should timeout");
+
+        // Should be a HookTimeoutError
+        let timeout_err = err.downcast_ref::<HookTimeoutError>()
+            .expect("error should be HookTimeoutError");
+        assert_eq!(timeout_err.timeout_secs, 1);
+
+        // Event should be recorded with exit code 7
+        let events = db.list_events(wt_id, 10).unwrap();
+        assert_eq!(events.len(), 1);
+        let payload: serde_json::Value =
+            serde_json::from_str(events[0].payload.as_deref().unwrap()).unwrap();
+        assert_eq!(payload["exit_code"], 7);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn timeout_shared_across_run_and_shell() {
+        let source = TempDir::new().unwrap();
+        let work = TempDir::new().unwrap();
+        let (db, repo_id, wt_id) = setup_db();
+
+        // Run takes ~1s, shell takes ~10s, total timeout is 2s
+        // Shell should be killed by timeout
+        let config = HookDef {
+            copy: None,
+            run: Some(vec!["sleep 1".to_string()]),
+            shell: Some("sleep 10".to_string()),
+            timeout_secs: Some(2),
+        };
+
+        let env_ctx = test_env_ctx(source.path(), work.path());
+
+        let err = execute_hook(
+            &HookEvent::PostCreate,
+            &config,
+            &env_ctx,
+            source.path(),
+            work.path(),
+            &db,
+            repo_id,
+            Some(wt_id),
+        )
+        .await
+        .expect_err("hook should timeout on shell step");
+
+        let timeout_err = err.downcast_ref::<HookTimeoutError>()
+            .expect("error should be HookTimeoutError");
+        assert_eq!(timeout_err.timeout_secs, 2);
+    }
 }

--- a/src/hooks/runner.rs
+++ b/src/hooks/runner.rs
@@ -1,0 +1,232 @@
+use std::path::Path;
+use std::time::Instant;
+
+use anyhow::{Context, Result};
+
+use super::copy::execute_copy_step;
+use super::run::execute_run_step;
+use super::shell::execute_shell_step;
+use super::{build_env, HookConfig, HookEnvContext, HookEvent};
+use crate::state::Database;
+
+/// Timeout error returned when run + shell steps exceed `timeout_secs`.
+#[derive(Debug, thiserror::Error)]
+#[error("hook timed out after {timeout_secs}s")]
+pub struct HookTimeoutError {
+    pub timeout_secs: u64,
+}
+
+/// Result of a successful hook execution.
+#[derive(Debug)]
+pub struct HookResult {
+    /// Event id recorded in the database.
+    pub event_id: i64,
+    /// Total wall-clock duration in seconds.
+    pub duration_secs: f64,
+}
+
+/// Execute a hook lifecycle event: copy → run → shell.
+///
+/// - `copy` runs first (not subject to timeout).
+/// - `run` and `shell` share the `timeout_secs` budget.
+/// - Any step failure stops remaining steps.
+/// - All output is captured and logged to the database.
+/// - Returns `HookTimeoutError` (exit code 7) on timeout.
+pub async fn execute_hook(
+    event: &HookEvent,
+    config: &HookConfig,
+    env_ctx: &HookEnvContext,
+    source_dir: &Path,
+    work_dir: &Path,
+    db: &Database,
+    repo_id: i64,
+    worktree_id: Option<i64>,
+) -> Result<HookResult> {
+    let start = Instant::now();
+    let env_vars = build_env(env_ctx, event);
+    let timeout_secs = config.timeout_secs.unwrap_or(120);
+
+    let mut all_output: Vec<(String, String)> = Vec::new(); // (stream, line)
+
+    // Step 1: Copy (not subject to timeout)
+    if let Some(ref patterns) = config.copy {
+        execute_copy_step(source_dir, work_dir, patterns)
+            .context("copy step failed")?;
+    }
+
+    // Step 2: Run (subject to timeout)
+    let run_deadline = Instant::now() + std::time::Duration::from_secs(timeout_secs);
+    if let Some(ref commands) = config.run {
+        let remaining = run_deadline.saturating_duration_since(Instant::now());
+        match tokio::time::timeout(remaining, execute_run_step(commands, work_dir, &env_vars))
+            .await
+        {
+            Ok(result) => {
+                let run_result = result?;
+                for cmd_output in &run_result.executed {
+                    collect_output(&mut all_output, &cmd_output.stdout, &cmd_output.stderr);
+                }
+            }
+            Err(_) => {
+                let duration = start.elapsed();
+                record_execution(
+                    db, repo_id, worktree_id, event, 7, duration.as_secs_f64(), &all_output,
+                )?;
+                return Err(HookTimeoutError { timeout_secs }.into());
+            }
+        }
+    }
+
+    // Step 3: Shell (remaining timeout budget)
+    if let Some(ref script) = config.shell {
+        let remaining = run_deadline.saturating_duration_since(Instant::now());
+        match tokio::time::timeout(remaining, execute_shell_step(script, work_dir, &env_vars))
+            .await
+        {
+            Ok(result) => {
+                let shell_output = result?;
+                collect_output(&mut all_output, &shell_output.stdout, &shell_output.stderr);
+            }
+            Err(_) => {
+                let duration = start.elapsed();
+                record_execution(
+                    db, repo_id, worktree_id, event, 7, duration.as_secs_f64(), &all_output,
+                )?;
+                return Err(HookTimeoutError { timeout_secs }.into());
+            }
+        }
+    }
+
+    let duration = start.elapsed();
+    let event_id = record_execution(
+        db, repo_id, worktree_id, event, 0, duration.as_secs_f64(), &all_output,
+    )?;
+
+    Ok(HookResult {
+        event_id,
+        duration_secs: duration.as_secs_f64(),
+    })
+}
+
+fn collect_output(all_output: &mut Vec<(String, String)>, stdout: &str, stderr: &str) {
+    for line in stdout.lines() {
+        all_output.push(("stdout".to_string(), line.to_string()));
+    }
+    for line in stderr.lines() {
+        all_output.push(("stderr".to_string(), line.to_string()));
+    }
+}
+
+fn record_execution(
+    db: &Database,
+    repo_id: i64,
+    worktree_id: Option<i64>,
+    event: &HookEvent,
+    exit_code: i32,
+    duration_secs: f64,
+    output: &[(String, String)],
+) -> Result<i64> {
+    let payload = serde_json::json!({
+        "hook": event.as_str(),
+        "exit_code": exit_code,
+        "duration_secs": duration_secs,
+    });
+
+    let event_id = db.insert_event(
+        repo_id,
+        worktree_id,
+        &format!("hook:{}", event.as_str()),
+        Some(&payload),
+    )?;
+
+    for (i, (stream, line)) in output.iter().enumerate() {
+        db.insert_log(event_id, stream, line, (i + 1) as i64)?;
+    }
+
+    Ok(event_id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::HookDef;
+    use tempfile::TempDir;
+
+    fn test_env_ctx(source: &Path, work: &Path) -> HookEnvContext {
+        HookEnvContext {
+            worktree_path: work.to_string_lossy().into_owned(),
+            worktree_name: "test-wt".into(),
+            branch: "test-branch".into(),
+            repo_name: "test-repo".into(),
+            repo_path: source.to_string_lossy().into_owned(),
+            base_branch: "main".into(),
+        }
+    }
+
+    fn setup_db() -> (Database, i64, i64) {
+        let db = Database::open_in_memory().unwrap();
+        let repo = db.insert_repo("r", "/r", None).unwrap();
+        let wt = db
+            .insert_worktree(repo.id, "wt", "branch", "/wt", None)
+            .unwrap();
+        (db, repo.id, wt.id)
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn success_path_executes_copy_run_shell_in_order() {
+        let source = TempDir::new().unwrap();
+        let work = TempDir::new().unwrap();
+        let (db, repo_id, wt_id) = setup_db();
+
+        // Create a file in source for copy step
+        std::fs::write(source.path().join(".env"), "SECRET=123").unwrap();
+
+        let config = HookDef {
+            copy: Some(vec![".env".to_string()]),
+            run: Some(vec!["echo run_output".to_string()]),
+            shell: Some("echo shell_output".to_string()),
+            timeout_secs: Some(30),
+        };
+
+        let env_ctx = test_env_ctx(source.path(), work.path());
+
+        let result = execute_hook(
+            &HookEvent::PostCreate,
+            &config,
+            &env_ctx,
+            source.path(),
+            work.path(),
+            &db,
+            repo_id,
+            Some(wt_id),
+        )
+        .await
+        .expect("hook should succeed");
+
+        // Verify result
+        assert!(result.event_id > 0);
+        assert!(result.duration_secs >= 0.0);
+
+        // Verify copy happened
+        assert!(work.path().join(".env").exists());
+        assert_eq!(
+            std::fs::read_to_string(work.path().join(".env")).unwrap(),
+            "SECRET=123"
+        );
+
+        // Verify event in DB
+        let events = db.list_events(wt_id, 10).unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].event_type, "hook:post_create");
+
+        // Verify logs in DB contain output from run + shell
+        let logs = db.get_logs(result.event_id).unwrap();
+        let stdout_lines: Vec<&str> = logs
+            .iter()
+            .filter(|(s, _, _)| s == "stdout")
+            .map(|(_, l, _)| l.as_str())
+            .collect();
+        assert!(stdout_lines.contains(&"run_output"));
+        assert!(stdout_lines.contains(&"shell_output"));
+    }
+}

--- a/src/hooks/runner.rs
+++ b/src/hooks/runner.rs
@@ -229,4 +229,73 @@ mod tests {
         assert!(stdout_lines.contains(&"run_output"));
         assert!(stdout_lines.contains(&"shell_output"));
     }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn only_configured_steps_execute() {
+        let source = TempDir::new().unwrap();
+        let work = TempDir::new().unwrap();
+        let (db, repo_id, wt_id) = setup_db();
+
+        // Config with only run — no copy, no shell
+        let config = HookDef {
+            copy: None,
+            run: Some(vec!["echo only_run".to_string()]),
+            shell: None,
+            timeout_secs: Some(30),
+        };
+
+        let env_ctx = test_env_ctx(source.path(), work.path());
+
+        let result = execute_hook(
+            &HookEvent::PostCreate,
+            &config,
+            &env_ctx,
+            source.path(),
+            work.path(),
+            &db,
+            repo_id,
+            Some(wt_id),
+        )
+        .await
+        .expect("hook should succeed");
+
+        // Only run output should be in logs
+        let logs = db.get_logs(result.event_id).unwrap();
+        assert_eq!(logs.len(), 1);
+        assert_eq!(logs[0].0, "stdout");
+        assert_eq!(logs[0].1, "only_run");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn empty_config_succeeds_with_no_output() {
+        let source = TempDir::new().unwrap();
+        let work = TempDir::new().unwrap();
+        let (db, repo_id, wt_id) = setup_db();
+
+        // All steps None
+        let config = HookDef {
+            copy: None,
+            run: None,
+            shell: None,
+            timeout_secs: Some(30),
+        };
+
+        let env_ctx = test_env_ctx(source.path(), work.path());
+
+        let result = execute_hook(
+            &HookEvent::PostCreate,
+            &config,
+            &env_ctx,
+            source.path(),
+            work.path(),
+            &db,
+            repo_id,
+            Some(wt_id),
+        )
+        .await
+        .expect("hook should succeed");
+
+        let logs = db.get_logs(result.event_id).unwrap();
+        assert!(logs.is_empty());
+    }
 }

--- a/src/hooks/runner.rs
+++ b/src/hooks/runner.rs
@@ -4,8 +4,8 @@ use std::time::Instant;
 use anyhow::{Context, Result};
 
 use super::copy::execute_copy_step;
-use super::run::execute_run_step;
-use super::shell::execute_shell_step;
+use super::run::{execute_run_step, RunStepError};
+use super::shell::{execute_shell_step, ShellStepError};
 use super::{build_env, HookConfig, HookEnvContext, HookEvent};
 use crate::state::Database;
 
@@ -50,8 +50,13 @@ pub async fn execute_hook(
 
     // Step 1: Copy (not subject to timeout)
     if let Some(ref patterns) = config.copy {
-        execute_copy_step(source_dir, work_dir, patterns)
-            .context("copy step failed")?;
+        if let Err(e) = execute_copy_step(source_dir, work_dir, patterns) {
+            let duration = start.elapsed();
+            record_execution(
+                db, repo_id, worktree_id, event, 1, duration.as_secs_f64(), &all_output,
+            )?;
+            return Err(e.context("copy step failed"));
+        }
     }
 
     // Step 2: Run (subject to timeout)
@@ -61,11 +66,19 @@ pub async fn execute_hook(
         match tokio::time::timeout(remaining, execute_run_step(commands, work_dir, &env_vars))
             .await
         {
-            Ok(result) => {
-                let run_result = result?;
+            Ok(Ok(run_result)) => {
                 for cmd_output in &run_result.executed {
                     collect_output(&mut all_output, &cmd_output.stdout, &cmd_output.stderr);
                 }
+            }
+            Ok(Err(e)) => {
+                // Collect partial output from the error if it's a RunStepError
+                let exit_code = extract_run_error_output(&e, &mut all_output);
+                let duration = start.elapsed();
+                record_execution(
+                    db, repo_id, worktree_id, event, exit_code, duration.as_secs_f64(), &all_output,
+                )?;
+                return Err(e);
             }
             Err(_) => {
                 let duration = start.elapsed();
@@ -83,9 +96,16 @@ pub async fn execute_hook(
         match tokio::time::timeout(remaining, execute_shell_step(script, work_dir, &env_vars))
             .await
         {
-            Ok(result) => {
-                let shell_output = result?;
+            Ok(Ok(shell_output)) => {
                 collect_output(&mut all_output, &shell_output.stdout, &shell_output.stderr);
+            }
+            Ok(Err(e)) => {
+                let exit_code = extract_shell_error_output(&e, &mut all_output);
+                let duration = start.elapsed();
+                record_execution(
+                    db, repo_id, worktree_id, event, exit_code, duration.as_secs_f64(), &all_output,
+                )?;
+                return Err(e);
             }
             Err(_) => {
                 let duration = start.elapsed();
@@ -106,6 +126,34 @@ pub async fn execute_hook(
         event_id,
         duration_secs: duration.as_secs_f64(),
     })
+}
+
+/// Extract partial output from a RunStepError and return the exit code.
+fn extract_run_error_output(
+    err: &anyhow::Error,
+    all_output: &mut Vec<(String, String)>,
+) -> i32 {
+    if let Some(run_err) = err.downcast_ref::<RunStepError>() {
+        for cmd_output in &run_err.results.executed {
+            collect_output(all_output, &cmd_output.stdout, &cmd_output.stderr);
+        }
+        run_err.exit_code
+    } else {
+        1
+    }
+}
+
+/// Extract output from a ShellStepError and return the exit code.
+fn extract_shell_error_output(
+    err: &anyhow::Error,
+    all_output: &mut Vec<(String, String)>,
+) -> i32 {
+    if let Some(shell_err) = err.downcast_ref::<ShellStepError>() {
+        collect_output(all_output, &shell_err.output.stdout, &shell_err.output.stderr);
+        shell_err.exit_code
+    } else {
+        1
+    }
 }
 
 fn collect_output(all_output: &mut Vec<(String, String)>, stdout: &str, stderr: &str) {
@@ -297,5 +345,98 @@ mod tests {
 
         let logs = db.get_logs(result.event_id).unwrap();
         assert!(logs.is_empty());
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn run_failure_stops_shell_and_records_error() {
+        let source = TempDir::new().unwrap();
+        let work = TempDir::new().unwrap();
+        let (db, repo_id, wt_id) = setup_db();
+
+        let config = HookDef {
+            copy: None,
+            run: Some(vec![
+                "echo before_fail".to_string(),
+                "exit 42".to_string(),
+            ]),
+            shell: Some("echo should_not_run".to_string()),
+            timeout_secs: Some(30),
+        };
+
+        let env_ctx = test_env_ctx(source.path(), work.path());
+
+        let err = execute_hook(
+            &HookEvent::PostCreate,
+            &config,
+            &env_ctx,
+            source.path(),
+            work.path(),
+            &db,
+            repo_id,
+            Some(wt_id),
+        )
+        .await
+        .expect_err("hook should fail");
+
+        // Error message should mention the failed command
+        let msg = err.to_string();
+        assert!(msg.contains("exit 42") || msg.contains("42"), "error: {msg}");
+
+        // Event should be recorded with non-zero exit code
+        let events = db.list_events(wt_id, 10).unwrap();
+        assert_eq!(events.len(), 1);
+        let payload: serde_json::Value =
+            serde_json::from_str(events[0].payload.as_deref().unwrap()).unwrap();
+        assert_ne!(payload["exit_code"], 0);
+
+        // Logs should contain "before_fail" but NOT "should_not_run"
+        let event_id = events[0].id;
+        let logs = db.get_logs(event_id).unwrap();
+        let lines: Vec<&str> = logs.iter().map(|(_, l, _)| l.as_str()).collect();
+        assert!(lines.contains(&"before_fail"), "should have run output before failure");
+        assert!(
+            !lines.iter().any(|l| l.contains("should_not_run")),
+            "shell should not have run after run failure"
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn shell_failure_returns_error_and_records_event() {
+        let source = TempDir::new().unwrap();
+        let work = TempDir::new().unwrap();
+        let (db, repo_id, wt_id) = setup_db();
+
+        let config = HookDef {
+            copy: None,
+            run: Some(vec!["echo run_ok".to_string()]),
+            shell: Some("echo shell_before; exit 1".to_string()),
+            timeout_secs: Some(30),
+        };
+
+        let env_ctx = test_env_ctx(source.path(), work.path());
+
+        let err = execute_hook(
+            &HookEvent::PostCreate,
+            &config,
+            &env_ctx,
+            source.path(),
+            work.path(),
+            &db,
+            repo_id,
+            Some(wt_id),
+        )
+        .await
+        .expect_err("hook should fail");
+
+        assert!(err.to_string().contains("exit code"), "error: {err}");
+
+        // Both run and shell output should be logged
+        let events = db.list_events(wt_id, 10).unwrap();
+        assert_eq!(events.len(), 1);
+        let event_id = events[0].id;
+        let logs = db.get_logs(event_id).unwrap();
+        let lines: Vec<&str> = logs.iter().map(|(_, l, _)| l.as_str()).collect();
+        assert!(lines.contains(&"run_ok"));
+        assert!(lines.contains(&"shell_before"));
     }
 }

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -777,6 +777,45 @@ mod tests {
     }
 
     #[test]
+    fn insert_and_get_logs_round_trip() {
+        let db = Database::open_in_memory().unwrap();
+        let repo = db.insert_repo("r", "/r", None).unwrap();
+        let wt = db
+            .insert_worktree(repo.id, "wt", "branch", "/wt", None)
+            .unwrap();
+
+        let event_id = db
+            .insert_event(repo.id, Some(wt.id), "hook:post_create", None)
+            .unwrap();
+
+        db.insert_log(event_id, "stdout", "hello world", 1).unwrap();
+        db.insert_log(event_id, "stderr", "warning: something", 2).unwrap();
+        db.insert_log(event_id, "stdout", "done", 3).unwrap();
+
+        let logs = db.get_logs(event_id).unwrap();
+        assert_eq!(logs.len(), 3);
+        assert_eq!(logs[0], ("stdout".to_string(), "hello world".to_string(), 1));
+        assert_eq!(logs[1], ("stderr".to_string(), "warning: something".to_string(), 2));
+        assert_eq!(logs[2], ("stdout".to_string(), "done".to_string(), 3));
+    }
+
+    #[test]
+    fn get_logs_returns_empty_for_no_logs() {
+        let db = Database::open_in_memory().unwrap();
+        let repo = db.insert_repo("r", "/r", None).unwrap();
+        let wt = db
+            .insert_worktree(repo.id, "wt", "branch", "/wt", None)
+            .unwrap();
+
+        let event_id = db
+            .insert_event(repo.id, Some(wt.id), "hook:post_create", None)
+            .unwrap();
+
+        let logs = db.get_logs(event_id).unwrap();
+        assert!(logs.is_empty());
+    }
+
+    #[test]
     fn get_repo_by_path_returns_existing_repo() {
         let db = Database::open_in_memory().unwrap();
         let repo = db.insert_repo("my-project", "/home/user/my-project", Some("main")).unwrap();

--- a/src/state/queries.rs
+++ b/src/state/queries.rs
@@ -423,6 +423,48 @@ impl Database {
         Ok(())
     }
 
+    /// Insert a single log line for an event.
+    pub fn insert_log(
+        &self,
+        event_id: i64,
+        stream: &str,
+        line: &str,
+        line_number: i64,
+    ) -> Result<()> {
+        let created_at = now();
+        self.conn
+            .execute(
+                "INSERT INTO logs (event_id, stream, line, line_number, created_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5)",
+                rusqlite::params![event_id, stream, line, line_number, created_at],
+            )
+            .context("failed to insert log line")?;
+        Ok(())
+    }
+
+    /// Retrieve log lines for an event, ordered by line number.
+    pub fn get_logs(&self, event_id: i64) -> Result<Vec<(String, String, i64)>> {
+        let mut stmt = self
+            .conn
+            .prepare(
+                "SELECT stream, line, line_number FROM logs
+                 WHERE event_id = ?1 ORDER BY line_number",
+            )
+            .context("failed to prepare get_logs query")?;
+
+        let rows = stmt
+            .query_map(rusqlite::params![event_id], |row| {
+                Ok((row.get(0)?, row.get(1)?, row.get(2)?))
+            })
+            .context("failed to get logs")?;
+
+        let mut logs = Vec::new();
+        for row in rows {
+            logs.push(row.context("failed to read log row")?);
+        }
+        Ok(logs)
+    }
+
     /// Count events for a worktree, optionally filtered by event type.
     pub fn count_events(
         &self,


### PR DESCRIPTION
Closes #36

## Summary
Implements the complete hook runner in `src/hooks/runner.rs` that orchestrates copy → run → shell steps in order, enforces a shared timeout budget on run + shell, records all output to the database, and classifies failure severity per hook type (FR-24). Adds `insert_log`/`get_logs` DB methods and the `FailureSeverity` enum.

## User Stories Addressed
- US-2: Reliable hook execution (copy → run → shell orchestration with failure handling)
- US-10: Hook output logging (all stdout/stderr captured and stored in DB with sequential line numbering)

## Automated Testing
- Total tests added: 12
- Tests passing: 12
- Tests failing: 0
- `cargo clippy`: pass (no new warnings)
- `cargo test`: pass (406/408 — 2 pre-existing failures in git module unrelated to this PR)

## UAT Checklist
- [ ] Configure `.trench.toml` with `[hooks.post_create]` containing `copy`, `run`, and `shell` steps → `trench create` runs all three in order
- [ ] Configure a hook with a failing `run` command → shell step is skipped, error reported
- [ ] Configure a hook with `timeout_secs = 5` and a `run = ["sleep 30"]` → process exits with code 7
- [ ] After hook execution, verify `trench log` shows the hook event with stdout/stderr output
- [ ] Configure `[hooks.pre_remove]` with a failing command → `trench remove` is cancelled (hard stop)
- [ ] Configure `[hooks.post_remove]` with a failing command → `trench remove` succeeds with warning

## Known Issues
None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Hooks now support configurable timeouts (default 120 seconds) with graceful timeout handling.
  * Hook execution output (stdout/stderr) is now captured and persistently logged.
  * Hook results now include execution duration and event tracking metadata.
  * Hook lifecycle stages are mapped to failure severity levels for better error handling.

* **Tests**
  * Added tests for hook execution and log retrieval functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->