### PR TITLE
feat(create): wire pre_create + post_create hooks into trench create

### DIFF
--- a/src/cli/commands/create.rs
+++ b/src/cli/commands/create.rs
@@ -235,10 +235,35 @@ pub async fn execute_with_hooks(
     // Step 2: create worktree
     let result = execute(branch, from, cwd, worktree_root, template, db)?;
 
+    // Step 3: post_create hook (cwd = worktree path)
+    let post_create_error = if let Some(post_create) = &hooks.post_create {
+        // Look up worktree_id for DB logging
+        let wt = db.find_worktree_by_identifier(repo.id, branch)?;
+        let worktree_id = wt.map(|w| w.id);
+
+        match hooks::runner::execute_hook(
+            &HookEvent::PostCreate,
+            post_create,
+            &env_ctx,
+            &repo_info.path,
+            &result.path,
+            db,
+            repo.id,
+            worktree_id,
+        )
+        .await
+        {
+            Ok(_) => None,
+            Err(e) => Some(e),
+        }
+    } else {
+        None
+    };
+
     Ok(CreateWithHooksResult {
         result,
         hooks_status: HooksStatus::Ran,
-        post_create_error: None,
+        post_create_error,
     })
 }
 
@@ -1200,5 +1225,53 @@ mod tests {
             !expected_wt_path.exists(),
             "worktree should NOT be created when pre_create fails"
         );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn post_create_hook_runs_after_worktree_creation() {
+        let repo_dir = tempfile::tempdir().unwrap();
+        let _repo = init_repo_with_commit(repo_dir.path());
+        let wt_root = tempfile::tempdir().unwrap();
+        let db_dir = tempfile::tempdir().unwrap();
+        let db = Database::open(&db_dir.path().join("test.db")).unwrap();
+
+        // post_create hook creates a marker file in the worktree dir
+        let hooks = HooksConfig {
+            post_create: Some(HookDef {
+                run: Some(vec!["touch post_create_ran.marker".to_string()]),
+                ..HookDef::default()
+            }),
+            ..HooksConfig::default()
+        };
+
+        let result = execute_with_hooks(
+            "my-feature",
+            None,
+            repo_dir.path(),
+            wt_root.path(),
+            paths::DEFAULT_WORKTREE_TEMPLATE,
+            &db,
+            Some(&hooks),
+            false,
+        )
+        .await
+        .expect("should succeed");
+
+        // Worktree exists
+        assert!(result.result.path.exists(), "worktree should be created");
+
+        // Marker file in worktree dir proves post_create ran with cwd = worktree
+        let marker = result.result.path.join("post_create_ran.marker");
+        assert!(marker.exists(), "post_create hook should have run in worktree dir");
+
+        assert!(matches!(result.hooks_status, HooksStatus::Ran));
+        assert!(result.post_create_error.is_none());
+
+        // Hook event logged to DB
+        let repo_path_str = repo_dir.path().canonicalize().unwrap().to_str().unwrap().to_string();
+        let db_repo = db.get_repo_by_path(&repo_path_str).unwrap().expect("repo in DB");
+        let wts = db.list_worktrees(db_repo.id).unwrap();
+        let hook_events = db.count_events(wts[0].id, Some("hook:post_create")).unwrap();
+        assert_eq!(hook_events, 1, "post_create hook event should be logged");
     }
 }

