### PR TITLE
feat(sync): trench sync <branch> — strategy prompt + rebase/merge

### DIFF
--- a/src/cli/commands/sync.rs
+++ b/src/cli/commands/sync.rs
@@ -279,6 +279,40 @@ mod tests {
     }
 
     #[test]
+    fn sync_merge_merges_base_into_branch() {
+        let (_git_repo, wt_path, db, repo_dir, _wt_dir, _repo_path_str) = setup_diverged_repo();
+
+        let result = execute("feature", repo_dir.path(), &db, Strategy::Merge)
+            .expect("merge sync should succeed");
+
+        assert_eq!(result.name, "feature");
+        assert_eq!(result.strategy, Strategy::Merge);
+        assert_eq!(result.before_behind, 1, "should be 1 behind before sync");
+
+        // After merge, behind should be 0
+        assert_eq!(result.after_behind, 0, "should be 0 behind after merge");
+
+        // Both files should exist
+        assert!(
+            wt_path.join("upstream.txt").exists(),
+            "upstream file should exist after merge"
+        );
+        assert!(
+            wt_path.join("feature.txt").exists(),
+            "feature file should still exist after merge"
+        );
+
+        // Should have a merge commit (the HEAD commit should have 2 parents)
+        let wt_repo = git2::Repository::open(&wt_path).unwrap();
+        let head = wt_repo.head().unwrap().peel_to_commit().unwrap();
+        assert_eq!(
+            head.parent_count(),
+            2,
+            "merge commit should have 2 parents"
+        );
+    }
+
+    #[test]
     fn sync_adopts_unmanaged_worktree() {
         let repo_dir = tempfile::tempdir().unwrap();
         let git_repo = init_repo_with_commit(repo_dir.path());

--- a/src/cli/commands/sync.rs
+++ b/src/cli/commands/sync.rs
@@ -572,6 +572,38 @@ mod tests {
     }
 
     #[test]
+    fn sync_rebase_shows_correct_ahead_counts() {
+        let (_git_repo, _wt_path, db, repo_dir, _wt_dir, _repo_path_str) = setup_diverged_repo();
+
+        let result = execute("feature", repo_dir.path(), &db, Strategy::Rebase)
+            .expect("sync should succeed");
+
+        // Feature has 1 commit ahead of main (the "feature commit")
+        assert_eq!(result.before_ahead, 1, "should be 1 ahead before sync");
+        // After rebase, still 1 ahead (the rebased feature commit)
+        assert_eq!(result.after_ahead, 1, "should still be 1 ahead after rebase");
+        // Before: 1 behind (main has upstream commit)
+        assert_eq!(result.before_behind, 1);
+        // After: 0 behind
+        assert_eq!(result.after_behind, 0);
+    }
+
+    #[test]
+    fn sync_merge_shows_correct_ahead_counts() {
+        let (_git_repo, _wt_path, db, repo_dir, _wt_dir, _repo_path_str) = setup_diverged_repo();
+
+        let result = execute("feature", repo_dir.path(), &db, Strategy::Merge)
+            .expect("sync should succeed");
+
+        // Before: 1 ahead (feature commit), 1 behind (upstream commit)
+        assert_eq!(result.before_ahead, 1);
+        assert_eq!(result.before_behind, 1);
+        // After merge: ahead increases (feature commit + merge commit), behind = 0
+        assert!(result.after_ahead >= 2, "should be at least 2 ahead after merge (feature + merge commit)");
+        assert_eq!(result.after_behind, 0);
+    }
+
+    #[test]
     fn sync_adopts_unmanaged_worktree() {
         let repo_dir = tempfile::tempdir().unwrap();
         let git_repo = init_repo_with_commit(repo_dir.path());

--- a/src/cli/commands/sync.rs
+++ b/src/cli/commands/sync.rs
@@ -1,28 +1,133 @@
 use std::path::Path;
 
 use anyhow::Result;
+use serde::Serialize;
 
 use crate::state::Database;
+
+/// Sync strategy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Strategy {
+    Rebase,
+    Merge,
+}
+
+impl std::fmt::Display for Strategy {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Strategy::Rebase => write!(f, "rebase"),
+            Strategy::Merge => write!(f, "merge"),
+        }
+    }
+}
 
 /// Result of a sync operation.
 #[derive(Debug)]
 pub struct SyncResult {
-    /// Name of the worktree that was resolved.
+    /// Name of the worktree that was synced.
     pub name: String,
+    /// Strategy used.
+    pub strategy: Strategy,
+    /// Ahead count before sync.
+    pub before_ahead: usize,
+    /// Behind count before sync.
+    pub before_behind: usize,
+    /// Ahead count after sync.
+    pub after_ahead: usize,
+    /// Behind count after sync.
+    pub after_behind: usize,
+}
+
+/// JSON representation of a sync result.
+#[derive(Debug, Serialize)]
+pub struct SyncResultJson {
+    pub name: String,
+    pub strategy: String,
+    pub before: AheadBehind,
+    pub after: AheadBehind,
+}
+
+#[derive(Debug, Serialize)]
+pub struct AheadBehind {
+    pub ahead: usize,
+    pub behind: usize,
+}
+
+impl SyncResult {
+    pub fn to_json(&self) -> SyncResultJson {
+        SyncResultJson {
+            name: self.name.clone(),
+            strategy: self.strategy.to_string(),
+            before: AheadBehind {
+                ahead: self.before_ahead,
+                behind: self.before_behind,
+            },
+            after: AheadBehind {
+                ahead: self.after_ahead,
+                behind: self.after_behind,
+            },
+        }
+    }
 }
 
 /// Execute the `trench sync <identifier>` command.
 ///
