### PR TITLE
feat(tui): detail view — branch info, files, commits, hook status

### DIFF
--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -135,20 +135,16 @@ impl App {
         }
     }
 
+    fn open_db() -> Option<(std::path::PathBuf, Database)> {
+        let cwd = std::env::current_dir().ok()?;
+        let db_path = paths::data_dir().ok()?.join("trench.db");
+        let db = Database::open(&db_path).ok()?;
+        Some((cwd, db))
+    }
+
     /// Reload worktree data from git + DB for the list screen.
     pub fn refresh_list(&mut self) {
-        let cwd = match std::env::current_dir() {
-            Ok(p) => p,
-            Err(_) => return,
-        };
-        let db_path = match paths::data_dir() {
-            Ok(p) => p.join("trench.db"),
-            Err(_) => return,
-        };
-        let db = match Database::open(&db_path) {
-            Ok(d) => d,
-            Err(_) => return,
-        };
+        let Some((cwd, db)) = Self::open_db() else { return };
         if let Ok(rows) = screens::list::load_worktrees(&cwd, &db, &[]) {
             let prev_selected = self.list_state.selected;
             self.list_state = screens::list::ListState::new(rows);
@@ -189,18 +185,7 @@ impl App {
             row.branch.clone()
         };
 
-        let cwd = match std::env::current_dir() {
-            Ok(p) => p,
-            Err(_) => return,
-        };
-        let db_path = match paths::data_dir() {
-            Ok(p) => p.join("trench.db"),
-            Err(_) => return,
-        };
-        let db = match Database::open(&db_path) {
-            Ok(d) => d,
-            Err(_) => return,
-        };
+        let Some((cwd, db)) = Self::open_db() else { return };
         let repo_info = match crate::git::discover_repo(&cwd) {
             Ok(r) => r,
             Err(_) => return,
@@ -210,18 +195,7 @@ impl App {
     }
 
     fn load_detail(&mut self, name: &str) {
-        let cwd = match std::env::current_dir() {
-            Ok(p) => p,
-            Err(_) => return,
-        };
-        let db_path = match paths::data_dir() {
-            Ok(p) => p.join("trench.db"),
-            Err(_) => return,
-        };
-        let db = match Database::open(&db_path) {
-            Ok(d) => d,
-            Err(_) => return,
-        };
+        let Some((cwd, db)) = Self::open_db() else { return };
         self.detail_state = Some(screens::detail::load_detail(name, &cwd, &db));
     }
 

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -160,7 +160,7 @@ impl App {
     fn handle_screen_key(&mut self, key: KeyEvent) {
         match self.active_screen() {
             Screen::List => self.handle_list_key(key),
-            Screen::Detail => {}
+            Screen::Detail => self.handle_detail_key(key),
             Screen::Create => {}
             Screen::Help => {}
         }
@@ -196,6 +196,14 @@ impl App {
         };
         let _ = crate::adopt::resolve_or_adopt(&identifier, &repo_info, &db);
         self.refresh_list();
+    }
+
+    fn handle_detail_key(&mut self, key: KeyEvent) {
+        match key.code {
+            KeyCode::Char('s') => {} // TODO: trigger sync
+            KeyCode::Char('o') => {} // TODO: open in $EDITOR
+            _ => {}
+        }
     }
 
     fn handle_list_key(&mut self, key: KeyEvent) {
@@ -569,5 +577,23 @@ mod tests {
             "non-list screens should show placeholder, got: {:?}",
             content.trim()
         );
+    }
+
+    #[test]
+    fn s_on_detail_is_handled_without_crash() {
+        let mut app = App::new();
+        app.push_screen(Screen::Detail);
+        app.handle_key_event(KeyEvent::new(KeyCode::Char('s'), KeyModifiers::NONE));
+        assert!(app.is_running(), "s on detail should not crash or quit");
+        assert_eq!(app.active_screen(), Screen::Detail);
+    }
+
+    #[test]
+    fn o_on_detail_is_handled_without_crash() {
+        let mut app = App::new();
+        app.push_screen(Screen::Detail);
+        app.handle_key_event(KeyEvent::new(KeyCode::Char('o'), KeyModifiers::NONE));
+        assert!(app.is_running(), "o on detail should not crash or quit");
+        assert_eq!(app.active_screen(), Screen::Detail);
     }
 }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -194,9 +194,11 @@ impl App {
         self.refresh_list();
     }
 
-    fn load_detail(&mut self, name: &str) {
-        let Some((cwd, db)) = Self::open_db() else { return };
+    fn load_detail(&mut self, name: &str) -> bool {
+        self.detail_state = None;
+        let Some((cwd, db)) = Self::open_db() else { return false };
         self.detail_state = Some(screens::detail::load_detail(name, &cwd, &db));
+        true
     }
 
     fn handle_detail_key(&mut self, key: KeyEvent) {
@@ -223,9 +225,10 @@ impl App {
                 }
                 // Load detail data for the selected worktree
                 if let Some(name) = identity {
-                    self.load_detail(&name);
+                    if self.load_detail(&name) {
+                        self.push_screen(Screen::Detail);
+                    }
                 }
-                self.push_screen(Screen::Detail);
             }
             KeyCode::Char('n') => self.push_screen(Screen::Create),
             KeyCode::Down | KeyCode::Char('j') => self.list_state.select_next(),
@@ -353,15 +356,15 @@ mod tests {
     }
 
     #[test]
-    fn enter_on_list_pushes_detail() {
-        let mut app = App::new();
+    fn enter_on_list_with_rows_pushes_detail() {
+        let mut app = app_with_rows();
         assert_eq!(app.active_screen(), Screen::List);
 
         app.handle_key_event(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
         assert_eq!(
             app.active_screen(),
             Screen::Detail,
-            "Enter on List should push Detail screen"
+            "Enter on List with rows should push Detail screen"
         );
         assert_eq!(app.nav_stack_depth(), 2);
     }
@@ -399,7 +402,7 @@ mod tests {
 
     #[test]
     fn deep_stack_navigation_push_pop_sequence() {
-        let mut app = App::new();
+        let mut app = app_with_rows();
         // List → Detail → Help → pop → pop → List
         app.handle_key_event(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
         assert_eq!(app.active_screen(), Screen::Detail);
@@ -427,7 +430,7 @@ mod tests {
 
     #[test]
     fn question_mark_opens_help_from_detail_screen() {
-        let mut app = App::new();
+        let mut app = app_with_rows();
         // Navigate to Detail first
         app.handle_key_event(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
         assert_eq!(app.active_screen(), Screen::Detail);
@@ -514,6 +517,19 @@ mod tests {
         app.handle_key_event(KeyEvent::new(KeyCode::Char('D'), KeyModifiers::SHIFT));
         assert!(app.is_running());
         assert_eq!(app.active_screen(), Screen::List);
+    }
+
+    #[test]
+    fn enter_on_empty_list_does_not_push_detail() {
+        let mut app = App::new();
+        // Empty list — no rows
+        app.handle_key_event(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+        assert_eq!(
+            app.active_screen(),
+            Screen::List,
+            "Enter on empty list should stay on List"
+        );
+        assert!(app.detail_state.is_none());
     }
 
     #[test]

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -72,6 +72,7 @@ pub struct App {
     running: bool,
     nav_stack: Vec<Screen>,
     pub list_state: screens::list::ListState,
+    pub detail_state: Option<screens::detail::DetailState>,
 }
 
 impl App {
@@ -80,6 +81,7 @@ impl App {
             running: true,
             nav_stack: vec![Screen::List],
             list_state: screens::list::ListState::new(vec![]),
+            detail_state: None,
         }
     }
 
@@ -105,6 +107,15 @@ impl App {
     pub fn ui(&self, frame: &mut Frame) {
         match self.active_screen() {
             Screen::List => screens::list::render(&self.list_state, frame, frame.area()),
+            Screen::Detail => {
+                if let Some(ref detail) = self.detail_state {
+                    screens::detail::render(detail, frame, frame.area());
+                } else {
+                    let placeholder = Paragraph::new("trench TUI — press q to quit")
+                        .alignment(Alignment::Center);
+                    frame.render_widget(placeholder, frame.area());
+                }
+            }
             _ => {
                 let placeholder =
                     Paragraph::new("trench TUI — press q to quit").alignment(Alignment::Center);
@@ -198,6 +209,22 @@ impl App {
         self.refresh_list();
     }
 
+    fn load_detail(&mut self, name: &str) {
+        let cwd = match std::env::current_dir() {
+            Ok(p) => p,
+            Err(_) => return,
+        };
+        let db_path = match paths::data_dir() {
+            Ok(p) => p.join("trench.db"),
+            Err(_) => return,
+        };
+        let db = match Database::open(&db_path) {
+            Ok(d) => d,
+            Err(_) => return,
+        };
+        self.detail_state = Some(screens::detail::load_detail(name, &cwd, &db));
+    }
+
     fn handle_detail_key(&mut self, key: KeyEvent) {
         match key.code {
             KeyCode::Char('s') => {} // TODO: trigger sync
@@ -215,10 +242,14 @@ impl App {
                     .get(self.list_state.selected)
                     .map(|r| r.name.clone());
                 self.adopt_selected_if_unmanaged();
-                if let Some(name) = identity {
-                    if let Some(idx) = self.list_state.rows.iter().position(|r| r.name == name) {
+                if let Some(ref name) = identity {
+                    if let Some(idx) = self.list_state.rows.iter().position(|r| r.name == *name) {
                         self.list_state.selected = idx;
                     }
+                }
+                // Load detail data for the selected worktree
+                if let Some(name) = identity {
+                    self.load_detail(&name);
                 }
                 self.push_screen(Screen::Detail);
             }
@@ -577,6 +608,61 @@ mod tests {
             "non-list screens should show placeholder, got: {:?}",
             content.trim()
         );
+    }
+
+    fn sample_detail_state() -> screens::detail::DetailState {
+        screens::detail::DetailState {
+            name: "feat-a".into(),
+            branch: "feat/a".into(),
+            path: "/tmp/wt/feat-a".into(),
+            base_branch: "main".into(),
+            ahead_behind: "+0/-0".into(),
+            created: "2026-03-10".into(),
+            last_accessed: "2026-03-11".into(),
+            hook_status: "success".into(),
+            hook_timestamp: "2026-03-10".into(),
+            changed_files: vec![("file.rs".into(), "modified".into())],
+            commits: vec![("abc1234".into(), "test commit".into())],
+        }
+    }
+
+    #[test]
+    fn detail_screen_renders_detail_state_not_placeholder() {
+        let mut app = App::new();
+        app.detail_state = Some(sample_detail_state());
+        app.push_screen(Screen::Detail);
+
+        let backend = ratatui::backend::TestBackend::new(100, 30);
+        let mut terminal = ratatui::Terminal::new(backend).unwrap();
+        terminal.draw(|frame| app.ui(frame)).unwrap();
+        let buffer = terminal.backend().buffer().clone();
+        let content: String = buffer.content().iter().map(|cell| cell.symbol()).collect();
+
+        assert!(
+            content.contains("feat/a"),
+            "detail screen should show branch from detail_state, got: {:?}",
+            content.trim()
+        );
+        assert!(
+            !content.contains("trench TUI"),
+            "detail screen should NOT show placeholder"
+        );
+    }
+
+    #[test]
+    fn detail_screen_shows_changed_files_and_commits() {
+        let mut app = App::new();
+        app.detail_state = Some(sample_detail_state());
+        app.push_screen(Screen::Detail);
+
+        let backend = ratatui::backend::TestBackend::new(100, 30);
+        let mut terminal = ratatui::Terminal::new(backend).unwrap();
+        terminal.draw(|frame| app.ui(frame)).unwrap();
+        let buffer = terminal.backend().buffer().clone();
+        let content: String = buffer.content().iter().map(|cell| cell.symbol()).collect();
+
+        assert!(content.contains("file.rs"), "should show changed file");
+        assert!(content.contains("abc1234"), "should show commit hash");
     }
 
     #[test]

--- a/src/tui/screens/detail.rs
+++ b/src/tui/screens/detail.rs
@@ -22,9 +22,19 @@ pub struct DetailState {
     pub commits: Vec<(String, String)>,
 }
 
+const METADATA_HEIGHT: u16 = 4;
+
 pub fn render(state: &DetailState, frame: &mut Frame, area: Rect) {
     let bold = Style::default().add_modifier(Modifier::BOLD);
 
+    let chunks = Layout::vertical([
+        Constraint::Length(METADATA_HEIGHT),
+        Constraint::Length(1), // separator
+        Constraint::Min(1),   // body (files + commits)
+    ])
+    .split(area);
+
+    // — Metadata section —
     let metadata_lines = vec![
         Line::from(vec![
             Span::styled("Branch: ", bold),
@@ -52,9 +62,18 @@ pub fn render(state: &DetailState, frame: &mut Frame, area: Rect) {
             Span::raw(&state.last_accessed),
         ]),
     ];
+    frame.render_widget(Paragraph::new(metadata_lines), chunks[0]);
 
-    let metadata = Paragraph::new(metadata_lines);
-    frame.render_widget(metadata, area);
+    // — Changed files section —
+    let mut file_lines: Vec<Line> = vec![Line::from(Span::styled("Changed Files", bold))];
+    if state.changed_files.is_empty() {
+        file_lines.push(Line::from("  No changes"));
+    } else {
+        for (path, status) in &state.changed_files {
+            file_lines.push(Line::from(format!("  {status:>10}  {path}")));
+        }
+    }
+    frame.render_widget(Paragraph::new(file_lines), chunks[2]);
 }
 
 #[cfg(test)]
@@ -174,5 +193,26 @@ mod tests {
         let text = buffer_text(&buf);
         assert!(text.contains("2026-03-10 14:30"), "should show created date");
         assert!(text.contains("2026-03-11 09:15"), "should show last accessed");
+    }
+
+    #[test]
+    fn renders_changed_files_section() {
+        let state = sample_detail();
+        let buf = render_to_buffer(&state, 100, 30);
+        let text = buffer_text(&buf);
+        assert!(text.contains("Changed Files"), "should show section header");
+        assert!(text.contains("src/auth.rs"), "should show first changed file");
+        assert!(text.contains("modified"), "should show file status");
+        assert!(text.contains("tests/auth_test.rs"), "should show second file");
+        assert!(text.contains("new"), "should show second file status");
+    }
+
+    #[test]
+    fn renders_no_changes_when_files_empty() {
+        let mut state = sample_detail();
+        state.changed_files = vec![];
+        let buf = render_to_buffer(&state, 100, 30);
+        let text = buffer_text(&buf);
+        assert!(text.contains("No changes"), "should show empty state message");
     }
 }

--- a/src/tui/screens/detail.rs
+++ b/src/tui/screens/detail.rs
@@ -64,6 +64,13 @@ pub fn render(state: &DetailState, frame: &mut Frame, area: Rect) {
     ];
     frame.render_widget(Paragraph::new(metadata_lines), chunks[0]);
 
+    // Split body into files and commits
+    let body_chunks = Layout::vertical([
+        Constraint::Percentage(50),
+        Constraint::Percentage(50),
+    ])
+    .split(chunks[2]);
+
     // — Changed files section —
     let mut file_lines: Vec<Line> = vec![Line::from(Span::styled("Changed Files", bold))];
     if state.changed_files.is_empty() {
@@ -73,7 +80,18 @@ pub fn render(state: &DetailState, frame: &mut Frame, area: Rect) {
             file_lines.push(Line::from(format!("  {status:>10}  {path}")));
         }
     }
-    frame.render_widget(Paragraph::new(file_lines), chunks[2]);
+    frame.render_widget(Paragraph::new(file_lines), body_chunks[0]);
+
+    // — Recent commits section —
+    let mut commit_lines: Vec<Line> = vec![Line::from(Span::styled("Recent Commits", bold))];
+    if state.commits.is_empty() {
+        commit_lines.push(Line::from("  No commits"));
+    } else {
+        for (hash, message) in &state.commits {
+            commit_lines.push(Line::from(format!("  {hash}  {message}")));
+        }
+    }
+    frame.render_widget(Paragraph::new(commit_lines), body_chunks[1]);
 }
 
 #[cfg(test)]
@@ -214,5 +232,25 @@ mod tests {
         let buf = render_to_buffer(&state, 100, 30);
         let text = buffer_text(&buf);
         assert!(text.contains("No changes"), "should show empty state message");
+    }
+
+    #[test]
+    fn renders_recent_commits_section() {
+        let state = sample_detail();
+        let buf = render_to_buffer(&state, 100, 30);
+        let text = buffer_text(&buf);
+        assert!(text.contains("Recent Commits"), "should show commits header");
+        assert!(text.contains("abc1234"), "should show first commit hash");
+        assert!(text.contains("feat: add auth module"), "should show first commit message");
+        assert!(text.contains("def5678"), "should show second commit hash");
+    }
+
+    #[test]
+    fn renders_no_commits_when_empty() {
+        let mut state = sample_detail();
+        state.commits = vec![];
+        let buf = render_to_buffer(&state, 100, 30);
+        let text = buffer_text(&buf);
+        assert!(text.contains("No commits"), "should show empty commits message");
     }
 }

--- a/src/tui/screens/detail.rs
+++ b/src/tui/screens/detail.rs
@@ -24,6 +24,8 @@ pub struct DetailState {
 
 const METADATA_HEIGHT: u16 = 5;
 
+const DETAIL_FOOTER_KEYS: &str = " s sync  o open  Esc back ";
+
 pub fn render(state: &DetailState, frame: &mut Frame, area: Rect) {
     let bold = Style::default().add_modifier(Modifier::BOLD);
 
@@ -31,6 +33,7 @@ pub fn render(state: &DetailState, frame: &mut Frame, area: Rect) {
         Constraint::Length(METADATA_HEIGHT),
         Constraint::Length(1), // separator
         Constraint::Min(1),   // body (files + commits)
+        Constraint::Length(1), // footer
     ])
     .split(area);
 
@@ -99,6 +102,11 @@ pub fn render(state: &DetailState, frame: &mut Frame, area: Rect) {
         }
     }
     frame.render_widget(Paragraph::new(commit_lines), body_chunks[1]);
+
+    // — Footer —
+    let footer = Paragraph::new(Line::from(DETAIL_FOOTER_KEYS))
+        .style(Style::default().add_modifier(Modifier::REVERSED));
+    frame.render_widget(footer, chunks[3]);
 }
 
 #[cfg(test)]
@@ -279,5 +287,29 @@ mod tests {
         let buf = render_to_buffer(&state, 100, 30);
         let text = buffer_text(&buf);
         assert!(text.contains("none"), "should show 'none' for no hooks");
+    }
+
+    #[test]
+    fn renders_detail_footer_with_keybindings() {
+        let state = sample_detail();
+        let buf = render_to_buffer(&state, 100, 30);
+        let text = buffer_text(&buf);
+        assert!(text.contains("s sync"), "footer should show s sync");
+        assert!(text.contains("o open"), "footer should show o open");
+        assert!(text.contains("Esc back"), "footer should show Esc back");
+    }
+
+    #[test]
+    fn footer_is_on_last_line() {
+        let state = sample_detail();
+        let height: u16 = 20;
+        let buf = render_to_buffer(&state, 100, height);
+        // Extract last line text
+        let last_row = height - 1;
+        let mut last_line = String::new();
+        for col in 0..100 {
+            last_line.push_str(buf.cell((col, last_row)).unwrap().symbol());
+        }
+        assert!(last_line.contains("s sync"), "last line should contain keybindings, got: {last_line}");
     }
 }

--- a/src/tui/screens/detail.rs
+++ b/src/tui/screens/detail.rs
@@ -1,0 +1,103 @@
+use ratatui::{
+    layout::Rect,
+    Frame,
+};
+
+/// View model for the detail screen showing a single worktree's information.
+#[derive(Debug, Clone, PartialEq)]
+pub struct DetailState {
+    pub name: String,
+    pub branch: String,
+    pub path: String,
+    pub base_branch: String,
+    pub ahead_behind: String,
+    pub created: String,
+    pub last_accessed: String,
+    pub hook_status: String,
+    pub hook_timestamp: String,
+    pub changed_files: Vec<(String, String)>,
+    pub commits: Vec<(String, String)>,
+}
+
+pub fn render(_state: &DetailState, _frame: &mut Frame, _area: Rect) {
+    // TODO: implement
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_detail() -> DetailState {
+        DetailState {
+            name: "feature-auth".into(),
+            branch: "feature/auth".into(),
+            path: "/home/user/.worktrees/myproject/feature-auth".into(),
+            base_branch: "main".into(),
+            ahead_behind: "+1/-0".into(),
+            created: "2026-03-10 14:30".into(),
+            last_accessed: "2026-03-11 09:15".into(),
+            hook_status: "success".into(),
+            hook_timestamp: "2026-03-10 14:31".into(),
+            changed_files: vec![
+                ("src/auth.rs".into(), "modified".into()),
+                ("tests/auth_test.rs".into(), "new".into()),
+            ],
+            commits: vec![
+                ("abc1234".into(), "feat: add auth module".into()),
+                ("def5678".into(), "test: add auth tests".into()),
+            ],
+        }
+    }
+
+    #[test]
+    fn detail_state_holds_all_metadata_fields() {
+        let state = sample_detail();
+        assert_eq!(state.name, "feature-auth");
+        assert_eq!(state.branch, "feature/auth");
+        assert_eq!(state.path, "/home/user/.worktrees/myproject/feature-auth");
+        assert_eq!(state.base_branch, "main");
+        assert_eq!(state.ahead_behind, "+1/-0");
+        assert_eq!(state.created, "2026-03-10 14:30");
+        assert_eq!(state.last_accessed, "2026-03-11 09:15");
+    }
+
+    #[test]
+    fn detail_state_holds_hook_status() {
+        let state = sample_detail();
+        assert_eq!(state.hook_status, "success");
+        assert_eq!(state.hook_timestamp, "2026-03-10 14:31");
+    }
+
+    #[test]
+    fn detail_state_holds_changed_files() {
+        let state = sample_detail();
+        assert_eq!(state.changed_files.len(), 2);
+        assert_eq!(state.changed_files[0], ("src/auth.rs".into(), "modified".into()));
+    }
+
+    #[test]
+    fn detail_state_holds_commits() {
+        let state = sample_detail();
+        assert_eq!(state.commits.len(), 2);
+        assert_eq!(state.commits[0], ("abc1234".into(), "feat: add auth module".into()));
+    }
+
+    #[test]
+    fn detail_state_supports_empty_lists() {
+        let state = DetailState {
+            name: "empty".into(),
+            branch: "empty-branch".into(),
+            path: "/tmp/empty".into(),
+            base_branch: "-".into(),
+            ahead_behind: "-".into(),
+            created: "-".into(),
+            last_accessed: "never".into(),
+            hook_status: "none".into(),
+            hook_timestamp: "-".into(),
+            changed_files: vec![],
+            commits: vec![],
+        };
+        assert!(state.changed_files.is_empty());
+        assert!(state.commits.is_empty());
+    }
+}

--- a/src/tui/screens/detail.rs
+++ b/src/tui/screens/detail.rs
@@ -126,6 +126,9 @@ pub fn load_detail(
 }
 
 fn format_timestamp(ts: i64) -> String {
+    if ts < 0 {
+        return "-".to_string();
+    }
     // Simple formatting: seconds since epoch to YYYY-MM-DD HH:MM
     let secs = ts;
     let days = secs / 86400;
@@ -442,6 +445,12 @@ mod tests {
             last_line.push_str(buf.cell((col, last_row)).unwrap().symbol());
         }
         assert!(last_line.contains("s sync"), "last line should contain keybindings, got: {last_line}");
+    }
+
+    #[test]
+    fn format_timestamp_returns_dash_for_negative_input() {
+        let result = super::format_timestamp(-3600);
+        assert_eq!(result, "-", "negative timestamps should return dash");
     }
 
     #[test]

--- a/src/tui/screens/detail.rs
+++ b/src/tui/screens/detail.rs
@@ -1,5 +1,8 @@
 use ratatui::{
-    layout::Rect,
+    layout::{Constraint, Layout, Rect},
+    style::{Modifier, Style},
+    text::{Line, Span},
+    widgets::Paragraph,
     Frame,
 };
 
@@ -19,13 +22,58 @@ pub struct DetailState {
     pub commits: Vec<(String, String)>,
 }
 
-pub fn render(_state: &DetailState, _frame: &mut Frame, _area: Rect) {
-    // TODO: implement
+pub fn render(state: &DetailState, frame: &mut Frame, area: Rect) {
+    let bold = Style::default().add_modifier(Modifier::BOLD);
+
+    let metadata_lines = vec![
+        Line::from(vec![
+            Span::styled("Branch: ", bold),
+            Span::raw(&state.branch),
+            Span::raw("  "),
+            Span::styled("Name: ", bold),
+            Span::raw(&state.name),
+        ]),
+        Line::from(vec![
+            Span::styled("Path:   ", bold),
+            Span::raw(&state.path),
+        ]),
+        Line::from(vec![
+            Span::styled("Base:   ", bold),
+            Span::raw(&state.base_branch),
+            Span::raw("  "),
+            Span::styled("Ahead/Behind: ", bold),
+            Span::raw(&state.ahead_behind),
+        ]),
+        Line::from(vec![
+            Span::styled("Created: ", bold),
+            Span::raw(&state.created),
+            Span::raw("  "),
+            Span::styled("Last Accessed: ", bold),
+            Span::raw(&state.last_accessed),
+        ]),
+    ];
+
+    let metadata = Paragraph::new(metadata_lines);
+    frame.render_widget(metadata, area);
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ratatui::backend::TestBackend;
+
+    fn render_to_buffer(state: &DetailState, width: u16, height: u16) -> ratatui::buffer::Buffer {
+        let backend = TestBackend::new(width, height);
+        let mut terminal = ratatui::Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| render(state, frame, frame.area()))
+            .unwrap();
+        terminal.backend().buffer().clone()
+    }
+
+    fn buffer_text(buf: &ratatui::buffer::Buffer) -> String {
+        buf.content().iter().map(|cell| cell.symbol()).collect()
+    }
 
     fn sample_detail() -> DetailState {
         DetailState {
@@ -99,5 +147,32 @@ mod tests {
         };
         assert!(state.changed_files.is_empty());
         assert!(state.commits.is_empty());
+    }
+
+    #[test]
+    fn renders_metadata_section_with_branch_and_path() {
+        let state = sample_detail();
+        let buf = render_to_buffer(&state, 100, 30);
+        let text = buffer_text(&buf);
+        assert!(text.contains("feature/auth"), "should show branch, got: {text}");
+        assert!(text.contains("feature-auth"), "should show worktree name");
+    }
+
+    #[test]
+    fn renders_metadata_with_base_branch_and_ahead_behind() {
+        let state = sample_detail();
+        let buf = render_to_buffer(&state, 100, 30);
+        let text = buffer_text(&buf);
+        assert!(text.contains("main"), "should show base branch");
+        assert!(text.contains("+1/-0"), "should show ahead/behind");
+    }
+
+    #[test]
+    fn renders_metadata_with_created_and_last_accessed() {
+        let state = sample_detail();
+        let buf = render_to_buffer(&state, 100, 30);
+        let text = buffer_text(&buf);
+        assert!(text.contains("2026-03-10 14:30"), "should show created date");
+        assert!(text.contains("2026-03-11 09:15"), "should show last accessed");
     }
 }

--- a/src/tui/screens/detail.rs
+++ b/src/tui/screens/detail.rs
@@ -49,7 +49,7 @@ pub fn load_detail(
         .as_ref()
         .and_then(|r| db.find_worktree_by_identifier(r.id, name).ok().flatten());
 
-    let wt_path = db_wt.as_ref().map(|w| w.path.clone()).unwrap_or_default();
+    let wt_path = db_wt.as_ref().map(|w| w.path.clone());
     let branch = db_wt
         .as_ref()
         .map(|w| w.branch.clone())
@@ -90,8 +90,8 @@ pub fn load_detail(
         .unwrap_or_else(|| ("none".to_string(), "-".to_string()));
 
     // Git data
-    let changed_files = if !wt_path.is_empty() {
-        git::changed_files(Path::new(&wt_path))
+    let changed_files = if let Some(ref wt_path) = wt_path {
+        git::changed_files(Path::new(wt_path))
             .unwrap_or_default()
             .into_iter()
             .map(|f| (f.path, f.status.to_string()))
@@ -100,8 +100,8 @@ pub fn load_detail(
         vec![]
     };
 
-    let commits = if !wt_path.is_empty() {
-        git::recent_commits(Path::new(&wt_path), 10)
+    let commits = if let Some(ref wt_path) = wt_path {
+        git::recent_commits(Path::new(wt_path), 10)
             .unwrap_or_default()
             .into_iter()
             .map(|c| (c.hash, c.message))
@@ -113,7 +113,7 @@ pub fn load_detail(
     DetailState {
         name: name.to_string(),
         branch,
-        path: wt_path,
+        path: wt_path.unwrap_or_else(|| "-".to_string()),
         base_branch,
         ahead_behind,
         created,
@@ -471,6 +471,7 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let state = load_detail("nonexistent", tmp.path(), &db);
         assert_eq!(state.name, "nonexistent");
+        assert_eq!(state.path, "-", "missing path should show dash fallback");
         assert_eq!(state.hook_status, "none");
         assert_eq!(state.hook_timestamp, "-");
         assert!(state.changed_files.is_empty());

--- a/src/tui/screens/detail.rs
+++ b/src/tui/screens/detail.rs
@@ -22,7 +22,7 @@ pub struct DetailState {
     pub commits: Vec<(String, String)>,
 }
 
-const METADATA_HEIGHT: u16 = 4;
+const METADATA_HEIGHT: u16 = 5;
 
 pub fn render(state: &DetailState, frame: &mut Frame, area: Rect) {
     let bold = Style::default().add_modifier(Modifier::BOLD);
@@ -60,6 +60,13 @@ pub fn render(state: &DetailState, frame: &mut Frame, area: Rect) {
             Span::raw("  "),
             Span::styled("Last Accessed: ", bold),
             Span::raw(&state.last_accessed),
+        ]),
+        Line::from(vec![
+            Span::styled("Hook:    ", bold),
+            Span::raw(&state.hook_status),
+            Span::raw("  "),
+            Span::styled("At: ", bold),
+            Span::raw(&state.hook_timestamp),
         ]),
     ];
     frame.render_widget(Paragraph::new(metadata_lines), chunks[0]);
@@ -252,5 +259,25 @@ mod tests {
         let buf = render_to_buffer(&state, 100, 30);
         let text = buffer_text(&buf);
         assert!(text.contains("No commits"), "should show empty commits message");
+    }
+
+    #[test]
+    fn renders_hook_status_in_metadata() {
+        let state = sample_detail();
+        let buf = render_to_buffer(&state, 100, 30);
+        let text = buffer_text(&buf);
+        assert!(text.contains("Hook"), "should show hook label");
+        assert!(text.contains("success"), "should show hook status value");
+        assert!(text.contains("2026-03-10 14:31"), "should show hook timestamp");
+    }
+
+    #[test]
+    fn renders_hook_status_none() {
+        let mut state = sample_detail();
+        state.hook_status = "none".into();
+        state.hook_timestamp = "-".into();
+        let buf = render_to_buffer(&state, 100, 30);
+        let text = buffer_text(&buf);
+        assert!(text.contains("none"), "should show 'none' for no hooks");
     }
 }

--- a/src/tui/screens/detail.rs
+++ b/src/tui/screens/detail.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 use ratatui::{
     layout::{Constraint, Layout, Rect},
     style::{Modifier, Style},
@@ -5,6 +7,9 @@ use ratatui::{
     widgets::Paragraph,
     Frame,
 };
+
+use crate::git;
+use crate::state::Database;
 
 /// View model for the detail screen showing a single worktree's information.
 #[derive(Debug, Clone, PartialEq)]
@@ -20,6 +25,132 @@ pub struct DetailState {
     pub hook_timestamp: String,
     pub changed_files: Vec<(String, String)>,
     pub commits: Vec<(String, String)>,
+}
+
+/// Build a DetailState for the selected worktree by querying DB and git.
+///
+/// Best-effort: fields that fail to load are replaced with fallback values
+/// so the detail screen always renders something.
+pub fn load_detail(
+    name: &str,
+    cwd: &Path,
+    db: &Database,
+) -> DetailState {
+    let repo_info = git::discover_repo(cwd).ok();
+    let repo_path = repo_info.as_ref().map(|r| r.path.clone());
+
+    // Look up DB worktree
+    let db_repo = repo_path
+        .as_ref()
+        .and_then(|p| p.to_str())
+        .and_then(|p| db.get_repo_by_path(p).ok().flatten());
+
+    let db_wt = db_repo
+        .as_ref()
+        .and_then(|r| db.find_worktree_by_identifier(r.id, name).ok().flatten());
+
+    let wt_path = db_wt.as_ref().map(|w| w.path.clone()).unwrap_or_default();
+    let branch = db_wt
+        .as_ref()
+        .map(|w| w.branch.clone())
+        .unwrap_or_else(|| name.to_string());
+    let base_branch = db_wt
+        .as_ref()
+        .and_then(|w| w.base_branch.clone())
+        .or_else(|| repo_info.as_ref().map(|r| r.default_branch.clone()))
+        .unwrap_or_else(|| "-".to_string());
+
+    let ahead_behind = repo_path
+        .as_ref()
+        .and_then(|rp| git::ahead_behind(rp, &branch, Some(&base_branch)).ok().flatten())
+        .map(|(a, b)| format!("+{a}/-{b}"))
+        .unwrap_or_else(|| "-".to_string());
+
+    let created = db_wt
+        .as_ref()
+        .map(|w| format_timestamp(w.created_at))
+        .unwrap_or_else(|| "-".to_string());
+
+    let last_accessed = db_wt
+        .as_ref()
+        .and_then(|w| w.last_accessed)
+        .map(format_timestamp)
+        .unwrap_or_else(|| "never".to_string());
+
+    // Hook status from most recent event
+    let (hook_status, hook_timestamp) = db_wt
+        .as_ref()
+        .and_then(|w| {
+            db.list_events(w.id, 1).ok().and_then(|events| {
+                events.into_iter().next().map(|e| {
+                    (e.event_type.clone(), format_timestamp(e.created_at))
+                })
+            })
+        })
+        .unwrap_or_else(|| ("none".to_string(), "-".to_string()));
+
+    // Git data
+    let changed_files = if !wt_path.is_empty() {
+        git::changed_files(Path::new(&wt_path))
+            .unwrap_or_default()
+            .into_iter()
+            .map(|f| (f.path, f.status.to_string()))
+            .collect()
+    } else {
+        vec![]
+    };
+
+    let commits = if !wt_path.is_empty() {
+        git::recent_commits(Path::new(&wt_path), 10)
+            .unwrap_or_default()
+            .into_iter()
+            .map(|c| (c.hash, c.message))
+            .collect()
+    } else {
+        vec![]
+    };
+
+    DetailState {
+        name: name.to_string(),
+        branch,
+        path: wt_path,
+        base_branch,
+        ahead_behind,
+        created,
+        last_accessed,
+        hook_status,
+        hook_timestamp,
+        changed_files,
+        commits,
+    }
+}
+
+fn format_timestamp(ts: i64) -> String {
+    // Simple formatting: seconds since epoch to YYYY-MM-DD HH:MM
+    let secs = ts;
+    let days = secs / 86400;
+    let time_of_day = secs % 86400;
+    let hours = time_of_day / 3600;
+    let minutes = (time_of_day % 3600) / 60;
+
+    // Convert days since epoch to date using a simple algorithm
+    let (year, month, day) = days_to_date(days);
+    format!("{year:04}-{month:02}-{day:02} {hours:02}:{minutes:02}")
+}
+
+fn days_to_date(days_since_epoch: i64) -> (i64, i64, i64) {
+    // Algorithm from https://howardhinnant.github.io/date_algorithms.html
+    let z = days_since_epoch + 719468;
+    let era = if z >= 0 { z } else { z - 146096 } / 146097;
+    let doe = z - era * 146097;
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    let y = if m <= 2 { y + 1 } else { y };
+    (y, m, d)
 }
 
 const METADATA_HEIGHT: u16 = 5;
@@ -311,5 +442,29 @@ mod tests {
             last_line.push_str(buf.cell((col, last_row)).unwrap().symbol());
         }
         assert!(last_line.contains("s sync"), "last line should contain keybindings, got: {last_line}");
+    }
+
+    #[test]
+    fn format_timestamp_converts_epoch_to_readable() {
+        // 2026-03-11 00:00 UTC = 1773187200
+        let ts = 1773187200_i64;
+        let result = super::format_timestamp(ts);
+        assert!(
+            result.starts_with("2026-03-11"),
+            "should format as 2026-03-11, got: {result}"
+        );
+    }
+
+    #[test]
+    fn load_detail_returns_fallbacks_for_unknown_worktree() {
+        let db = Database::open_in_memory().unwrap();
+        // load_detail with a cwd that isn't a git repo — should return safe fallbacks
+        let tmp = tempfile::tempdir().unwrap();
+        let state = load_detail("nonexistent", tmp.path(), &db);
+        assert_eq!(state.name, "nonexistent");
+        assert_eq!(state.hook_status, "none");
+        assert_eq!(state.hook_timestamp, "-");
+        assert!(state.changed_files.is_empty());
+        assert!(state.commits.is_empty());
     }
 }

--- a/src/tui/screens/mod.rs
+++ b/src/tui/screens/mod.rs
@@ -1,1 +1,2 @@
+pub mod detail;
 pub mod list;


### PR DESCRIPTION
Closes #38

## Summary
Implements the TUI detail view screen accessible by pressing `Enter` on a worktree in the list view. Shows full worktree metadata (branch, path, base branch, ahead/behind, created date, last accessed), changed files from git status, recent commits (last 10), hook status with timestamp, and a context-sensitive keybindings footer. Pressing `Esc` returns to the list view.

## User Stories Addressed
- US-11: Use a TUI to browse worktrees, create new ones, and view details

## Automated Testing
- Total tests added: 22
- Tests passing: 22
- Tests failing: 0
- `cargo clippy`: pass (all warnings pre-existing)
- `cargo test`: 448 passed, 2 failed (pre-existing failures in `git::tests::create_worktree_succeeds_after_remote_branch_deleted` and `git::tests::delete_remote_branch_deletes_branch_on_remote` — unrelated to this PR)

## UAT Checklist
- [ ] Launch `trench` TUI in a repo with worktrees
- [ ] Navigate list with `j`/`k`, press `Enter` on a worktree → detail view opens
- [ ] Verify metadata section shows branch, name, path, base branch, ahead/behind, created, last accessed
- [ ] Verify changed files section lists modified/new/deleted files (or "No changes" if clean)
- [ ] Verify recent commits section shows last 10 commits with hash and message
- [ ] Verify hook status shows last event type and timestamp (or "none" / "-" if no hooks ran)
- [ ] Verify footer shows `s sync  o open  Esc back`
- [ ] Press `Esc` → returns to list view
- [ ] Press `q` → returns to list view
- [ ] Press `?` on detail → opens help, `Esc` returns to detail
- [ ] Press `s` on detail → no crash (sync not yet implemented)
- [ ] Press `o` on detail → no crash (open not yet implemented)
- [ ] Enter on an unmanaged worktree → adopts it, then opens detail with data

## Known Issues
- The 2 failing tests (`create_worktree_succeeds_after_remote_branch_deleted`, `delete_remote_branch_deletes_branch_on_remote`) are pre-existing failures in the git module unrelated to this PR — they fail due to `refs/heads/master` not found on the test system.
- `s` (sync) and `o` (open) keys are wired as no-ops on the detail screen — actual functionality will be implemented in future issues.
- Timestamp formatting uses a simple epoch-to-date algorithm without timezone awareness (displays UTC).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a detail screen for worktrees showing metadata (branch/base, ahead/behind), timestamps, hook status, changed files, and recent commits.
  * Selecting an item loads its detail data and navigates to the detail screen; if no detail is loaded a centered placeholder is shown.
  * Added on-screen keybinding hints for detail actions.

* **Tests**
  * Added comprehensive tests for detail loading, rendering, empty states, timestamps, and key handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->