--- a/src/cli/commands/create.rs
+++ b/src/cli/commands/create.rs
@@ -147,6 +147,7 @@ fn path_to_utf8(path: &Path) -> Result<&str> {
 
 /// Result of `execute_with_hooks` — includes the create result, hooks status,
 /// and any post_create hook error (worktree stays on post_create failure).
+#[derive(Debug)]
 pub struct CreateWithHooksResult {
     pub result: CreateResult,
     pub hooks_status: HooksStatus,
@@ -1146,5 +1147,58 @@ mod tests {
         // Worktree should also exist
         assert!(result.result.path.exists(), "worktree should be created");
         assert!(matches!(result.hooks_status, HooksStatus::Ran));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn pre_create_failure_cancels_worktree_creation() {
+        let repo_dir = tempfile::tempdir().unwrap();
+        let _repo = init_repo_with_commit(repo_dir.path());
+        let wt_root = tempfile::tempdir().unwrap();
+        let db_dir = tempfile::tempdir().unwrap();
+        let db = Database::open(&db_dir.path().join("test.db")).unwrap();
+
+        let hooks = HooksConfig {
+            pre_create: Some(HookDef {
+                run: Some(vec!["exit 1".to_string()]),
+                ..HookDef::default()
+            }),
+            ..HooksConfig::default()
+        };
+
+        let err = execute_with_hooks(
+            "my-feature",
+            None,
+            repo_dir.path(),
+            wt_root.path(),
+            paths::DEFAULT_WORKTREE_TEMPLATE,
+            &db,
+            Some(&hooks),
+            false,
+        )
+        .await
+        .expect_err("should fail when pre_create hook fails");
+
+        // Error should mention pre_create
+        let msg = err.to_string();
+        assert!(
+            msg.contains("pre_create"),
+            "error should mention pre_create, got: {msg}"
+        );
+
+        // Worktree should NOT exist on disk
+        let repo_name = repo_dir
+            .path()
+            .canonicalize()
+            .unwrap()
+            .file_name()
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .to_string();
+        let expected_wt_path = wt_root.path().join(&repo_name).join("my-feature");
+        assert!(
+            !expected_wt_path.exists(),
+            "worktree should NOT be created when pre_create fails"
+        );
     }
 }

--- a/src/cli/commands/create.rs
+++ b/src/cli/commands/create.rs
@@ -144,6 +144,53 @@ fn path_to_utf8(path: &Path) -> Result<&str> {
         .ok_or_else(|| anyhow::anyhow!("path is not valid UTF-8: {}", path.display()))
 }
 
+/// Result of `execute_with_hooks` — includes the create result, hooks status,
+/// and any post_create hook error (worktree stays on post_create failure).
+pub struct CreateWithHooksResult {
+    pub result: CreateResult,
+    pub hooks_status: HooksStatus,
+    /// If post_create hook failed, this contains the error.
+    /// The worktree was still created successfully.
+    pub post_create_error: Option<anyhow::Error>,
+}
+
+/// Execute `trench create <branch>` with lifecycle hooks.
+///
+/// Orchestrates: pre_create hook → worktree creation → post_create hook.
+/// - If `no_hooks` is true or no hooks configured, hooks are skipped.
+/// - Pre_create failure cancels the operation (worktree not created).
+/// - Post_create failure: worktree stays, error captured in result.
+pub async fn execute_with_hooks(
+    branch: &str,
+    from: Option<&str>,
+    cwd: &Path,
+    worktree_root: &Path,
+    template: &str,
+    db: &Database,
+    hooks: Option<&HooksConfig>,
+    no_hooks: bool,
+) -> Result<CreateWithHooksResult> {
+    let has_hooks = hooks
+        .map(|h| h.pre_create.is_some() || h.post_create.is_some())
+        .unwrap_or(false);
+
+    let hooks_status = if no_hooks && has_hooks {
+        HooksStatus::Skipped
+    } else if !has_hooks {
+        HooksStatus::None
+    } else {
+        HooksStatus::Ran
+    };
+
+    let result = execute(branch, from, cwd, worktree_root, template, db)?;
+
+    Ok(CreateWithHooksResult {
+        result,
+        hooks_status,
+        post_create_error: None,
+    })
+}
+
 /// Execute the `trench create <branch>` command.
 ///
 /// Discovers the git repo, resolves the worktree path, creates the worktree
@@ -191,6 +238,7 @@ pub fn execute(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::{HookDef, HooksConfig};
 
     #[test]
     fn path_to_utf8_succeeds_for_valid_utf8() {
@@ -943,5 +991,31 @@ mod tests {
             Some(head_branch.as_str()),
             "repos.default_base should be the HEAD branch, not the --from override"
         );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn execute_with_hooks_no_hooks_configured_returns_none_status() {
+        let repo_dir = tempfile::tempdir().unwrap();
+        let _repo = init_repo_with_commit(repo_dir.path());
+        let wt_root = tempfile::tempdir().unwrap();
+        let db_dir = tempfile::tempdir().unwrap();
+        let db = Database::open(&db_dir.path().join("test.db")).unwrap();
+
+        let result = execute_with_hooks(
+            "my-feature",
+            None,
+            repo_dir.path(),
+            wt_root.path(),
+            paths::DEFAULT_WORKTREE_TEMPLATE,
+            &db,
+            None, // no hooks configured
+            false, // no_hooks flag = false
+        )
+        .await
+        .expect("should succeed");
+
+        assert!(matches!(result.hooks_status, HooksStatus::None));
+        assert!(result.result.path.exists(), "worktree should be created");
+        assert!(result.post_create_error.is_none());
     }
 }

--- a/src/cli/commands/create.rs
+++ b/src/cli/commands/create.rs
@@ -1018,4 +1018,44 @@ mod tests {
         assert!(result.result.path.exists(), "worktree should be created");
         assert!(result.post_create_error.is_none());
     }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn execute_with_hooks_no_hooks_flag_returns_skipped_status() {
+        let repo_dir = tempfile::tempdir().unwrap();
+        let _repo = init_repo_with_commit(repo_dir.path());
+        let wt_root = tempfile::tempdir().unwrap();
+        let db_dir = tempfile::tempdir().unwrap();
+        let db = Database::open(&db_dir.path().join("test.db")).unwrap();
+
+        let hooks = HooksConfig {
+            post_create: Some(HookDef {
+                run: Some(vec!["echo should-not-run".to_string()]),
+                ..HookDef::default()
+            }),
+            ..HooksConfig::default()
+        };
+
+        let result = execute_with_hooks(
+            "my-feature",
+            None,
+            repo_dir.path(),
+            wt_root.path(),
+            paths::DEFAULT_WORKTREE_TEMPLATE,
+            &db,
+            Some(&hooks),
+            true, // no_hooks = true → skip
+        )
+        .await
+        .expect("should succeed");
+
+        assert!(matches!(result.hooks_status, HooksStatus::Skipped));
+        assert!(result.result.path.exists(), "worktree should still be created");
+
+        // Verify no hook events were logged
+        let repo_path_str = repo_dir.path().canonicalize().unwrap().to_str().unwrap().to_string();
+        let db_repo = db.get_repo_by_path(&repo_path_str).unwrap().expect("repo in DB");
+        let wts = db.list_worktrees(db_repo.id).unwrap();
+        let hook_events = db.count_events(wts[0].id, Some("hook:post_create")).unwrap();
+        assert_eq!(hook_events, 0, "no hook events should be logged when --no-hooks");
+    }
 }

--- a/src/cli/commands/create.rs
+++ b/src/cli/commands/create.rs
@@ -9,6 +9,13 @@ use crate::hooks::{self, HookEnvContext, HookEvent};
 use crate::paths;
 use crate::state::Database;
 
+/// Typed errors for the `create` command.
+#[derive(Debug, thiserror::Error)]
+pub enum CreateError {
+    #[error("pre_create hook failed")]
+    PreCreateHookFailed(#[source] anyhow::Error),
+}
+
 /// Plan produced by `--dry-run` showing what `trench create` would do.
 #[derive(Debug, serde::Serialize)]
 pub struct DryRunPlan {
@@ -229,7 +236,7 @@ pub async fn execute_with_hooks(
             None,
         )
         .await
-        .context("pre_create hook failed")?;
+        .map_err(CreateError::PreCreateHookFailed)?;
     }
 
     // Step 2: create worktree
@@ -1203,11 +1210,10 @@ mod tests {
         .await
         .expect_err("should fail when pre_create hook fails");
 
-        // Error should mention pre_create
-        let msg = err.to_string();
+        // Error should be a typed CreateError::PreCreateHookFailed
         assert!(
-            msg.contains("pre_create"),
-            "error should mention pre_create, got: {msg}"
+            err.downcast_ref::<CreateError>().is_some(),
+            "expected CreateError::PreCreateHookFailed, got: {err:?}"
         );
 
         // Worktree should NOT exist on disk
@@ -1395,5 +1401,41 @@ mod tests {
         let wts = db.list_worktrees(db_repo.id).unwrap();
         let post_hook_count = db.count_events(wts[0].id, Some("hook:post_create")).unwrap();
         assert_eq!(post_hook_count, 1, "post_create hook event should be logged");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn pre_create_failure_returns_typed_error() {
+        let repo_dir = tempfile::tempdir().unwrap();
+        let _repo = init_repo_with_commit(repo_dir.path());
+        let wt_root = tempfile::tempdir().unwrap();
+        let db_dir = tempfile::tempdir().unwrap();
+        let db = Database::open(&db_dir.path().join("test.db")).unwrap();
+
+        let hooks = HooksConfig {
+            pre_create: Some(HookDef {
+                run: Some(vec!["exit 1".to_string()]),
+                ..HookDef::default()
+            }),
+            ..HooksConfig::default()
+        };
+
+        let err = execute_with_hooks(
+            "my-feature",
+            None,
+            repo_dir.path(),
+            wt_root.path(),
+            paths::DEFAULT_WORKTREE_TEMPLATE,
+            &db,
+            Some(&hooks),
+            false,
+        )
+        .await
+        .expect_err("should fail when pre_create hook fails");
+
+        // The error must be a typed CreateError::PreCreateHookFailed, not a string
+        assert!(
+            err.downcast_ref::<CreateError>().is_some(),
+            "expected CreateError::PreCreateHookFailed, got: {err:?}"
+        );
     }
 }

--- a/src/cli/commands/create.rs
+++ b/src/cli/commands/create.rs
@@ -1318,4 +1318,82 @@ mod tests {
 
         assert!(matches!(result.hooks_status, HooksStatus::Ran));
     }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn integration_create_with_hooks_copies_files_and_runs_commands() {
+        let repo_dir = tempfile::tempdir().unwrap();
+        let _repo = init_repo_with_commit(repo_dir.path());
+        let wt_root = tempfile::tempdir().unwrap();
+        let db_dir = tempfile::tempdir().unwrap();
+        let db = Database::open(&db_dir.path().join("test.db")).unwrap();
+
+        // Create files in repo that should be copied by post_create
+        std::fs::write(repo_dir.path().join(".env"), "DATABASE_URL=postgres://localhost/mydb").unwrap();
+        std::fs::write(repo_dir.path().join(".env.local"), "SECRET=abc123").unwrap();
+        std::fs::write(repo_dir.path().join(".env.example"), "DATABASE_URL=").unwrap();
+        std::fs::write(repo_dir.path().join("README.md"), "# readme").unwrap();
+
+        let hooks = HooksConfig {
+            pre_create: Some(HookDef {
+                run: Some(vec!["echo pre_create_ok".to_string()]),
+                ..HookDef::default()
+            }),
+            post_create: Some(HookDef {
+                copy: Some(vec![".env*".to_string(), "!.env.example".to_string()]),
+                run: Some(vec!["echo post_create_ok".to_string()]),
+                ..HookDef::default()
+            }),
+            ..HooksConfig::default()
+        };
+
+        let result = execute_with_hooks(
+            "integration-test",
+            None,
+            repo_dir.path(),
+            wt_root.path(),
+            paths::DEFAULT_WORKTREE_TEMPLATE,
+            &db,
+            Some(&hooks),
+            false,
+        )
+        .await
+        .expect("should succeed");
+
+        let wt_path = &result.result.path;
+
+        // Worktree created
+        assert!(wt_path.exists(), "worktree should exist");
+        assert!(wt_path.join(".git").exists(), "worktree should have .git");
+
+        // Copy: .env and .env.local copied, .env.example excluded, README.md not matched
+        assert!(
+            wt_path.join(".env").exists(),
+            ".env should be copied to worktree"
+        );
+        assert_eq!(
+            std::fs::read_to_string(wt_path.join(".env")).unwrap(),
+            "DATABASE_URL=postgres://localhost/mydb"
+        );
+        assert!(
+            wt_path.join(".env.local").exists(),
+            ".env.local should be copied to worktree"
+        );
+        assert!(
+            !wt_path.join(".env.example").exists(),
+            ".env.example should be excluded by !.env.example pattern"
+        );
+        // README.md doesn't match .env* so it shouldn't be copied as an extra file
+        // (it may exist from git checkout, which is fine — we just verify the copy step)
+
+        // Status
+        assert!(matches!(result.hooks_status, HooksStatus::Ran));
+        assert!(result.post_create_error.is_none());
+
+        // DB: hook events logged
+        let repo_path_str = repo_dir.path().canonicalize().unwrap().to_str().unwrap().to_string();
+        let db_repo = db.get_repo_by_path(&repo_path_str).unwrap().expect("repo in DB");
+        let wts = db.list_worktrees(db_repo.id).unwrap();
+        let post_hook_count = db.count_events(wts[0].id, Some("hook:post_create")).unwrap();
+        assert_eq!(post_hook_count, 1, "post_create hook event should be logged");
+    }
 }

--- a/src/cli/commands/create.rs
+++ b/src/cli/commands/create.rs
@@ -5,6 +5,7 @@ use anyhow::{Context, Result};
 
 use crate::config::HooksConfig;
 use crate::git;
+use crate::hooks::{self, HookEnvContext, HookEvent};
 use crate::paths;
 use crate::state::Database;
 
@@ -167,26 +168,75 @@ pub async fn execute_with_hooks(
     worktree_root: &Path,
     template: &str,
     db: &Database,
-    hooks: Option<&HooksConfig>,
+    hooks_config: Option<&HooksConfig>,
     no_hooks: bool,
 ) -> Result<CreateWithHooksResult> {
-    let has_hooks = hooks
+    let has_hooks = hooks_config
         .map(|h| h.pre_create.is_some() || h.post_create.is_some())
         .unwrap_or(false);
 
-    let hooks_status = if no_hooks && has_hooks {
-        HooksStatus::Skipped
-    } else if !has_hooks {
-        HooksStatus::None
-    } else {
-        HooksStatus::Ran
+    // Fast path: no hooks to run
+    if no_hooks || !has_hooks {
+        let hooks_status = if no_hooks && has_hooks {
+            HooksStatus::Skipped
+        } else {
+            HooksStatus::None
+        };
+        let result = execute(branch, from, cwd, worktree_root, template, db)?;
+        return Ok(CreateWithHooksResult {
+            result,
+            hooks_status,
+            post_create_error: None,
+        });
+    }
+
+    let hooks = hooks_config.unwrap(); // safe: has_hooks is true
+
+    // Pre-compute info needed for hooks
+    let repo_info = git::discover_repo(cwd)?;
+    let relative_path = paths::render_worktree_path(template, &repo_info.name, branch)?;
+    let worktree_path = worktree_root.join(relative_path);
+    let base = from.unwrap_or(&repo_info.default_branch);
+    let sanitized_name = paths::sanitize_branch(branch);
+
+    // Ensure repo in DB for hook event logging
+    let repo_path_str = path_to_utf8(&repo_info.path)?;
+    let repo = match db.get_repo_by_path(repo_path_str)? {
+        Some(r) => r,
+        None => db.insert_repo(&repo_info.name, repo_path_str, Some(&repo_info.default_branch))?,
     };
 
+    let env_ctx = HookEnvContext {
+        worktree_path: worktree_path.to_string_lossy().to_string(),
+        worktree_name: sanitized_name,
+        branch: branch.to_string(),
+        repo_name: repo_info.name.clone(),
+        repo_path: repo_info.path.to_string_lossy().to_string(),
+        base_branch: base.to_string(),
+    };
+
+    // Step 1: pre_create hook (cwd = repo path, no worktree_id yet)
+    if let Some(pre_create) = &hooks.pre_create {
+        hooks::runner::execute_hook(
+            &HookEvent::PreCreate,
+            pre_create,
+            &env_ctx,
+            &repo_info.path,
+            &repo_info.path,
+            db,
+            repo.id,
+            None,
+        )
+        .await
+        .context("pre_create hook failed")?;
+    }
+
+    // Step 2: create worktree
     let result = execute(branch, from, cwd, worktree_root, template, db)?;
 
     Ok(CreateWithHooksResult {
         result,
-        hooks_status,
+        hooks_status: HooksStatus::Ran,
         post_create_error: None,
     })
 }
@@ -1057,5 +1107,44 @@ mod tests {
         let wts = db.list_worktrees(db_repo.id).unwrap();
         let hook_events = db.count_events(wts[0].id, Some("hook:post_create")).unwrap();
         assert_eq!(hook_events, 0, "no hook events should be logged when --no-hooks");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn pre_create_hook_runs_before_worktree_creation() {
+        let repo_dir = tempfile::tempdir().unwrap();
+        let _repo = init_repo_with_commit(repo_dir.path());
+        let wt_root = tempfile::tempdir().unwrap();
+        let db_dir = tempfile::tempdir().unwrap();
+        let db = Database::open(&db_dir.path().join("test.db")).unwrap();
+
+        // pre_create hook creates a marker file in repo dir
+        let marker = repo_dir.path().join("pre_create_ran.marker");
+        let hooks = HooksConfig {
+            pre_create: Some(HookDef {
+                run: Some(vec![format!("touch {}", marker.display())]),
+                ..HookDef::default()
+            }),
+            ..HooksConfig::default()
+        };
+
+        let result = execute_with_hooks(
+            "my-feature",
+            None,
+            repo_dir.path(),
+            wt_root.path(),
+            paths::DEFAULT_WORKTREE_TEMPLATE,
+            &db,
+            Some(&hooks),
+            false,
+        )
+        .await
+        .expect("should succeed");
+
+        // Marker file should exist (pre_create hook ran)
+        assert!(marker.exists(), "pre_create hook should have run");
+
+        // Worktree should also exist
+        assert!(result.result.path.exists(), "worktree should be created");
+        assert!(matches!(result.hooks_status, HooksStatus::Ran));
     }
 }

--- a/src/cli/commands/create.rs
+++ b/src/cli/commands/create.rs
@@ -1274,4 +1274,48 @@ mod tests {
         let hook_events = db.count_events(wts[0].id, Some("hook:post_create")).unwrap();
         assert_eq!(hook_events, 1, "post_create hook event should be logged");
     }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn post_create_failure_keeps_worktree_and_reports_error() {
+        let repo_dir = tempfile::tempdir().unwrap();
+        let _repo = init_repo_with_commit(repo_dir.path());
+        let wt_root = tempfile::tempdir().unwrap();
+        let db_dir = tempfile::tempdir().unwrap();
+        let db = Database::open(&db_dir.path().join("test.db")).unwrap();
+
+        let hooks = HooksConfig {
+            post_create: Some(HookDef {
+                run: Some(vec!["exit 1".to_string()]),
+                ..HookDef::default()
+            }),
+            ..HooksConfig::default()
+        };
+
+        let result = execute_with_hooks(
+            "my-feature",
+            None,
+            repo_dir.path(),
+            wt_root.path(),
+            paths::DEFAULT_WORKTREE_TEMPLATE,
+            &db,
+            Some(&hooks),
+            false,
+        )
+        .await
+        .expect("should succeed (worktree stays despite hook failure)");
+
+        // Worktree should still exist on disk
+        assert!(
+            result.result.path.exists(),
+            "worktree should exist despite post_create failure"
+        );
+
+        // post_create_error should be set
+        assert!(
+            result.post_create_error.is_some(),
+            "post_create_error should contain the hook failure"
+        );
+
+        assert!(matches!(result.hooks_status, HooksStatus::Ran));
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -315,8 +315,8 @@ fn run_create(
             Ok(())
         }
         Err(e) => {
-            // Check for hook failure (pre_create)
-            if e.to_string().contains("pre_create hook failed") {
+            // Check for hook failure (pre_create) via typed error
+            if e.downcast_ref::<cli::commands::create::CreateError>().is_some() {
                 eprintln!("error: {e:#}");
                 std::process::exit(4);
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -247,7 +247,7 @@ fn run_create(
     from: Option<&str>,
     dry_run: bool,
     json: bool,
-    _no_hooks: bool,
+    no_hooks: bool,
 ) -> anyhow::Result<()> {
     let cwd = std::env::current_dir().context("failed to determine current directory")?;
 
@@ -283,25 +283,43 @@ fn run_create(
     let db_path = paths::data_dir()?.join("trench.db");
     let db = state::Database::open(&db_path)?;
 
-    match cli::commands::create::execute(
+    let rt = tokio::runtime::Runtime::new().context("failed to create async runtime")?;
+
+    match rt.block_on(cli::commands::create::execute_with_hooks(
         branch,
         from,
         &cwd,
         &worktree_root,
         &resolved.worktrees.root,
         &db,
-    ) {
-        Ok(result) => {
+        resolved.hooks.as_ref(),
+        no_hooks,
+    )) {
+        Ok(outcome) => {
+            // Report post_create hook failure to stderr
+            if let Some(ref hook_err) = outcome.post_create_error {
+                eprintln!("error: post_create hook failed: {hook_err:#}");
+            }
+
             if json {
-                let hooks_status = cli::commands::create::HooksStatus::None;
-                let json_output = result.to_json_output(hooks_status);
+                let json_output = outcome.result.to_json_output(outcome.hooks_status);
                 println!("{}", output::json::format_json_value(&json_output)?);
             } else {
-                println!("{}", result.path.display());
+                println!("{}", outcome.result.path.display());
+            }
+
+            // Exit 4 if post_create hook failed (FR-24: hard stop)
+            if outcome.post_create_error.is_some() {
+                std::process::exit(4);
             }
             Ok(())
         }
         Err(e) => {
+            // Check for hook failure (pre_create)
+            if e.to_string().contains("pre_create hook failed") {
+                eprintln!("error: {e:#}");
+                std::process::exit(4);
+            }
             if let Some(git_err) = e.downcast_ref::<git::GitError>() {
                 match git_err {
                     git::GitError::BranchAlreadyExists { .. }

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,6 +60,10 @@ enum Commands {
         /// Falls back to origin/<base> if not found locally.
         #[arg(long)]
         from: Option<String>,
+
+        /// Skip all lifecycle hooks (pre_create, post_create)
+        #[arg(long)]
+        no_hooks: bool,
     },
     /// Remove a worktree
     Remove {
@@ -198,9 +202,11 @@ fn main() -> anyhow::Result<()> {
     let porcelain = cli.porcelain;
 
     match cli.command {
-        Some(Commands::Create { branch, from }) => {
-            run_create(&branch, from.as_deref(), dry_run, json)
-        }
+        Some(Commands::Create {
+            branch,
+            from,
+            no_hooks,
+        }) => run_create(&branch, from.as_deref(), dry_run, json, no_hooks),
         Some(Commands::Remove {
             branch,
             force,
@@ -236,7 +242,13 @@ fn main() -> anyhow::Result<()> {
     }
 }
 
-fn run_create(branch: &str, from: Option<&str>, dry_run: bool, json: bool) -> anyhow::Result<()> {
+fn run_create(
+    branch: &str,
+    from: Option<&str>,
+    dry_run: bool,
+    json: bool,
+    _no_hooks: bool,
+) -> anyhow::Result<()> {
     let cwd = std::env::current_dir().context("failed to determine current directory")?;
 
     // Load config once so both dry-run and actual execution use the same
@@ -763,7 +775,7 @@ mod tests {
         let cli = Cli::try_parse_from(["trench", "create", "my-feature"])
             .expect("create with branch should succeed");
         match cli.command {
-            Some(Commands::Create { branch, from }) => {
+            Some(Commands::Create { branch, from, .. }) => {
                 assert_eq!(branch, "my-feature");
                 assert!(from.is_none());
             }
@@ -776,7 +788,7 @@ mod tests {
         let cli = Cli::try_parse_from(["trench", "create", "my-feature", "--from", "develop"])
             .expect("create with --from should succeed");
         match cli.command {
-            Some(Commands::Create { branch, from }) => {
+            Some(Commands::Create { branch, from, .. }) => {
                 assert_eq!(branch, "my-feature");
                 assert_eq!(from.as_deref(), Some("develop"));
             }
@@ -852,6 +864,33 @@ mod tests {
             .expect("--dry-run --json with create should parse");
         assert!(cli.dry_run);
         assert!(cli.json);
+    }
+
+    #[test]
+    fn create_subcommand_accepts_no_hooks_flag() {
+        let cli = Cli::try_parse_from(["trench", "create", "my-feature", "--no-hooks"])
+            .expect("create with --no-hooks should succeed");
+        match cli.command {
+            Some(Commands::Create {
+                branch, no_hooks, ..
+            }) => {
+                assert_eq!(branch, "my-feature");
+                assert!(no_hooks);
+            }
+            _ => panic!("expected Commands::Create"),
+        }
+    }
+
+    #[test]
+    fn create_subcommand_no_hooks_defaults_to_false() {
+        let cli = Cli::try_parse_from(["trench", "create", "my-feature"])
+            .expect("create without --no-hooks should succeed");
+        match cli.command {
+            Some(Commands::Create { no_hooks, .. }) => {
+                assert!(!no_hooks, "no_hooks should default to false");
+            }
+            _ => panic!("expected Commands::Create"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
Closes #39

## Summary
Integrates the hook runner into `trench create` with full pre_create and post_create lifecycle hook support. Pre_create hooks run before worktree creation (cwd = repo path) and cancel the operation on failure (exit code 4). Post_create hooks run after creation (cwd = worktree path); failure leaves the worktree intact but reports the error. The `--no-hooks` flag skips all hooks. All hook executions are logged to the database via the existing hook runner.

## User Stories Addressed
- US-2: Auto-setup with hooks on create (`.env` copy, `bun install`, etc.)
- US-3: Project-level hooks in `.trench.toml` execute on create

## Automated Testing
- Total tests added: 9
- Tests passing: 9
- Tests failing: 0
- `cargo clippy`: pass (warnings only, all pre-existing)
- `cargo test`: pass (459 passing; 2 pre-existing failures in git module unrelated to this PR)

## UAT Checklist
- [ ] Create a `.trench.toml` with `[hooks.post_create] copy = [".env*"] run = ["echo setup complete"]` and run `trench create my-feature` → `.env` files copied to worktree, "setup complete" printed to terminal
- [ ] Create a `.trench.toml` with `[hooks.pre_create] run = ["exit 1"]` and run `trench create my-feature` → operation fails with exit code 4, no worktree created
- [ ] Create a `.trench.toml` with `[hooks.post_create] run = ["exit 1"]` and run `trench create my-feature` → worktree created at expected path, error reported to stderr, exit code 4
- [ ] Run `trench create my-feature --no-hooks` with hooks configured → worktree created, no hooks executed
- [ ] Run `trench create my-feature --json` with hooks → JSON output includes `"hooks": {"status": "ran"}`
- [ ] Run `trench create my-feature --no-hooks --json` with hooks → JSON output includes `"hooks": {"status": "skipped"}`
- [ ] Run `trench create my-feature --dry-run` with hooks → shows hook plan, no side effects

## Known Issues
- Pre_create hook events are logged with `worktree_id: NULL` since the worktree doesn't exist yet. The existing `list_events` query filters by `worktree_id`, so pre_create events can't be queried via that function. A `list_repo_events` query would be needed for the `trench log` command (tracked separately).
- 2 pre-existing test failures in `git::tests` (`refs/heads/master` not found) — unrelated to this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a --no-hooks flag to skip lifecycle hooks during create.
  * Pre-create and post-create hooks run as part of the create workflow; hook status is included in outputs.
  * Command output now reports post-create errors separately and uses them to determine exit status.

* **Bug Fixes**
  * Post-create hook failures are surfaced clearly (to stderr/exit code) while preserving created worktrees.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->