-/// Resolves the worktree (adopting it if unmanaged), then reports
-/// that sync is not yet fully implemented.
-pub fn execute(identifier: &str, cwd: &Path, db: &Database) -> Result<SyncResult> {
+/// Resolves the worktree (adopting it if unmanaged), fetches from remote,
+/// then rebases or merges with the base branch.
+pub fn execute(
+    identifier: &str,
+    cwd: &Path,
+    db: &Database,
+    strategy: Strategy,
+) -> Result<SyncResult> {
     let repo_info = crate::git::discover_repo(cwd)?;
-    let (_repo, wt) = crate::adopt::resolve_or_adopt(identifier, &repo_info, db)?;
+    let (repo, wt) = crate::adopt::resolve_or_adopt(identifier, &repo_info, db)?;
 
-    // TODO: implement actual sync (rebase/merge with base branch)
+    let base_branch = wt
+        .base_branch
+        .as_deref()
+        .or(repo.default_base.as_deref())
+        .unwrap_or("main");
+
+    // Get before counts
+    let (before_ahead, before_behind) =
+        crate::git::ahead_behind(Path::new(&repo_info.path), &wt.branch, Some(base_branch))?
+            .unwrap_or((0, 0));
+
+    // Fetch from remote
+    crate::git::fetch_remote(Path::new(&repo_info.path))?;
+
+    // Perform sync
+    match strategy {
+        Strategy::Rebase => {
+            crate::git::sync_rebase(Path::new(&wt.path), &wt.branch, base_branch)?;
+        }
+        Strategy::Merge => {
+            crate::git::sync_merge(Path::new(&wt.path), &wt.branch, base_branch)?;
+        }
+    }
+
+    // Get after counts
+    let (after_ahead, after_behind) =
+        crate::git::ahead_behind(Path::new(&repo_info.path), &wt.branch, Some(base_branch))?
+            .unwrap_or((0, 0));
+
+    // Insert synced event
+    let payload = serde_json::json!({
+        "strategy": strategy.to_string(),
+        "base_branch": base_branch,
+        "before": { "ahead": before_ahead, "behind": before_behind },
+        "after": { "ahead": after_ahead, "behind": after_behind },
+    });
+    db.insert_event(repo.id, Some(wt.id), "synced", Some(&payload))?;
 
     Ok(SyncResult {
         name: wt.name.clone(),
+        strategy,
+        before_ahead,
+        before_behind,
+        after_ahead,
+        after_behind,
     })
 }
 
@@ -74,7 +179,7 @@ mod tests {
             .unwrap();
 
         // Sync the unmanaged worktree — should trigger adoption
-        let result = execute("sync-feat", repo_dir.path(), &db)
+        let result = execute("sync-feat", repo_dir.path(), &db, Strategy::Rebase)
             .expect("sync should succeed");
         assert_eq!(result.name, "sync-feat");
 

--- a/src/cli/commands/sync.rs
+++ b/src/cli/commands/sync.rs
@@ -343,6 +343,187 @@ mod tests {
     }
 
     #[test]
+    fn sync_rebase_conflict_returns_error() {
+        let repo_dir = tempfile::tempdir().unwrap();
+        let git_repo = init_repo_with_commit(repo_dir.path());
+        let db = Database::open_in_memory().unwrap();
+
+        let repo_path = repo_dir.path().canonicalize().unwrap();
+        let repo_path_str = repo_path.to_str().unwrap();
+
+        // Rename HEAD to "main"
+        {
+            let name = git_repo
+                .head()
+                .unwrap()
+                .shorthand()
+                .unwrap()
+                .to_string();
+            git_repo
+                .find_branch(&name, git2::BranchType::Local)
+                .unwrap()
+                .rename("main", true)
+                .unwrap();
+        }
+
+        // Create feature branch
+        {
+            let head_commit = git_repo.head().unwrap().peel_to_commit().unwrap();
+            git_repo.branch("conflict-feat", &head_commit, false).unwrap();
+        }
+
+        // Create worktree
+        let wt_dir = tempfile::tempdir().unwrap();
+        let wt_path = wt_dir.path().join("conflict-feat");
+        {
+            let branch_ref = git_repo
+                .find_branch("conflict-feat", git2::BranchType::Local)
+                .unwrap();
+            let mut opts = git2::WorktreeAddOptions::new();
+            opts.reference(Some(branch_ref.get()));
+            git_repo
+                .worktree("conflict-feat", &wt_path, Some(&opts))
+                .unwrap();
+        }
+
+        // Create conflicting changes on the SAME file in both branches
+        let wt_repo = git2::Repository::open(&wt_path).unwrap();
+        commit_file(
+            &wt_repo,
+            "conflict.txt",
+            "feature version",
+            "feature: edit conflict.txt",
+        );
+
+        // Switch main repo back to main and edit the same file
+        {
+            let main_obj = git_repo.revparse_single("refs/heads/main").unwrap();
+            git_repo.checkout_tree(&main_obj, None).unwrap();
+            git_repo.set_head("refs/heads/main").unwrap();
+        }
+        commit_file(
+            &git_repo,
+            "conflict.txt",
+            "main version",
+            "main: edit conflict.txt",
+        );
+
+        // Register in DB
+        db.insert_repo("test-repo", repo_path_str, Some("main"))
+            .unwrap();
+        let db_repo = db.get_repo_by_path(repo_path_str).unwrap().unwrap();
+        let wt_path_str = wt_path.canonicalize().unwrap_or(wt_path.clone());
+        db.insert_worktree(
+            db_repo.id,
+            "conflict-feat",
+            "conflict-feat",
+            wt_path_str.to_str().unwrap(),
+            Some("main"),
+        )
+        .unwrap();
+
+        // Attempt sync — should fail with merge conflict
+        let err = execute("conflict-feat", repo_dir.path(), &db, Strategy::Rebase)
+            .expect_err("sync should fail on conflict");
+
+        let msg = err.to_string();
+        assert!(
+            msg.contains("merge conflict") || msg.contains("conflict"),
+            "error should mention conflict, got: {msg}"
+        );
+
+        // Verify it's a GitError::MergeConflict
+        assert!(
+            err.downcast_ref::<crate::git::GitError>().is_some(),
+            "should be a GitError"
+        );
+    }
+
+    #[test]
+    fn sync_merge_conflict_returns_error() {
+        let repo_dir = tempfile::tempdir().unwrap();
+        let git_repo = init_repo_with_commit(repo_dir.path());
+        let db = Database::open_in_memory().unwrap();
+
+        let repo_path = repo_dir.path().canonicalize().unwrap();
+        let repo_path_str = repo_path.to_str().unwrap();
+
+        {
+            let name = git_repo
+                .head()
+                .unwrap()
+                .shorthand()
+                .unwrap()
+                .to_string();
+            git_repo
+                .find_branch(&name, git2::BranchType::Local)
+                .unwrap()
+                .rename("main", true)
+                .unwrap();
+        }
+
+        {
+            let head_commit = git_repo.head().unwrap().peel_to_commit().unwrap();
+            git_repo.branch("merge-conflict", &head_commit, false).unwrap();
+        }
+
+        let wt_dir = tempfile::tempdir().unwrap();
+        let wt_path = wt_dir.path().join("merge-conflict");
+        {
+            let branch_ref = git_repo
+                .find_branch("merge-conflict", git2::BranchType::Local)
+                .unwrap();
+            let mut opts = git2::WorktreeAddOptions::new();
+            opts.reference(Some(branch_ref.get()));
+            git_repo
+                .worktree("merge-conflict", &wt_path, Some(&opts))
+                .unwrap();
+        }
+
+        let wt_repo = git2::Repository::open(&wt_path).unwrap();
+        commit_file(
+            &wt_repo,
+            "shared.txt",
+            "feature text",
+            "feature: edit shared.txt",
+        );
+
+        {
+            let main_obj = git_repo.revparse_single("refs/heads/main").unwrap();
+            git_repo.checkout_tree(&main_obj, None).unwrap();
+            git_repo.set_head("refs/heads/main").unwrap();
+        }
+        commit_file(
+            &git_repo,
+            "shared.txt",
+            "main text",
+            "main: edit shared.txt",
+        );
+
+        db.insert_repo("test-repo", repo_path_str, Some("main"))
+            .unwrap();
+        let db_repo = db.get_repo_by_path(repo_path_str).unwrap().unwrap();
+        let wt_path_str = wt_path.canonicalize().unwrap_or(wt_path.clone());
+        db.insert_worktree(
+            db_repo.id,
+            "merge-conflict",
+            "merge-conflict",
+            wt_path_str.to_str().unwrap(),
+            Some("main"),
+        )
+        .unwrap();
+
+        let err = execute("merge-conflict", repo_dir.path(), &db, Strategy::Merge)
+            .expect_err("merge sync should fail on conflict");
+
+        let msg = err.to_string();
+        assert!(
+            msg.contains("merge conflict") || msg.contains("conflict"),
+            "error should mention conflict, got: {msg}"
+        );
+    }
+
+    #[test]
     fn sync_adopts_unmanaged_worktree() {
         let repo_dir = tempfile::tempdir().unwrap();
         let git_repo = init_repo_with_commit(repo_dir.path());

--- a/src/cli/commands/sync.rs
+++ b/src/cli/commands/sync.rs
@@ -443,10 +443,13 @@ mod tests {
             "error should mention conflict, got: {msg}"
         );
 
-        // Verify it's a GitError::MergeConflict
+        // Verify it's the exact GitError::MergeConflict variant
         assert!(
-            err.downcast_ref::<crate::git::GitError>().is_some(),
-            "should be a GitError"
+            matches!(
+                err.downcast_ref::<crate::git::GitError>(),
+                Some(crate::git::GitError::MergeConflict { branch }) if branch == "conflict-feat"
+            ),
+            "should be GitError::MergeConflict for 'conflict-feat'"
         );
     }
 
@@ -528,6 +531,15 @@ mod tests {
         assert!(
             msg.contains("merge conflict") || msg.contains("conflict"),
             "error should mention conflict, got: {msg}"
+        );
+
+        // Verify it's the exact GitError::MergeConflict variant
+        assert!(
+            matches!(
+                err.downcast_ref::<crate::git::GitError>(),
+                Some(crate::git::GitError::MergeConflict { branch }) if branch == "merge-conflict"
+            ),
+            "should be GitError::MergeConflict for 'merge-conflict'"
         );
 
         // After merge conflict error, MERGE_HEAD should be preserved so users can resolve

--- a/src/cli/commands/sync.rs
+++ b/src/cli/commands/sync.rs
@@ -148,11 +148,156 @@ mod tests {
         repo
     }
 
+    /// Helper: create a file, stage, and commit it in the given repo.
+    fn commit_file(repo: &git2::Repository, filename: &str, content: &str, message: &str) {
+        let workdir = repo.workdir().unwrap();
+        std::fs::write(workdir.join(filename), content).unwrap();
+        let mut index = repo.index().unwrap();
+        index.add_path(Path::new(filename)).unwrap();
+        index.write().unwrap();
+        let tree_id = index.write_tree().unwrap();
+        let tree = repo.find_tree(tree_id).unwrap();
+        let sig = git2::Signature::now("Test", "test@test.com").unwrap();
+        let parent = repo.head().unwrap().peel_to_commit().unwrap();
+        repo.commit(Some("HEAD"), &sig, &sig, message, &tree, &[&parent])
+            .unwrap();
+    }
+
+    /// Set up a test scenario with a main repo, a worktree branch behind main.
+    /// Returns (main_repo, worktree_path, db, repo_path_str).
+    fn setup_diverged_repo() -> (
+        git2::Repository,
+        std::path::PathBuf,
+        Database,
+        tempfile::TempDir,
+        tempfile::TempDir,
+        String,
+    ) {
+        let repo_dir = tempfile::tempdir().unwrap();
+        let git_repo = init_repo_with_commit(repo_dir.path());
+        let db = Database::open_in_memory().unwrap();
+
+        let repo_path = repo_dir.path().canonicalize().unwrap();
+        let repo_path_str = repo_path.to_str().unwrap().to_string();
+
+        // Rename HEAD branch to "main" for consistency
+        git_repo
+            .find_branch(
+                git_repo
+                    .head()
+                    .unwrap()
+                    .shorthand()
+                    .unwrap(),
+                git2::BranchType::Local,
+            )
+            .unwrap()
+            .rename("main", true)
+            .unwrap();
+
+        // Create feature branch at current main
+        {
+            let head_commit = git_repo.head().unwrap().peel_to_commit().unwrap();
+            git_repo
+                .branch("feature", &head_commit, false)
+                .unwrap();
+        }
+
+        // Create worktree for the feature branch
+        let wt_dir = tempfile::tempdir().unwrap();
+        let wt_path = wt_dir.path().join("feature");
+        {
+            let branch_ref = git_repo
+                .find_branch("feature", git2::BranchType::Local)
+                .unwrap();
+            let mut opts = git2::WorktreeAddOptions::new();
+            opts.reference(Some(branch_ref.get()));
+            git_repo
+                .worktree("feature", &wt_path, Some(&opts))
+                .unwrap();
+        }
+
+        // Add a commit on the feature branch (in worktree)
+        let wt_repo = git2::Repository::open(&wt_path).unwrap();
+        commit_file(&wt_repo, "feature.txt", "feature work", "feature commit");
+
+        // Add a commit on main (in main repo) to create divergence
+        // First, switch main repo back to main
+        {
+            let main_obj = git_repo.revparse_single("refs/heads/main").unwrap();
+            git_repo.checkout_tree(&main_obj, None).unwrap();
+            git_repo.set_head("refs/heads/main").unwrap();
+        }
+        commit_file(&git_repo, "upstream.txt", "upstream change", "upstream commit on main");
+
+        // Register in DB
+        db.insert_repo("test-repo", &repo_path_str, Some("main"))
+            .unwrap();
+        let db_repo = db.get_repo_by_path(&repo_path_str).unwrap().unwrap();
+        let wt_path_str = wt_path.canonicalize().unwrap_or(wt_path.clone());
+        db.insert_worktree(
+            db_repo.id,
+            "feature",
+            "feature",
+            wt_path_str.to_str().unwrap(),
+            Some("main"),
+        )
+        .unwrap();
+
+        (git_repo, wt_path, db, repo_dir, wt_dir, repo_path_str)
+    }
+
+    #[test]
+    fn sync_rebase_rebases_branch_onto_main() {
+        let (_git_repo, wt_path, db, repo_dir, _wt_dir, _repo_path_str) = setup_diverged_repo();
+
+        // Before sync: feature should be 1 behind main
+        let result = execute("feature", repo_dir.path(), &db, Strategy::Rebase)
+            .expect("rebase sync should succeed");
+
+        assert_eq!(result.name, "feature");
+        assert_eq!(result.strategy, Strategy::Rebase);
+        assert_eq!(result.before_behind, 1, "should be 1 behind before sync");
+
+        // After rebase, behind should be 0
+        assert_eq!(result.after_behind, 0, "should be 0 behind after rebase");
+
+        // Feature branch should still have its commit + upstream file should exist
+        let wt_repo = git2::Repository::open(&wt_path).unwrap();
+        let head = wt_repo.head().unwrap().peel_to_commit().unwrap();
+        assert!(
+            head.message().unwrap().contains("feature commit"),
+            "feature commit should be on top after rebase"
+        );
+        assert!(
+            wt_path.join("upstream.txt").exists(),
+            "upstream file should exist after rebase"
+        );
+        assert!(
+            wt_path.join("feature.txt").exists(),
+            "feature file should still exist after rebase"
+        );
+    }
+
     #[test]
     fn sync_adopts_unmanaged_worktree() {
         let repo_dir = tempfile::tempdir().unwrap();
         let git_repo = init_repo_with_commit(repo_dir.path());
         let db = Database::open_in_memory().unwrap();
+
+        // Rename HEAD branch to "main"
+        {
+            let head_branch_name = git_repo
+                .head()
+                .unwrap()
+                .shorthand()
+                .unwrap()
+                .to_string();
+            git_repo
+                .find_branch(&head_branch_name, git2::BranchType::Local)
+                .unwrap()
+                .rename("main", true)
+                .unwrap();
+        }
 
         let repo_path = repo_dir.path().canonicalize().unwrap();
         let repo_path_str = repo_path.to_str().unwrap();
@@ -162,21 +307,22 @@ mod tests {
         // Create a git worktree manually
         let wt_dir = tempfile::tempdir().unwrap();
         let wt_path = wt_dir.path().join("sync-feat");
-        git_repo
-            .branch(
-                "sync-feat",
-                &git_repo.head().unwrap().peel_to_commit().unwrap(),
-                false,
-            )
-            .unwrap();
-        let branch_ref = git_repo
-            .find_branch("sync-feat", git2::BranchType::Local)
-            .unwrap();
-        let mut opts = git2::WorktreeAddOptions::new();
-        opts.reference(Some(branch_ref.get()));
-        git_repo
-            .worktree("sync-feat", &wt_path, Some(&opts))
-            .unwrap();
+        {
+            let head_commit = git_repo.head().unwrap().peel_to_commit().unwrap();
+            git_repo
+                .branch("sync-feat", &head_commit, false)
+                .unwrap();
+        }
+        {
+            let branch_ref = git_repo
+                .find_branch("sync-feat", git2::BranchType::Local)
+                .unwrap();
+            let mut opts = git2::WorktreeAddOptions::new();
+            opts.reference(Some(branch_ref.get()));
+            git_repo
+                .worktree("sync-feat", &wt_path, Some(&opts))
+                .unwrap();
+        }
 
         // Sync the unmanaged worktree — should trigger adoption
         let result = execute("sync-feat", repo_dir.path(), &db, Strategy::Rebase)

--- a/src/cli/commands/sync.rs
+++ b/src/cli/commands/sync.rs
@@ -313,6 +313,36 @@ mod tests {
     }
 
     #[test]
+    fn sync_writes_synced_event_to_db() {
+        let (_git_repo, _wt_path, db, repo_dir, _wt_dir, repo_path_str) = setup_diverged_repo();
+
+        execute("feature", repo_dir.path(), &db, Strategy::Rebase)
+            .expect("sync should succeed");
+
+        // Find the worktree and check for "synced" event
+        let db_repo = db.get_repo_by_path(&repo_path_str).unwrap().unwrap();
+        let wt = db
+            .find_worktree_by_identifier(db_repo.id, "feature")
+            .unwrap()
+            .unwrap();
+
+        let events = db.list_events(wt.id, 10).unwrap();
+        assert!(
+            events.iter().any(|e| e.event_type == "synced"),
+            "should have a 'synced' event in DB"
+        );
+
+        // Verify payload contains strategy and counts
+        let synced_event = events.iter().find(|e| e.event_type == "synced").unwrap();
+        let payload: serde_json::Value =
+            serde_json::from_str(synced_event.payload.as_deref().unwrap()).unwrap();
+        assert_eq!(payload["strategy"], "rebase");
+        assert_eq!(payload["base_branch"], "main");
+        assert!(payload["before"].is_object());
+        assert!(payload["after"].is_object());
+    }
+
+    #[test]
     fn sync_adopts_unmanaged_worktree() {
         let repo_dir = tempfile::tempdir().unwrap();
         let git_repo = init_repo_with_commit(repo_dir.path());

--- a/src/cli/commands/sync.rs
+++ b/src/cli/commands/sync.rs
@@ -562,6 +562,16 @@ mod tests {
     }
 
     #[test]
+    fn strategy_display_rebase() {
+        assert_eq!(Strategy::Rebase.to_string(), "rebase");
+    }
+
+    #[test]
+    fn strategy_display_merge() {
+        assert_eq!(Strategy::Merge.to_string(), "merge");
+    }
+
+    #[test]
     fn sync_adopts_unmanaged_worktree() {
         let repo_dir = tempfile::tempdir().unwrap();
         let git_repo = init_repo_with_commit(repo_dir.path());

--- a/src/cli/commands/sync.rs
+++ b/src/cli/commands/sync.rs
@@ -524,6 +524,44 @@ mod tests {
     }
 
     #[test]
+    fn sync_result_to_json_has_expected_structure() {
+        let result = SyncResult {
+            name: "my-feature".to_string(),
+            strategy: Strategy::Rebase,
+            before_ahead: 2,
+            before_behind: 3,
+            after_ahead: 2,
+            after_behind: 0,
+        };
+
+        let json = result.to_json();
+        let serialized = serde_json::to_value(&json).unwrap();
+
+        assert_eq!(serialized["name"], "my-feature");
+        assert_eq!(serialized["strategy"], "rebase");
+        assert_eq!(serialized["before"]["ahead"], 2);
+        assert_eq!(serialized["before"]["behind"], 3);
+        assert_eq!(serialized["after"]["ahead"], 2);
+        assert_eq!(serialized["after"]["behind"], 0);
+    }
+
+    #[test]
+    fn sync_result_json_strategy_merge() {
+        let result = SyncResult {
+            name: "feat".to_string(),
+            strategy: Strategy::Merge,
+            before_ahead: 1,
+            before_behind: 1,
+            after_ahead: 2,
+            after_behind: 0,
+        };
+
+        let json = result.to_json();
+        let serialized = serde_json::to_value(&json).unwrap();
+        assert_eq!(serialized["strategy"], "merge");
+    }
+
+    #[test]
     fn sync_adopts_unmanaged_worktree() {
         let repo_dir = tempfile::tempdir().unwrap();
         let git_repo = init_repo_with_commit(repo_dir.path());

--- a/src/cli/commands/sync.rs
+++ b/src/cli/commands/sync.rs
@@ -521,6 +521,14 @@ mod tests {
             msg.contains("merge conflict") || msg.contains("conflict"),
             "error should mention conflict, got: {msg}"
         );
+
+        // After merge conflict error, MERGE_HEAD should be preserved so users can resolve
+        let wt_repo = git2::Repository::open(&wt_path).unwrap();
+        let merge_head_path = wt_repo.path().join("MERGE_HEAD");
+        assert!(
+            merge_head_path.exists(),
+            "MERGE_HEAD should be preserved after merge conflict so users can run `git merge --continue`"
+        );
     }
 
     #[test]

--- a/src/cli/commands/sync.rs
+++ b/src/cli/commands/sync.rs
@@ -87,7 +87,7 @@ pub fn execute(
         .base_branch
         .as_deref()
         .or(repo.default_base.as_deref())
-        .unwrap_or("main");
+        .unwrap_or(repo_info.default_branch.as_str());
 
     // Get before counts
     let (before_ahead, before_behind) =
@@ -670,5 +670,85 @@ mod tests {
             .expect("adopted worktree should be in DB");
         assert!(wt.adopted_at.is_some(), "adopted_at should be set");
         assert!(wt.managed, "should be managed after adoption");
+    }
+
+    #[test]
+    fn sync_falls_back_to_discovered_default_branch() {
+        // Create repo WITHOUT renaming to "main" — git2 defaults to "master"
+        let repo_dir = tempfile::tempdir().unwrap();
+        let git_repo = init_repo_with_commit(repo_dir.path());
+        let db = Database::open_in_memory().unwrap();
+
+        let repo_path = repo_dir.path().canonicalize().unwrap();
+        let repo_path_str = repo_path.to_str().unwrap().to_string();
+
+        // Get the actual default branch name (likely "master")
+        let default_branch = git_repo
+            .head()
+            .unwrap()
+            .shorthand()
+            .unwrap()
+            .to_string();
+
+        // Create feature branch from current HEAD
+        {
+            let head_commit = git_repo.head().unwrap().peel_to_commit().unwrap();
+            git_repo.branch("feat-master", &head_commit, false).unwrap();
+        }
+
+        // Create worktree
+        let wt_dir = tempfile::tempdir().unwrap();
+        let wt_path = wt_dir.path().join("feat-master");
+        {
+            let branch_ref = git_repo
+                .find_branch("feat-master", git2::BranchType::Local)
+                .unwrap();
+            let mut opts = git2::WorktreeAddOptions::new();
+            opts.reference(Some(branch_ref.get()));
+            git_repo
+                .worktree("feat-master", &wt_path, Some(&opts))
+                .unwrap();
+        }
+
+        // Add a commit on the feature branch so rebase has work to do
+        let wt_repo = git2::Repository::open(&wt_path).unwrap();
+        commit_file(&wt_repo, "feature.txt", "feature work", "feature commit");
+
+        // Register repo WITHOUT default_base
+        db.insert_repo("test-repo", &repo_path_str, None).unwrap();
+        let db_repo = db.get_repo_by_path(&repo_path_str).unwrap().unwrap();
+        // Register worktree WITHOUT base_branch
+        let wt_path_str = wt_path.canonicalize().unwrap_or(wt_path.clone());
+        db.insert_worktree(
+            db_repo.id,
+            "feat-master",
+            "feat-master",
+            wt_path_str.to_str().unwrap(),
+            None,
+        )
+        .unwrap();
+
+        // Add a commit on the default branch to create divergence
+        {
+            let head_ref = format!("refs/heads/{default_branch}");
+            let main_obj = git_repo.revparse_single(&head_ref).unwrap();
+            git_repo.checkout_tree(&main_obj, None).unwrap();
+            git_repo.set_head(&head_ref).unwrap();
+        }
+        commit_file(
+            &git_repo,
+            "upstream.txt",
+            "upstream change",
+            "upstream commit",
+        );
+
+        // Should succeed using discovered default branch (not hard-coded "main")
+        let result = execute("feat-master", repo_dir.path(), &db, Strategy::Rebase)
+            .expect("sync should succeed using discovered default branch");
+        assert_eq!(result.name, "feat-master");
+        assert_eq!(
+            result.after_behind, 0,
+            "should be 0 behind after rebase onto discovered default branch"
+        );
     }
 }

--- a/src/cli/commands/sync.rs
+++ b/src/cli/commands/sync.rs
@@ -138,6 +138,9 @@ mod tests {
     fn init_repo_with_commit(dir: &Path) -> git2::Repository {
         let repo = git2::Repository::init(dir).expect("failed to init repo");
         {
+            let mut config = repo.config().unwrap();
+            config.set_str("user.name", "Test").unwrap();
+            config.set_str("user.email", "test@test.com").unwrap();
             let sig = git2::Signature::now("Test", "test@test.com").unwrap();
             let tree_id = repo.index().unwrap().write_tree().unwrap();
             let tree = repo.find_tree(tree_id).unwrap();
@@ -748,6 +751,34 @@ mod tests {
         assert_eq!(
             result.after_behind, 0,
             "should be 0 behind after rebase onto discovered default branch"
+        );
+    }
+
+    #[test]
+    fn sync_rebase_uses_repo_configured_identity() {
+        let (_git_repo, wt_path, db, repo_dir, _wt_dir, _repo_path_str) = setup_diverged_repo();
+
+        // Set custom user identity in repo config
+        let main_repo = git2::Repository::open(repo_dir.path()).unwrap();
+        let mut config = main_repo.config().unwrap();
+        config.set_str("user.name", "Custom User").unwrap();
+        config.set_str("user.email", "custom@example.com").unwrap();
+
+        let _result = execute("feature", repo_dir.path(), &db, Strategy::Rebase)
+            .expect("rebase sync should succeed");
+
+        // The HEAD commit in the worktree should use the repo-configured identity
+        let wt_repo = git2::Repository::open(&wt_path).unwrap();
+        let head = wt_repo.head().unwrap().peel_to_commit().unwrap();
+        assert_eq!(
+            head.committer().name().unwrap(),
+            "Custom User",
+            "committer name should match repo config"
+        );
+        assert_eq!(
+            head.committer().email().unwrap(),
+            "custom@example.com",
+            "committer email should match repo config"
         );
     }
 }

--- a/src/cli/commands/sync.rs
+++ b/src/cli/commands/sync.rs
@@ -99,7 +99,9 @@ pub fn execute(
         .unwrap_or(repo_info.default_branch.as_str());
 
     // Fetch from remote before capturing the baseline counts
-    crate::git::fetch_remote(Path::new(&repo_info.path))?;
+    if let Err(e) = crate::git::fetch_remote(Path::new(&repo_info.path)) {
+        eprintln!("warning: fetch failed, using local refs: {e}");
+    }
 
     let (before_ahead, before_behind) =
         crate::git::ahead_behind(Path::new(&repo_info.path), &wt.branch, Some(base_branch))?
@@ -795,5 +797,23 @@ mod tests {
             "custom@example.com",
             "committer email should match repo config"
         );
+    }
+
+    #[test]
+    fn sync_continues_when_fetch_fails() {
+        let f = setup_diverged_repo();
+
+        // Add a broken remote so fetch_remote will fail
+        let main_repo = git2::Repository::open(f._repo_dir.path()).unwrap();
+        main_repo
+            .remote("origin", "https://invalid.example.com/nonexistent.git")
+            .unwrap();
+
+        // Sync should still succeed despite the fetch failure
+        let result = execute("feature", f._repo_dir.path(), &f.db, Strategy::Rebase)
+            .expect("sync should succeed even when fetch fails");
+
+        assert_eq!(result.name, "feature");
+        assert_eq!(result.after_behind, 0, "should still rebase successfully");
     }
 }

--- a/src/cli/commands/sync.rs
+++ b/src/cli/commands/sync.rs
@@ -87,7 +87,8 @@ pub fn execute(
     if dirty > 0 {
         anyhow::bail!(
             "worktree '{}' has {} uncommitted change(s); commit or stash before syncing",
-            wt.name, dirty
+            wt.name,
+            dirty
         );
     }
 
@@ -173,16 +174,17 @@ mod tests {
             .unwrap();
     }
 
+    struct DivergentRepoFixture {
+        _git_repo: git2::Repository,
+        wt_path: std::path::PathBuf,
+        db: Database,
+        _repo_dir: tempfile::TempDir,
+        _wt_dir: tempfile::TempDir,
+        repo_path_str: String,
+    }
+
     /// Set up a test scenario with a main repo, a worktree branch behind main.
-    /// Returns (main_repo, worktree_path, db, repo_path_str).
-    fn setup_diverged_repo() -> (
-        git2::Repository,
-        std::path::PathBuf,
-        Database,
-        tempfile::TempDir,
-        tempfile::TempDir,
-        String,
-    ) {
+    fn setup_diverged_repo() -> DivergentRepoFixture {
         let repo_dir = tempfile::tempdir().unwrap();
         let git_repo = init_repo_with_commit(repo_dir.path());
         let db = Database::open_in_memory().unwrap();
@@ -193,11 +195,7 @@ mod tests {
         // Rename HEAD branch to "main" for consistency
         git_repo
             .find_branch(
-                git_repo
-                    .head()
-                    .unwrap()
-                    .shorthand()
-                    .unwrap(),
+                git_repo.head().unwrap().shorthand().unwrap(),
                 git2::BranchType::Local,
             )
             .unwrap()
@@ -207,9 +205,7 @@ mod tests {
         // Create feature branch at current main
         {
             let head_commit = git_repo.head().unwrap().peel_to_commit().unwrap();
-            git_repo
-                .branch("feature", &head_commit, false)
-                .unwrap();
+            git_repo.branch("feature", &head_commit, false).unwrap();
         }
 
         // Create worktree for the feature branch
@@ -221,9 +217,7 @@ mod tests {
                 .unwrap();
             let mut opts = git2::WorktreeAddOptions::new();
             opts.reference(Some(branch_ref.get()));
-            git_repo
-                .worktree("feature", &wt_path, Some(&opts))
-                .unwrap();
+            git_repo.worktree("feature", &wt_path, Some(&opts)).unwrap();
         }
 
         // Add a commit on the feature branch (in worktree)
@@ -237,7 +231,12 @@ mod tests {
             git_repo.checkout_tree(&main_obj, None).unwrap();
             git_repo.set_head("refs/heads/main").unwrap();
         }
-        commit_file(&git_repo, "upstream.txt", "upstream change", "upstream commit on main");
+        commit_file(
+            &git_repo,
+            "upstream.txt",
+            "upstream change",
+            "upstream commit on main",
+        );
 
         // Register in DB
         db.insert_repo("test-repo", &repo_path_str, Some("main"))
@@ -253,15 +252,22 @@ mod tests {
         )
         .unwrap();
 
-        (git_repo, wt_path, db, repo_dir, wt_dir, repo_path_str)
+        DivergentRepoFixture {
+            _git_repo: git_repo,
+            wt_path,
+            db,
+            _repo_dir: repo_dir,
+            _wt_dir: wt_dir,
+            repo_path_str,
+        }
     }
 
     #[test]
     fn sync_rebase_rebases_branch_onto_main() {
-        let (_git_repo, wt_path, db, repo_dir, _wt_dir, _repo_path_str) = setup_diverged_repo();
+        let f = setup_diverged_repo();
 
         // Before sync: feature should be 1 behind main
-        let result = execute("feature", repo_dir.path(), &db, Strategy::Rebase)
+        let result = execute("feature", f._repo_dir.path(), &f.db, Strategy::Rebase)
             .expect("rebase sync should succeed");
 
         assert_eq!(result.name, "feature");
@@ -272,27 +278,27 @@ mod tests {
         assert_eq!(result.after_behind, 0, "should be 0 behind after rebase");
 
         // Feature branch should still have its commit + upstream file should exist
-        let wt_repo = git2::Repository::open(&wt_path).unwrap();
+        let wt_repo = git2::Repository::open(&f.wt_path).unwrap();
         let head = wt_repo.head().unwrap().peel_to_commit().unwrap();
         assert!(
             head.message().unwrap().contains("feature commit"),
             "feature commit should be on top after rebase"
         );
         assert!(
-            wt_path.join("upstream.txt").exists(),
+            f.wt_path.join("upstream.txt").exists(),
             "upstream file should exist after rebase"
         );
         assert!(
-            wt_path.join("feature.txt").exists(),
+            f.wt_path.join("feature.txt").exists(),
             "feature file should still exist after rebase"
         );
     }
 
     #[test]
     fn sync_merge_merges_base_into_branch() {
-        let (_git_repo, wt_path, db, repo_dir, _wt_dir, _repo_path_str) = setup_diverged_repo();
+        let f = setup_diverged_repo();
 
-        let result = execute("feature", repo_dir.path(), &db, Strategy::Merge)
+        let result = execute("feature", f._repo_dir.path(), &f.db, Strategy::Merge)
             .expect("merge sync should succeed");
 
         assert_eq!(result.name, "feature");
@@ -304,39 +310,35 @@ mod tests {
 
         // Both files should exist
         assert!(
-            wt_path.join("upstream.txt").exists(),
+            f.wt_path.join("upstream.txt").exists(),
             "upstream file should exist after merge"
         );
         assert!(
-            wt_path.join("feature.txt").exists(),
+            f.wt_path.join("feature.txt").exists(),
             "feature file should still exist after merge"
         );
 
         // Should have a merge commit (the HEAD commit should have 2 parents)
-        let wt_repo = git2::Repository::open(&wt_path).unwrap();
+        let wt_repo = git2::Repository::open(&f.wt_path).unwrap();
         let head = wt_repo.head().unwrap().peel_to_commit().unwrap();
-        assert_eq!(
-            head.parent_count(),
-            2,
-            "merge commit should have 2 parents"
-        );
+        assert_eq!(head.parent_count(), 2, "merge commit should have 2 parents");
     }
 
     #[test]
     fn sync_writes_synced_event_to_db() {
-        let (_git_repo, _wt_path, db, repo_dir, _wt_dir, repo_path_str) = setup_diverged_repo();
+        let f = setup_diverged_repo();
 
-        execute("feature", repo_dir.path(), &db, Strategy::Rebase)
+        execute("feature", f._repo_dir.path(), &f.db, Strategy::Rebase)
             .expect("sync should succeed");
 
         // Find the worktree and check for "synced" event
-        let db_repo = db.get_repo_by_path(&repo_path_str).unwrap().unwrap();
-        let wt = db
-            .find_worktree_by_identifier(db_repo.id, "feature")
-            .unwrap()
-            .unwrap();
+        let db_repo = f.db.get_repo_by_path(&f.repo_path_str).unwrap().unwrap();
+        let wt =
+            f.db.find_worktree_by_identifier(db_repo.id, "feature")
+                .unwrap()
+                .unwrap();
 
-        let events = db.list_events(wt.id, 10).unwrap();
+        let events = f.db.list_events(wt.id, 10).unwrap();
         assert!(
             events.iter().any(|e| e.event_type == "synced"),
             "should have a 'synced' event in DB"
@@ -363,12 +365,7 @@ mod tests {
 
         // Rename HEAD to "main"
         {
-            let name = git_repo
-                .head()
-                .unwrap()
-                .shorthand()
-                .unwrap()
-                .to_string();
+            let name = git_repo.head().unwrap().shorthand().unwrap().to_string();
             git_repo
                 .find_branch(&name, git2::BranchType::Local)
                 .unwrap()
@@ -379,7 +376,9 @@ mod tests {
         // Create feature branch
         {
             let head_commit = git_repo.head().unwrap().peel_to_commit().unwrap();
-            git_repo.branch("conflict-feat", &head_commit, false).unwrap();
+            git_repo
+                .branch("conflict-feat", &head_commit, false)
+                .unwrap();
         }
 
         // Create worktree
@@ -459,12 +458,7 @@ mod tests {
         let repo_path_str = repo_path.to_str().unwrap();
 
         {
-            let name = git_repo
-                .head()
-                .unwrap()
-                .shorthand()
-                .unwrap()
-                .to_string();
+            let name = git_repo.head().unwrap().shorthand().unwrap().to_string();
             git_repo
                 .find_branch(&name, git2::BranchType::Local)
                 .unwrap()
@@ -474,7 +468,9 @@ mod tests {
 
         {
             let head_commit = git_repo.head().unwrap().peel_to_commit().unwrap();
-            git_repo.branch("merge-conflict", &head_commit, false).unwrap();
+            git_repo
+                .branch("merge-conflict", &head_commit, false)
+                .unwrap();
         }
 
         let wt_dir = tempfile::tempdir().unwrap();
@@ -591,15 +587,18 @@ mod tests {
 
     #[test]
     fn sync_rebase_shows_correct_ahead_counts() {
-        let (_git_repo, _wt_path, db, repo_dir, _wt_dir, _repo_path_str) = setup_diverged_repo();
+        let f = setup_diverged_repo();
 
-        let result = execute("feature", repo_dir.path(), &db, Strategy::Rebase)
+        let result = execute("feature", f._repo_dir.path(), &f.db, Strategy::Rebase)
             .expect("sync should succeed");
 
         // Feature has 1 commit ahead of main (the "feature commit")
         assert_eq!(result.before_ahead, 1, "should be 1 ahead before sync");
         // After rebase, still 1 ahead (the rebased feature commit)
-        assert_eq!(result.after_ahead, 1, "should still be 1 ahead after rebase");
+        assert_eq!(
+            result.after_ahead, 1,
+            "should still be 1 ahead after rebase"
+        );
         // Before: 1 behind (main has upstream commit)
         assert_eq!(result.before_behind, 1);
         // After: 0 behind
@@ -608,16 +607,19 @@ mod tests {
 
     #[test]
     fn sync_merge_shows_correct_ahead_counts() {
-        let (_git_repo, _wt_path, db, repo_dir, _wt_dir, _repo_path_str) = setup_diverged_repo();
+        let f = setup_diverged_repo();
 
-        let result = execute("feature", repo_dir.path(), &db, Strategy::Merge)
+        let result = execute("feature", f._repo_dir.path(), &f.db, Strategy::Merge)
             .expect("sync should succeed");
 
         // Before: 1 ahead (feature commit), 1 behind (upstream commit)
         assert_eq!(result.before_ahead, 1);
         assert_eq!(result.before_behind, 1);
         // After merge: ahead increases (feature commit + merge commit), behind = 0
-        assert!(result.after_ahead >= 2, "should be at least 2 ahead after merge (feature + merge commit)");
+        assert!(
+            result.after_ahead >= 2,
+            "should be at least 2 ahead after merge (feature + merge commit)"
+        );
         assert_eq!(result.after_behind, 0);
     }
 
@@ -629,12 +631,7 @@ mod tests {
 
         // Rename HEAD branch to "main"
         {
-            let head_branch_name = git_repo
-                .head()
-                .unwrap()
-                .shorthand()
-                .unwrap()
-                .to_string();
+            let head_branch_name = git_repo.head().unwrap().shorthand().unwrap().to_string();
             git_repo
                 .find_branch(&head_branch_name, git2::BranchType::Local)
                 .unwrap()
@@ -652,9 +649,7 @@ mod tests {
         let wt_path = wt_dir.path().join("sync-feat");
         {
             let head_commit = git_repo.head().unwrap().peel_to_commit().unwrap();
-            git_repo
-                .branch("sync-feat", &head_commit, false)
-                .unwrap();
+            git_repo.branch("sync-feat", &head_commit, false).unwrap();
         }
         {
             let branch_ref = git_repo
@@ -693,12 +688,7 @@ mod tests {
         let repo_path_str = repo_path.to_str().unwrap().to_string();
 
         // Get the actual default branch name (likely "master")
-        let default_branch = git_repo
-            .head()
-            .unwrap()
-            .shorthand()
-            .unwrap()
-            .to_string();
+        let default_branch = git_repo.head().unwrap().shorthand().unwrap().to_string();
 
         // Create feature branch from current HEAD
         {
@@ -764,12 +754,12 @@ mod tests {
 
     #[test]
     fn sync_rebase_rejects_dirty_worktree() {
-        let (_git_repo, wt_path, db, repo_dir, _wt_dir, _repo_path_str) = setup_diverged_repo();
+        let f = setup_diverged_repo();
 
         // Write an uncommitted file to the worktree
-        std::fs::write(wt_path.join("dirty.txt"), "uncommitted change").unwrap();
+        std::fs::write(f.wt_path.join("dirty.txt"), "uncommitted change").unwrap();
 
-        let err = execute("feature", repo_dir.path(), &db, Strategy::Rebase)
+        let err = execute("feature", f._repo_dir.path(), &f.db, Strategy::Rebase)
             .expect_err("sync should reject dirty worktree");
 
         let msg = err.to_string();
@@ -781,19 +771,19 @@ mod tests {
 
     #[test]
     fn sync_rebase_uses_repo_configured_identity() {
-        let (_git_repo, wt_path, db, repo_dir, _wt_dir, _repo_path_str) = setup_diverged_repo();
+        let f = setup_diverged_repo();
 
         // Set custom user identity in repo config
-        let main_repo = git2::Repository::open(repo_dir.path()).unwrap();
+        let main_repo = git2::Repository::open(f._repo_dir.path()).unwrap();
         let mut config = main_repo.config().unwrap();
         config.set_str("user.name", "Custom User").unwrap();
         config.set_str("user.email", "custom@example.com").unwrap();
 
-        let _result = execute("feature", repo_dir.path(), &db, Strategy::Rebase)
+        let _result = execute("feature", f._repo_dir.path(), &f.db, Strategy::Rebase)
             .expect("rebase sync should succeed");
 
         // The HEAD commit in the worktree should use the repo-configured identity
-        let wt_repo = git2::Repository::open(&wt_path).unwrap();
+        let wt_repo = git2::Repository::open(&f.wt_path).unwrap();
         let head = wt_repo.head().unwrap().peel_to_commit().unwrap();
         assert_eq!(
             head.committer().name().unwrap(),

--- a/src/cli/commands/sync.rs
+++ b/src/cli/commands/sync.rs
@@ -89,13 +89,12 @@ pub fn execute(
         .or(repo.default_base.as_deref())
         .unwrap_or(repo_info.default_branch.as_str());
 
-    // Get before counts
+    // Fetch from remote before capturing the baseline counts
+    crate::git::fetch_remote(Path::new(&repo_info.path))?;
+
     let (before_ahead, before_behind) =
         crate::git::ahead_behind(Path::new(&repo_info.path), &wt.branch, Some(base_branch))?
             .unwrap_or((0, 0));
-
-    // Fetch from remote
-    crate::git::fetch_remote(Path::new(&repo_info.path))?;
 
     // Perform sync
     match strategy {

--- a/src/cli/commands/sync.rs
+++ b/src/cli/commands/sync.rs
@@ -83,6 +83,14 @@ pub fn execute(
     let repo_info = crate::git::discover_repo(cwd)?;
     let (repo, wt) = crate::adopt::resolve_or_adopt(identifier, &repo_info, db)?;
 
+    let dirty = crate::git::dirty_count(Path::new(&wt.path))?;
+    if dirty > 0 {
+        anyhow::bail!(
+            "worktree '{}' has {} uncommitted change(s); commit or stash before syncing",
+            wt.name, dirty
+        );
+    }
+
     let base_branch = wt
         .base_branch
         .as_deref()
@@ -751,6 +759,23 @@ mod tests {
         assert_eq!(
             result.after_behind, 0,
             "should be 0 behind after rebase onto discovered default branch"
+        );
+    }
+
+    #[test]
+    fn sync_rebase_rejects_dirty_worktree() {
+        let (_git_repo, wt_path, db, repo_dir, _wt_dir, _repo_path_str) = setup_diverged_repo();
+
+        // Write an uncommitted file to the worktree
+        std::fs::write(wt_path.join("dirty.txt"), "uncommitted change").unwrap();
+
+        let err = execute("feature", repo_dir.path(), &db, Strategy::Rebase)
+            .expect_err("sync should reject dirty worktree");
+
+        let msg = err.to_string();
+        assert!(
+            msg.contains("uncommitted"),
+            "error should mention uncommitted changes, got: {msg}"
         );
     }
 

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -227,6 +227,7 @@ pub fn sync_rebase(
 
     let sig = git2::Signature::now("trench", "trench@localhost")?;
 
+    let mut last_commit_oid = None;
     while let Some(op) = rebase.next() {
         let _op = op?;
         // Check for conflicts
@@ -237,10 +238,18 @@ pub fn sync_rebase(
                 branch: branch.to_string(),
             });
         }
-        rebase.commit(None, &sig, None)?;
+        last_commit_oid = Some(rebase.commit(None, &sig, None)?);
     }
 
     rebase.finish(None)?;
+
+    // Explicitly update the branch ref to point to the rebased HEAD
+    if let Some(oid) = last_commit_oid {
+        let ref_name = format!("refs/heads/{branch}");
+        repo.reference(&ref_name, oid, true, "trench sync: rebase")?;
+        repo.checkout_head(Some(git2::build::CheckoutBuilder::default().force()))?;
+    }
+
     Ok(())
 }
 

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -228,7 +228,7 @@ pub fn sync_rebase(
         None,
     )?;
 
-    let sig = git2::Signature::now("trench", "trench@localhost")?;
+    let sig = repo.signature()?;
 
     let mut last_commit_oid = None;
     while let Some(op) = rebase.next() {
@@ -300,7 +300,7 @@ pub fn sync_merge(
     }
 
     // Create merge commit
-    let sig = git2::Signature::now("trench", "trench@localhost")?;
+    let sig = repo.signature()?;
     let tree_oid = repo.index()?.write_tree()?;
     let tree = repo.find_tree(tree_oid)?;
     let head_commit = repo.head()?.peel_to_commit()?;

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -173,6 +173,162 @@ pub fn ahead_behind(
     }
 }
 
+/// Fetch from the default remote (origin).
+///
+/// Best-effort: if no remote exists or the fetch fails, the error is
+/// returned so callers can decide whether to proceed.
+pub fn fetch_remote(repo_path: &Path) -> Result<(), GitError> {
+    let repo =
+        git2::Repository::open(repo_path).map_err(|e| map_repo_open_error(e, repo_path))?;
+
+    let remote_name = "origin";
+    let mut remote = match repo.find_remote(remote_name) {
+        Ok(r) => r,
+        Err(_) => return Ok(()), // No remote — nothing to fetch
+    };
+
+    remote.fetch(&[] as &[&str], None, None)?;
+    Ok(())
+}
+
+/// Rebase a worktree branch onto its base branch.
+///
+/// Opens the repository at `worktree_path` and rebases the current branch
+/// onto `origin/<base_branch>` (or local `<base_branch>` if no remote ref).
+pub fn sync_rebase(
+    worktree_path: &Path,
+    branch: &str,
+    base_branch: &str,
+) -> Result<(), GitError> {
+    let repo = git2::Repository::open(worktree_path)
+        .map_err(|e| map_repo_open_error(e, worktree_path))?;
+
+    let upstream_oid = resolve_upstream_oid(&repo, base_branch)?;
+    let branch_oid = repo
+        .find_branch(branch, git2::BranchType::Local)
+        .map_err(|_| GitError::WorktreeNotFound {
+            name: branch.to_string(),
+        })?
+        .get()
+        .target()
+        .ok_or_else(|| GitError::BaseBranchNotFound {
+            base: branch.to_string(),
+        })?;
+
+    let upstream_annotated = repo.find_annotated_commit(upstream_oid)?;
+    let branch_annotated = repo.find_annotated_commit(branch_oid)?;
+
+    let mut rebase = repo.rebase(
+        Some(&branch_annotated),
+        Some(&upstream_annotated),
+        None,
+        None,
+    )?;
+
+    let sig = git2::Signature::now("trench", "trench@localhost")?;
+
+    while let Some(op) = rebase.next() {
+        let _op = op?;
+        // Check for conflicts
+        let index = repo.index()?;
+        if index.has_conflicts() {
+            rebase.abort()?;
+            return Err(GitError::MergeConflict {
+                branch: branch.to_string(),
+            });
+        }
+        rebase.commit(None, &sig, None)?;
+    }
+
+    rebase.finish(None)?;
+    Ok(())
+}
+
+/// Merge the base branch into a worktree branch.
+///
+/// Opens the repository at `worktree_path` and merges
+/// `origin/<base_branch>` (or local `<base_branch>`) into the current branch.
+pub fn sync_merge(
+    worktree_path: &Path,
+    branch: &str,
+    base_branch: &str,
+) -> Result<(), GitError> {
+    let repo = git2::Repository::open(worktree_path)
+        .map_err(|e| map_repo_open_error(e, worktree_path))?;
+
+    let upstream_oid = resolve_upstream_oid(&repo, base_branch)?;
+    let upstream_annotated = repo.find_annotated_commit(upstream_oid)?;
+
+    let (merge_analysis, _) = repo.merge_analysis(&[&upstream_annotated])?;
+
+    if merge_analysis.is_up_to_date() {
+        return Ok(());
+    }
+
+    if merge_analysis.is_fast_forward() {
+        // Fast-forward
+        let mut ref_name = format!("refs/heads/{branch}");
+        if repo.find_reference(&ref_name).is_err() {
+            ref_name = repo.head()?.name().unwrap_or("HEAD").to_string();
+        }
+        repo.find_reference(&ref_name)?
+            .set_target(upstream_oid, "trench sync: fast-forward")?;
+        repo.checkout_head(Some(git2::build::CheckoutBuilder::default().force()))?;
+        return Ok(());
+    }
+
+    // Normal merge
+    repo.merge(&[&upstream_annotated], None, None)?;
+
+    let index = repo.index()?;
+    if index.has_conflicts() {
+        let _ = repo.cleanup_state();
+        return Err(GitError::MergeConflict {
+            branch: branch.to_string(),
+        });
+    }
+
+    // Create merge commit
+    let sig = git2::Signature::now("trench", "trench@localhost")?;
+    let tree_oid = repo.index()?.write_tree()?;
+    let tree = repo.find_tree(tree_oid)?;
+    let head_commit = repo.head()?.peel_to_commit()?;
+    let upstream_commit = repo.find_commit(upstream_oid)?;
+    let msg = format!("trench sync: merge {base_branch} into {branch}");
+    repo.commit(
+        Some("HEAD"),
+        &sig,
+        &sig,
+        &msg,
+        &tree,
+        &[&head_commit, &upstream_commit],
+    )?;
+
+    let _ = repo.cleanup_state();
+    Ok(())
+}
+
+/// Resolve the OID for a base branch, preferring origin/<base> over local.
+fn resolve_upstream_oid(
+    repo: &git2::Repository,
+    base_branch: &str,
+) -> Result<git2::Oid, GitError> {
+    let remote_ref = format!("origin/{base_branch}");
+    if let Ok(branch) = repo.find_branch(&remote_ref, git2::BranchType::Remote) {
+        if let Some(oid) = branch.get().target() {
+            return Ok(oid);
+        }
+    }
+    if let Ok(branch) = repo.find_branch(base_branch, git2::BranchType::Local) {
+        if let Some(oid) = branch.get().target() {
+            return Ok(oid);
+        }
+    }
+    Err(GitError::BaseBranchNotFound {
+        base: base_branch.to_string(),
+    })
+}
+
 /// A worktree discovered via git (includes both main and additional worktrees).
 #[derive(Debug, Clone, PartialEq)]
 pub struct GitWorktreeEntry {
@@ -202,6 +358,9 @@ pub enum GitError {
 
     #[error("remote branch '{branch}' not found on {remote}")]
     RemoteBranchNotFound { branch: String, remote: String },
+
+    #[error("merge conflict while syncing '{branch}': resolve conflicts manually")]
+    MergeConflict { branch: String },
 
     #[error("I/O error: {0}")]
     Io(#[from] std::io::Error),

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -184,10 +184,13 @@ pub fn fetch_remote(repo_path: &Path) -> Result<(), GitError> {
     let remote_name = "origin";
     let mut remote = match repo.find_remote(remote_name) {
         Ok(r) => r,
-        Err(_) => return Ok(()), // No remote — nothing to fetch
+        Err(e) if e.code() == git2::ErrorCode::NotFound => return Ok(()),
+        Err(e) => return Err(e.into()),
     };
 
-    remote.fetch(&[] as &[&str], None, None)?;
+    let mut fetch_opts = git2::FetchOptions::new();
+    fetch_opts.prune(git2::FetchPrune::On);
+    remote.fetch(&[] as &[&str], Some(&mut fetch_opts), None)?;
     Ok(())
 }
 

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -268,6 +268,12 @@ pub fn sync_merge(
     let repo = git2::Repository::open(worktree_path)
         .map_err(|e| map_repo_open_error(e, worktree_path))?;
 
+    let _branch_ref = repo
+        .find_branch(branch, git2::BranchType::Local)
+        .map_err(|_| GitError::WorktreeNotFound {
+            name: branch.to_string(),
+        })?;
+
     let upstream_oid = resolve_upstream_oid(&repo, base_branch)?;
     let upstream_annotated = repo.find_annotated_commit(upstream_oid)?;
 
@@ -278,11 +284,7 @@ pub fn sync_merge(
     }
 
     if merge_analysis.is_fast_forward() {
-        // Fast-forward
-        let mut ref_name = format!("refs/heads/{branch}");
-        if repo.find_reference(&ref_name).is_err() {
-            ref_name = repo.head()?.name().unwrap_or("HEAD").to_string();
-        }
+        let ref_name = format!("refs/heads/{branch}");
         repo.find_reference(&ref_name)?
             .set_target(upstream_oid, "trench sync: fast-forward")?;
         repo.checkout_head(Some(git2::build::CheckoutBuilder::default().force()))?;
@@ -1550,6 +1552,22 @@ mod tests {
             "should find 1 worktree despite invalid path, got: {entries:?}"
         );
         assert_eq!(entries[0].name, "valid-wt");
+    }
+
+    #[test]
+    fn sync_merge_rejects_nonexistent_branch() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = init_repo_with_commit(tmp.path());
+        let base = head_branch(&repo);
+
+        let result = sync_merge(tmp.path(), "nonexistent-branch", &base);
+
+        assert!(result.is_err(), "should reject nonexistent branch");
+        let err = result.unwrap_err();
+        assert!(
+            matches!(err, GitError::WorktreeNotFound { ref name } if name == "nonexistent-branch"),
+            "expected WorktreeNotFound, got: {err:?}"
+        );
     }
 
     #[test]

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -291,7 +291,6 @@ pub fn sync_merge(
 
     let index = repo.index()?;
     if index.has_conflicts() {
-        let _ = repo.cleanup_state();
         return Err(GitError::MergeConflict {
             branch: branch.to_string(),
         });

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -327,15 +327,23 @@ fn resolve_upstream_oid(
     base_branch: &str,
 ) -> Result<git2::Oid, GitError> {
     let remote_ref = format!("origin/{base_branch}");
-    if let Ok(branch) = repo.find_branch(&remote_ref, git2::BranchType::Remote) {
-        if let Some(oid) = branch.get().target() {
-            return Ok(oid);
+    match repo.find_branch(&remote_ref, git2::BranchType::Remote) {
+        Ok(branch) => {
+            if let Some(oid) = branch.get().target() {
+                return Ok(oid);
+            }
         }
+        Err(e) if e.code() == git2::ErrorCode::NotFound => {}
+        Err(e) => return Err(GitError::Git(e)),
     }
-    if let Ok(branch) = repo.find_branch(base_branch, git2::BranchType::Local) {
-        if let Some(oid) = branch.get().target() {
-            return Ok(oid);
+    match repo.find_branch(base_branch, git2::BranchType::Local) {
+        Ok(branch) => {
+            if let Some(oid) = branch.get().target() {
+                return Ok(oid);
+            }
         }
+        Err(e) if e.code() == git2::ErrorCode::NotFound => {}
+        Err(e) => return Err(GitError::Git(e)),
     }
     Err(GitError::BaseBranchNotFound {
         base: base_branch.to_string(),

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -214,8 +214,8 @@ pub fn sync_rebase(
         })?
         .get()
         .target()
-        .ok_or_else(|| GitError::BaseBranchNotFound {
-            base: branch.to_string(),
+        .ok_or_else(|| GitError::WorktreeNotFound {
+            name: branch.to_string(),
         })?;
 
     let upstream_annotated = repo.find_annotated_commit(upstream_oid)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -109,10 +109,14 @@ enum Commands {
         /// Omit for summary of all worktrees.
         branch: Option<String>,
     },
-    /// Resolve/adopt a worktree (sync not yet implemented)
+    /// Sync a worktree with its base branch
     Sync {
         /// Branch name or sanitized name of the worktree to sync
         branch: String,
+
+        /// Sync strategy: rebase or merge. Prompts interactively if omitted.
+        #[arg(long)]
+        strategy: Option<SyncStrategy>,
     },
     /// View event log
     Log,
@@ -158,6 +162,13 @@ pub(crate) enum ShellType {
     Bash,
     Zsh,
     Fish,
+}
+
+/// Sync strategy for `trench sync`
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub(crate) enum SyncStrategy {
+    Rebase,
+    Merge,
 }
 
 impl Cli {
@@ -214,7 +225,7 @@ fn main() -> anyhow::Result<()> {
             cli::commands::completions::generate::<Cli>(shell, &mut std::io::stdout());
             Ok(())
         }
-        Some(Commands::Sync { branch }) => run_sync(&branch),
+        Some(Commands::Sync { branch, strategy }) => run_sync(&branch, strategy, json),
         Some(Commands::Log) => {
             // Log command not yet implemented
             Ok(())
@@ -509,20 +520,64 @@ fn run_status(
     }
 }
 
-fn run_sync(identifier: &str) -> anyhow::Result<()> {
+fn run_sync(identifier: &str, strategy: Option<SyncStrategy>, json: bool) -> anyhow::Result<()> {
     let cwd = std::env::current_dir().context("failed to determine current directory")?;
     let db_path = paths::data_dir()?.join("trench.db");
     let db = state::Database::open(&db_path)?;
 
-    match cli::commands::sync::execute(identifier, &cwd, &db) {
+    // Determine strategy: use CLI flag, or prompt interactively
+    let resolved_strategy = match strategy {
+        Some(s) => s,
+        None => {
+            if !std::io::stdin().is_terminal() {
+                eprintln!("error: --strategy is required in non-interactive mode (use --strategy rebase or --strategy merge)");
+                std::process::exit(8);
+            }
+            eprint!("Sync strategy — (r)ebase or (m)erge? ");
+            let mut input = String::new();
+            std::io::stdin()
+                .read_line(&mut input)
+                .context("failed to read strategy input")?;
+            match input.trim().to_lowercase().as_str() {
+                "r" | "rebase" => SyncStrategy::Rebase,
+                "m" | "merge" => SyncStrategy::Merge,
+                other => {
+                    eprintln!("error: unknown strategy '{other}'. Use 'rebase' or 'merge'.");
+                    std::process::exit(1);
+                }
+            }
+        }
+    };
+
+    let sync_strategy = match resolved_strategy {
+        SyncStrategy::Rebase => cli::commands::sync::Strategy::Rebase,
+        SyncStrategy::Merge => cli::commands::sync::Strategy::Merge,
+    };
+
+    match cli::commands::sync::execute(identifier, &cwd, &db, sync_strategy) {
         Ok(result) => {
-            eprintln!(
-                "Resolved worktree '{}' (sync not yet implemented)",
-                result.name
-            );
+            if json {
+                println!("{}", output::json::format_json_value(&result.to_json())?);
+            } else {
+                eprintln!("Synced '{}' via {}", result.name, result.strategy);
+                eprintln!(
+                    "  before: ahead={}, behind={}",
+                    result.before_ahead, result.before_behind
+                );
+                eprintln!(
+                    "  after:  ahead={}, behind={}",
+                    result.after_ahead, result.after_behind
+                );
+            }
             Ok(())
         }
         Err(e) => {
+            if let Some(git::GitError::MergeConflict { .. }) =
+                e.downcast_ref::<git::GitError>()
+            {
+                eprintln!("error: {e}");
+                std::process::exit(5);
+            }
             let msg = e.to_string();
             if msg.contains("not found") || msg.contains("not tracked") {
                 eprintln!("error: {e}");
@@ -1108,5 +1163,50 @@ mod tests {
         assert!(!config.should_color());
         assert!(config.is_quiet());
         assert!(!config.is_verbose());
+    }
+
+    #[test]
+    fn sync_subcommand_accepts_strategy_rebase() {
+        let cli = Cli::try_parse_from(["trench", "sync", "foo", "--strategy", "rebase"])
+            .expect("sync with --strategy rebase should parse");
+        match cli.command {
+            Some(Commands::Sync { branch, strategy }) => {
+                assert_eq!(branch, "foo");
+                assert_eq!(strategy, Some(SyncStrategy::Rebase));
+            }
+            _ => panic!("expected Commands::Sync"),
+        }
+    }
+
+    #[test]
+    fn sync_subcommand_accepts_strategy_merge() {
+        let cli = Cli::try_parse_from(["trench", "sync", "foo", "--strategy", "merge"])
+            .expect("sync with --strategy merge should parse");
+        match cli.command {
+            Some(Commands::Sync { branch, strategy }) => {
+                assert_eq!(branch, "foo");
+                assert_eq!(strategy, Some(SyncStrategy::Merge));
+            }
+            _ => panic!("expected Commands::Sync"),
+        }
+    }
+
+    #[test]
+    fn sync_subcommand_strategy_defaults_to_none() {
+        let cli = Cli::try_parse_from(["trench", "sync", "foo"])
+            .expect("sync without --strategy should parse");
+        match cli.command {
+            Some(Commands::Sync { branch, strategy }) => {
+                assert_eq!(branch, "foo");
+                assert!(strategy.is_none());
+            }
+            _ => panic!("expected Commands::Sync"),
+        }
+    }
+
+    #[test]
+    fn sync_subcommand_rejects_invalid_strategy() {
+        let result = Cli::try_parse_from(["trench", "sync", "foo", "--strategy", "squash"]);
+        assert!(result.is_err(), "invalid strategy should be rejected");
     }
 }


### PR DESCRIPTION
Closes #37

## Summary

- Implements `trench sync <branch>` with full rebase and merge support via `git2`, including `--strategy rebase|merge` flag, interactive prompt, before/after ahead/behind counts, JSON output, and "synced" DB events
- Adds safety guards: dirty-worktree rejection before sync, branch validation in `sync_merge`, and proper error propagation in `resolve_upstream_oid`
- Handles merge conflicts with exit code 5 and preserves merge state for manual resolution

## Changes

### Core sync implementation (`src/cli/commands/sync.rs`)
- `Strategy` enum (Rebase/Merge) with Display trait
- `SyncResult` / `SyncResultJson` structs for structured output
- `execute()` — resolves worktree (with auto-adoption), fetches remote, syncs via chosen strategy, records DB event
- Dirty-worktree guard: rejects sync if worktree has uncommitted changes

### Git operations (`src/git/mod.rs`)
- `sync_rebase()` — rebases worktree branch onto base using `git2::Repository::rebase()`
- `sync_merge()` — merges base into worktree branch (fast-forward or normal merge with merge commit)
- `resolve_upstream_oid()` — resolves base branch OID, preferring `origin/<base>` over local; propagates non-NotFound errors via `match` with explicit `ErrorCode::NotFound` handling
- `fetch_remote()` — best-effort fetch with prune from origin
- Branch validation in `sync_merge` matching `sync_rebase`'s pattern
- `GitError::MergeConflict` variant for conflict reporting

### CLI wiring (`src/main.rs`)
- `--strategy rebase|merge` flag on `sync` subcommand
- Interactive prompt when no strategy specified (TTY) or error on non-TTY
- `--json` output support
- Exit code 5 for merge conflicts, exit code 8 for non-interactive missing strategy

## Test Plan

- 18 sync-related tests (all passing), covering:
  - [x] Rebase sync with diverged history
  - [x] Merge sync with diverged history
  - [x] Synced event written to DB with correct payload
  - [x] Rebase conflict detection and error reporting
  - [x] Merge conflict detection with MERGE_HEAD preservation
  - [x] JSON output serialization
  - [x] Strategy Display trait
  - [x] Before/after ahead/behind counts for both strategies
  - [x] Auto-adoption of unmanaged worktrees
  - [x] Fallback to discovered default branch
  - [x] Repo-configured identity used in rebase commits
  - [x] **Dirty worktree rejection** — sync errors before any mutation if uncommitted changes exist
  - [x] **Nonexistent branch rejection** — `sync_merge` errors with `WorktreeNotFound` if branch doesn't exist
- `cargo clippy`: pass (0 new warnings)
- `cargo test`: all sync tests pass; 2 pre-existing failures unrelated to this PR

## UAT Checklist

- [ ] `trench sync <branch> --strategy rebase` → rebases worktree branch onto base, shows before/after counts
- [ ] `trench sync <branch> --strategy merge` → merges base into worktree branch, shows before/after counts
- [ ] `trench sync <branch>` (no --strategy, in TTY) → prompts for rebase or merge interactively
- [ ] `echo "" | trench sync <branch>` (non-interactive) → exits with code 8 and hint message
- [ ] `trench sync <branch> --strategy rebase --json` → outputs JSON with name, strategy, before/after counts
- [ ] `trench sync <branch>` with conflicting files → exits with code 5 and "merge conflict" message
- [ ] `trench sync <branch>` with dirty worktree → exits with error mentioning "uncommitted"
- [ ] `trench sync <unmanaged-worktree> --strategy rebase` → adopts worktree silently, then syncs
- [ ] After sync, `trench status <branch>` → shows updated ahead/behind (behind=0)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Sync command now supports choosing between rebase or merge strategies, with interactive prompts when not specified.
  * Enhanced sync results display before/after ahead/behind branch counts for improved visibility.
  * Added JSON output format for sync operations.
  * Improved error handling for merge conflicts during sync operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->