### PR TITLE
feat(remove): wire pre_remove + post_remove hooks into trench remove

### DIFF
--- a/src/cli/commands/remove.rs
+++ b/src/cli/commands/remove.rs
@@ -183,10 +183,17 @@ pub async fn execute_resolved_with_hooks(
         }
     }
 
-    // Step 2: remove worktree
-    let result = execute_resolved(repo, wt, repo_info, db, prune)?;
+    // Step 2: remove worktree from disk
+    // Inlined from execute_resolved so that post_remove fires immediately after
+    // disk deletion, regardless of whether DB bookkeeping succeeds.
+    let worktree_path = Path::new(&wt.path);
+    if worktree_path.exists() {
+        git::remove_worktree(&repo_info.path, worktree_path)?;
+    } else {
+        eprintln!("warning: worktree directory already removed from disk");
+    }
 
-    // Step 3: post_remove hook (cwd = repo path, FR-22)
+    // Step 3: post_remove hook fires IMMEDIATELY after disk deletion (FR-22)
     let post_remove_warning = if let Some(post_remove) = &hooks.post_remove {
         match hooks::runner::execute_hook(
             &HookEvent::PostRemove,
@@ -207,8 +214,37 @@ pub async fn execute_resolved_with_hooks(
         None
     };
 
+    // Step 4: DB bookkeeping — cannot prevent post_remove from running
+    let now = crate::state::unix_epoch_secs() as i64;
+    db.update_worktree(
+        wt.id,
+        &crate::state::WorktreeUpdate {
+            removed_at: Some(Some(now)),
+            ..Default::default()
+        },
+    )
+    .context("failed to update worktree record")?;
+
+    db.insert_event(repo.id, Some(wt.id), "removed", None)
+        .context("failed to insert removed event")?;
+
+    // Optionally delete the remote branch
+    let mut pruned_remote = false;
+    if prune {
+        match git::delete_remote_branch(&repo_info.path, "origin", &wt.branch) {
+            Ok(()) => pruned_remote = true,
+            Err(git::GitError::RemoteBranchNotFound { branch, remote }) => {
+                eprintln!("warning: remote branch '{branch}' not found on {remote}");
+            }
+            Err(e) => return Err(e.into()),
+        }
+    }
+
     Ok(RemoveWithHooksResult {
-        result,
+        result: RemoveResult {
+            name: wt.name.clone(),
+            pruned_remote,
+        },
         hooks_status: RemoveHooksStatus::Ran,
         post_remove_warning,
     })

--- a/src/cli/commands/remove.rs
+++ b/src/cli/commands/remove.rs
@@ -763,4 +763,69 @@ mod tests {
             "pre_remove output should be logged: {stdout_lines:?}"
         );
     }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn pre_remove_failure_cancels_removal() {
+        let repo_dir = tempfile::tempdir().unwrap();
+        let _repo = init_repo_with_commit(repo_dir.path());
+        let wt_root = tempfile::tempdir().unwrap();
+        let db_dir = tempfile::tempdir().unwrap();
+        let db = Database::open(&db_dir.path().join("test.db")).unwrap();
+
+        let create_result = crate::cli::commands::create::execute(
+            "fail-pre-rm",
+            None,
+            repo_dir.path(),
+            wt_root.path(),
+            crate::paths::DEFAULT_WORKTREE_TEMPLATE,
+            &db,
+        )
+        .expect("create should succeed");
+
+        let repo_info = crate::git::discover_repo(repo_dir.path()).unwrap();
+        let (repo, wt) =
+            crate::adopt::resolve_or_adopt("fail-pre-rm", &repo_info, &db).unwrap();
+
+        // pre_remove hook that fails
+        let hooks = crate::config::HooksConfig {
+            pre_remove: Some(crate::config::HookDef {
+                copy: None,
+                run: Some(vec!["exit 1".to_string()]),
+                shell: None,
+                timeout_secs: Some(30),
+            }),
+            ..Default::default()
+        };
+
+        let err = execute_resolved_with_hooks(
+            &repo,
+            &wt,
+            &repo_info,
+            &db,
+            false,
+            Some(&hooks),
+            false,
+        )
+        .await
+        .expect_err("should fail when pre_remove hook fails");
+
+        // Verify error is a RemoveError::PreRemoveHookFailed
+        assert!(
+            err.downcast_ref::<RemoveError>().is_some(),
+            "error should be RemoveError, got: {err:#}"
+        );
+
+        // Verify worktree was NOT deleted
+        assert!(
+            create_result.path.exists(),
+            "worktree directory should still exist after pre_remove failure"
+        );
+
+        // Verify DB record was NOT marked as removed
+        let wt_record = db.get_worktree(wt.id).unwrap().unwrap();
+        assert!(
+            wt_record.removed_at.is_none(),
+            "removed_at should be None after pre_remove failure"
+        );
+    }
 }

--- a/src/cli/commands/remove.rs
+++ b/src/cli/commands/remove.rs
@@ -910,4 +910,65 @@ mod tests {
         let hook_events = db.count_events(wt.id, Some("hook:post_remove")).unwrap();
         assert_eq!(hook_events, 1, "post_remove hook event should be logged");
     }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn post_remove_failure_is_warning_only() {
+        let repo_dir = tempfile::tempdir().unwrap();
+        let _repo = init_repo_with_commit(repo_dir.path());
+        let wt_root = tempfile::tempdir().unwrap();
+        let db_dir = tempfile::tempdir().unwrap();
+        let db = Database::open(&db_dir.path().join("test.db")).unwrap();
+
+        let create_result = crate::cli::commands::create::execute(
+            "post-fail",
+            None,
+            repo_dir.path(),
+            wt_root.path(),
+            crate::paths::DEFAULT_WORKTREE_TEMPLATE,
+            &db,
+        )
+        .expect("create should succeed");
+
+        let repo_info = crate::git::discover_repo(repo_dir.path()).unwrap();
+        let (repo, wt) =
+            crate::adopt::resolve_or_adopt("post-fail", &repo_info, &db).unwrap();
+
+        // post_remove hook that fails
+        let hooks = crate::config::HooksConfig {
+            post_remove: Some(crate::config::HookDef {
+                copy: None,
+                run: Some(vec!["exit 42".to_string()]),
+                shell: None,
+                timeout_secs: Some(30),
+            }),
+            ..Default::default()
+        };
+
+        // Should succeed despite post_remove failure (FR-24: WarnOnly)
+        let outcome = execute_resolved_with_hooks(
+            &repo,
+            &wt,
+            &repo_info,
+            &db,
+            false,
+            Some(&hooks),
+            false,
+        )
+        .await
+        .expect("remove should succeed even if post_remove fails");
+
+        assert_eq!(outcome.result.name, "post-fail");
+        assert_eq!(outcome.hooks_status, RemoveHooksStatus::Ran);
+        assert!(!create_result.path.exists(), "worktree should be deleted");
+
+        // Post_remove failure should be captured as warning
+        assert!(
+            outcome.post_remove_warning.is_some(),
+            "post_remove warning should be captured"
+        );
+
+        // DB should still have removed_at set
+        let wt_record = db.get_worktree(wt.id).unwrap().unwrap();
+        assert!(wt_record.removed_at.is_some(), "removed_at should be set");
+    }
 }

--- a/src/cli/commands/remove.rs
+++ b/src/cli/commands/remove.rs
@@ -180,10 +180,31 @@ pub async fn execute_resolved_with_hooks(
     // Step 2: remove worktree
     let result = execute_resolved(repo, wt, repo_info, db, prune)?;
 
+    // Step 3: post_remove hook (cwd = repo path, FR-22)
+    let post_remove_warning = if let Some(post_remove) = &hooks.post_remove {
+        match hooks::runner::execute_hook(
+            &HookEvent::PostRemove,
+            post_remove,
+            &env_ctx,
+            &repo_info.path,
+            &repo_info.path, // cwd = repo path (worktree is gone)
+            db,
+            repo.id,
+            Some(wt.id),
+        )
+        .await
+        {
+            Ok(_) => None,
+            Err(e) => Some(e),
+        }
+    } else {
+        None
+    };
+
     Ok(RemoveWithHooksResult {
         result,
         hooks_status: RemoveHooksStatus::Ran,
-        post_remove_warning: None,
+        post_remove_warning,
     })
 }
 
@@ -827,5 +848,66 @@ mod tests {
             wt_record.removed_at.is_none(),
             "removed_at should be None after pre_remove failure"
         );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn post_remove_hook_runs_after_deletion_with_repo_cwd() {
+        let repo_dir = tempfile::tempdir().unwrap();
+        let _repo = init_repo_with_commit(repo_dir.path());
+        let wt_root = tempfile::tempdir().unwrap();
+        let db_dir = tempfile::tempdir().unwrap();
+        let db = Database::open(&db_dir.path().join("test.db")).unwrap();
+
+        let create_result = crate::cli::commands::create::execute(
+            "post-rm-test",
+            None,
+            repo_dir.path(),
+            wt_root.path(),
+            crate::paths::DEFAULT_WORKTREE_TEMPLATE,
+            &db,
+        )
+        .expect("create should succeed");
+
+        let repo_info = crate::git::discover_repo(repo_dir.path()).unwrap();
+        let (repo, wt) =
+            crate::adopt::resolve_or_adopt("post-rm-test", &repo_info, &db).unwrap();
+
+        // post_remove hook creates a marker file in repo dir to prove cwd = repo path
+        let marker = repo_dir.path().join("post_remove_marker.txt");
+        let hooks = crate::config::HooksConfig {
+            post_remove: Some(crate::config::HookDef {
+                copy: None,
+                run: Some(vec![format!("echo done > {}", marker.display())]),
+                shell: None,
+                timeout_secs: Some(30),
+            }),
+            ..Default::default()
+        };
+
+        let outcome = execute_resolved_with_hooks(
+            &repo,
+            &wt,
+            &repo_info,
+            &db,
+            false,
+            Some(&hooks),
+            false,
+        )
+        .await
+        .expect("remove should succeed");
+
+        assert_eq!(outcome.hooks_status, RemoveHooksStatus::Ran);
+        assert!(!create_result.path.exists(), "worktree dir should be deleted");
+        assert!(outcome.post_remove_warning.is_none());
+
+        // Verify post_remove hook ran with cwd = repo path
+        assert!(
+            marker.exists(),
+            "post_remove marker should exist (proves cwd = repo path)"
+        );
+
+        // Verify hook event logged
+        let hook_events = db.count_events(wt.id, Some("hook:post_remove")).unwrap();
+        assert_eq!(hook_events, 1, "post_remove hook event should be logged");
     }
 }

--- a/src/cli/commands/remove.rs
+++ b/src/cli/commands/remove.rs
@@ -163,18 +163,24 @@ pub async fn execute_resolved_with_hooks(
     // Step 1: pre_remove hook (cwd = worktree path, FR-22)
     if let Some(pre_remove) = &hooks.pre_remove {
         let worktree_path = Path::new(&wt.path);
-        hooks::runner::execute_hook(
-            &HookEvent::PreRemove,
-            pre_remove,
-            &env_ctx,
-            &repo_info.path,
-            worktree_path,
-            db,
-            repo.id,
-            Some(wt.id),
-        )
-        .await
-        .map_err(RemoveError::PreRemoveHookFailed)?;
+        if worktree_path.exists() {
+            hooks::runner::execute_hook(
+                &HookEvent::PreRemove,
+                pre_remove,
+                &env_ctx,
+                &repo_info.path,
+                worktree_path,
+                db,
+                repo.id,
+                Some(wt.id),
+            )
+            .await
+            .map_err(RemoveError::PreRemoveHookFailed)?;
+        } else {
+            eprintln!(
+                "warning: skipping pre_remove hook because the worktree directory is already gone"
+            );
+        }
     }
 
     // Step 2: remove worktree
@@ -909,6 +915,67 @@ mod tests {
         // Verify hook event logged
         let hook_events = db.count_events(wt.id, Some("hook:post_remove")).unwrap();
         assert_eq!(hook_events, 1, "post_remove hook event should be logged");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn pre_remove_hook_skipped_when_worktree_dir_missing() {
+        let repo_dir = tempfile::tempdir().unwrap();
+        let _repo = init_repo_with_commit(repo_dir.path());
+        let wt_root = tempfile::tempdir().unwrap();
+        let db_dir = tempfile::tempdir().unwrap();
+        let db = Database::open(&db_dir.path().join("test.db")).unwrap();
+
+        let create_result = crate::cli::commands::create::execute(
+            "gone-dir",
+            None,
+            repo_dir.path(),
+            wt_root.path(),
+            crate::paths::DEFAULT_WORKTREE_TEMPLATE,
+            &db,
+        )
+        .expect("create should succeed");
+
+        let repo_info = crate::git::discover_repo(repo_dir.path()).unwrap();
+        let (repo, wt) =
+            crate::adopt::resolve_or_adopt("gone-dir", &repo_info, &db).unwrap();
+
+        // Manually delete the worktree directory to simulate user deletion
+        std::fs::remove_dir_all(&create_result.path).unwrap();
+        assert!(!create_result.path.exists());
+
+        // pre_remove hook configured — should be skipped, not error
+        let hooks = crate::config::HooksConfig {
+            pre_remove: Some(crate::config::HookDef {
+                copy: None,
+                run: Some(vec!["echo should_not_run".to_string()]),
+                shell: None,
+                timeout_secs: Some(30),
+            }),
+            ..Default::default()
+        };
+
+        let outcome = execute_resolved_with_hooks(
+            &repo,
+            &wt,
+            &repo_info,
+            &db,
+            false,
+            Some(&hooks),
+            false,
+        )
+        .await
+        .expect("remove should succeed even when worktree dir is gone");
+
+        assert_eq!(outcome.result.name, "gone-dir");
+        assert_eq!(outcome.hooks_status, RemoveHooksStatus::Ran);
+
+        // DB record should have removed_at set
+        let wt_record = db.get_worktree(wt.id).unwrap().unwrap();
+        assert!(wt_record.removed_at.is_some(), "removed_at should be set");
+
+        // No pre_remove hook event should be logged (hook was skipped)
+        let hook_events = db.count_events(wt.id, Some("hook:pre_remove")).unwrap();
+        assert_eq!(hook_events, 0, "pre_remove hook should not have run");
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/src/cli/commands/remove.rs
+++ b/src/cli/commands/remove.rs
@@ -2,8 +2,39 @@ use std::path::Path;
 
 use anyhow::{Context, Result};
 
+use crate::config::HooksConfig;
 use crate::git::{self, RepoInfo};
+use crate::hooks::{self, HookEnvContext, HookEvent};
 use crate::state::{Database, Repo, Worktree};
+
+/// Typed errors for the `remove` command.
+#[derive(Debug, thiserror::Error)]
+pub enum RemoveError {
+    #[error("pre_remove hook failed")]
+    PreRemoveHookFailed(#[source] anyhow::Error),
+}
+
+/// Hook execution status for the remove operation.
+#[derive(Debug, PartialEq, Eq)]
+pub enum RemoveHooksStatus {
+    /// No hooks were configured.
+    None,
+    /// Hooks executed successfully.
+    Ran,
+    /// Hooks were configured but skipped (`--no-hooks`).
+    Skipped,
+}
+
+/// Result of `execute_resolved_with_hooks` — includes remove result, hooks
+/// status, and any post_remove hook warning.
+#[derive(Debug)]
+pub struct RemoveWithHooksResult {
+    pub result: RemoveResult,
+    pub hooks_status: RemoveHooksStatus,
+    /// If post_remove hook failed, this contains the error.
+    /// The worktree was already removed — this is a warning only (FR-24).
+    pub post_remove_warning: Option<anyhow::Error>,
+}
 
 /// Result of a worktree removal.
 #[derive(Debug)]
@@ -81,6 +112,49 @@ pub fn execute_resolved(
     Ok(RemoveResult {
         name: wt.name.clone(),
         pruned_remote,
+    })
+}
+
+/// Execute `trench remove` with lifecycle hooks.
+///
+/// Orchestrates: pre_remove hook → removal → post_remove hook.
+/// - If `no_hooks` is true or no hooks configured, hooks are skipped.
+/// - Pre_remove failure cancels the operation (worktree not removed).
+/// - Post_remove failure: worktree already gone, warning only (FR-24).
+pub async fn execute_resolved_with_hooks(
+    repo: &Repo,
+    wt: &Worktree,
+    repo_info: &RepoInfo,
+    db: &Database,
+    prune: bool,
+    hooks_config: Option<&HooksConfig>,
+    no_hooks: bool,
+) -> Result<RemoveWithHooksResult> {
+    let has_hooks = hooks_config
+        .map(|h| h.pre_remove.is_some() || h.post_remove.is_some())
+        .unwrap_or(false);
+
+    // Fast path: no hooks to run
+    if no_hooks || !has_hooks {
+        let hooks_status = if no_hooks && has_hooks {
+            RemoveHooksStatus::Skipped
+        } else {
+            RemoveHooksStatus::None
+        };
+        let result = execute_resolved(repo, wt, repo_info, db, prune)?;
+        return Ok(RemoveWithHooksResult {
+            result,
+            hooks_status,
+            post_remove_warning: None,
+        });
+    }
+
+    // TODO: hook execution will be added in subsequent cycles
+    let result = execute_resolved(repo, wt, repo_info, db, prune)?;
+    Ok(RemoveWithHooksResult {
+        result,
+        hooks_status: RemoveHooksStatus::Ran,
+        post_remove_warning: None,
     })
 }
 
@@ -480,5 +554,51 @@ mod tests {
             msg.contains("not found"),
             "error should mention 'not found', got: {msg}"
         );
+    }
+
+    // ── Hook integration tests ──────────────────────────────────────────
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn execute_with_hooks_no_hooks_configured_returns_none_status() {
+        let repo_dir = tempfile::tempdir().unwrap();
+        let _repo = init_repo_with_commit(repo_dir.path());
+        let wt_root = tempfile::tempdir().unwrap();
+        let db_dir = tempfile::tempdir().unwrap();
+        let db = Database::open(&db_dir.path().join("test.db")).unwrap();
+
+        // Create a worktree first
+        let create_result = crate::cli::commands::create::execute(
+            "hooks-none",
+            None,
+            repo_dir.path(),
+            wt_root.path(),
+            crate::paths::DEFAULT_WORKTREE_TEMPLATE,
+            &db,
+        )
+        .expect("create should succeed");
+        assert!(create_result.path.exists());
+
+        // Resolve worktree for the hooks variant
+        let repo_info = crate::git::discover_repo(repo_dir.path()).unwrap();
+        let (repo, wt) =
+            crate::adopt::resolve_or_adopt("hooks-none", &repo_info, &db).unwrap();
+
+        // Remove with no hooks configured
+        let outcome = execute_resolved_with_hooks(
+            &repo,
+            &wt,
+            &repo_info,
+            &db,
+            false,
+            None,  // no hooks
+            false, // no_hooks flag irrelevant
+        )
+        .await
+        .expect("remove should succeed");
+
+        assert_eq!(outcome.result.name, "hooks-none");
+        assert_eq!(outcome.hooks_status, RemoveHooksStatus::None);
+        assert!(outcome.post_remove_warning.is_none());
+        assert!(!create_result.path.exists(), "worktree dir should be deleted");
     }
 }

--- a/src/cli/commands/remove.rs
+++ b/src/cli/commands/remove.rs
@@ -149,8 +149,37 @@ pub async fn execute_resolved_with_hooks(
         });
     }
 
-    // TODO: hook execution will be added in subsequent cycles
+    let hooks = hooks_config.unwrap(); // safe: has_hooks is true
+
+    let env_ctx = HookEnvContext {
+        worktree_path: wt.path.clone(),
+        worktree_name: wt.name.clone(),
+        branch: wt.branch.clone(),
+        repo_name: repo.name.clone(),
+        repo_path: repo_info.path.to_string_lossy().to_string(),
+        base_branch: wt.base_branch.clone().unwrap_or_default(),
+    };
+
+    // Step 1: pre_remove hook (cwd = worktree path, FR-22)
+    if let Some(pre_remove) = &hooks.pre_remove {
+        let worktree_path = Path::new(&wt.path);
+        hooks::runner::execute_hook(
+            &HookEvent::PreRemove,
+            pre_remove,
+            &env_ctx,
+            &repo_info.path,
+            worktree_path,
+            db,
+            repo.id,
+            Some(wt.id),
+        )
+        .await
+        .map_err(RemoveError::PreRemoveHookFailed)?;
+    }
+
+    // Step 2: remove worktree
     let result = execute_resolved(repo, wt, repo_info, db, prune)?;
+
     Ok(RemoveWithHooksResult {
         result,
         hooks_status: RemoveHooksStatus::Ran,
@@ -666,5 +695,72 @@ mod tests {
         let wt_record = db.get_worktree(wt.id).unwrap().unwrap();
         let hook_events = db.count_events(wt_record.id, Some("hook:pre_remove")).unwrap();
         assert_eq!(hook_events, 0, "no hook events should be recorded when --no-hooks");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn pre_remove_hook_runs_before_worktree_deletion() {
+        let repo_dir = tempfile::tempdir().unwrap();
+        let _repo = init_repo_with_commit(repo_dir.path());
+        let wt_root = tempfile::tempdir().unwrap();
+        let db_dir = tempfile::tempdir().unwrap();
+        let db = Database::open(&db_dir.path().join("test.db")).unwrap();
+
+        let create_result = crate::cli::commands::create::execute(
+            "pre-rm-test",
+            None,
+            repo_dir.path(),
+            wt_root.path(),
+            crate::paths::DEFAULT_WORKTREE_TEMPLATE,
+            &db,
+        )
+        .expect("create should succeed");
+
+        let repo_info = crate::git::discover_repo(repo_dir.path()).unwrap();
+        let (repo, wt) =
+            crate::adopt::resolve_or_adopt("pre-rm-test", &repo_info, &db).unwrap();
+
+        // pre_remove hook writes a marker file to prove it ran with cwd = worktree path
+        let hooks = crate::config::HooksConfig {
+            pre_remove: Some(crate::config::HookDef {
+                copy: None,
+                run: Some(vec!["echo pre_remove_executed".to_string()]),
+                shell: None,
+                timeout_secs: Some(30),
+            }),
+            ..Default::default()
+        };
+
+        let outcome = execute_resolved_with_hooks(
+            &repo,
+            &wt,
+            &repo_info,
+            &db,
+            false,
+            Some(&hooks),
+            false,
+        )
+        .await
+        .expect("remove should succeed");
+
+        assert_eq!(outcome.hooks_status, RemoveHooksStatus::Ran);
+        assert!(!create_result.path.exists(), "worktree dir should be deleted after hooks");
+
+        // Verify hook event was logged
+        let hook_events = db.count_events(wt.id, Some("hook:pre_remove")).unwrap();
+        assert_eq!(hook_events, 1, "pre_remove hook event should be logged");
+
+        // Verify hook output was captured in logs
+        let events = db.list_events(wt.id, 10).unwrap();
+        let hook_event = events.iter().find(|e| e.event_type == "hook:pre_remove").unwrap();
+        let logs = db.get_logs(hook_event.id).unwrap();
+        let stdout_lines: Vec<&str> = logs
+            .iter()
+            .filter(|(s, _, _)| s == "stdout")
+            .map(|(_, l, _)| l.as_str())
+            .collect();
+        assert!(
+            stdout_lines.contains(&"pre_remove_executed"),
+            "pre_remove output should be logged: {stdout_lines:?}"
+        );
     }
 }

--- a/src/cli/commands/remove.rs
+++ b/src/cli/commands/remove.rs
@@ -558,6 +558,24 @@ mod tests {
 
     // ── Hook integration tests ──────────────────────────────────────────
 
+    fn sample_hooks_config() -> crate::config::HooksConfig {
+        crate::config::HooksConfig {
+            pre_remove: Some(crate::config::HookDef {
+                copy: None,
+                run: Some(vec!["echo pre_remove_ran".to_string()]),
+                shell: None,
+                timeout_secs: Some(30),
+            }),
+            post_remove: Some(crate::config::HookDef {
+                copy: None,
+                run: Some(vec!["echo post_remove_ran".to_string()]),
+                shell: None,
+                timeout_secs: Some(30),
+            }),
+            ..Default::default()
+        }
+    }
+
     #[tokio::test(flavor = "current_thread")]
     async fn execute_with_hooks_no_hooks_configured_returns_none_status() {
         let repo_dir = tempfile::tempdir().unwrap();
@@ -600,5 +618,53 @@ mod tests {
         assert_eq!(outcome.hooks_status, RemoveHooksStatus::None);
         assert!(outcome.post_remove_warning.is_none());
         assert!(!create_result.path.exists(), "worktree dir should be deleted");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn execute_with_hooks_no_hooks_flag_skips_hooks() {
+        let repo_dir = tempfile::tempdir().unwrap();
+        let _repo = init_repo_with_commit(repo_dir.path());
+        let wt_root = tempfile::tempdir().unwrap();
+        let db_dir = tempfile::tempdir().unwrap();
+        let db = Database::open(&db_dir.path().join("test.db")).unwrap();
+
+        let create_result = crate::cli::commands::create::execute(
+            "skip-hooks",
+            None,
+            repo_dir.path(),
+            wt_root.path(),
+            crate::paths::DEFAULT_WORKTREE_TEMPLATE,
+            &db,
+        )
+        .expect("create should succeed");
+
+        let repo_info = crate::git::discover_repo(repo_dir.path()).unwrap();
+        let (repo, wt) =
+            crate::adopt::resolve_or_adopt("skip-hooks", &repo_info, &db).unwrap();
+
+        let hooks = sample_hooks_config();
+
+        // Remove with --no-hooks
+        let outcome = execute_resolved_with_hooks(
+            &repo,
+            &wt,
+            &repo_info,
+            &db,
+            false,
+            Some(&hooks),
+            true, // no_hooks = true
+        )
+        .await
+        .expect("remove should succeed");
+
+        assert_eq!(outcome.result.name, "skip-hooks");
+        assert_eq!(outcome.hooks_status, RemoveHooksStatus::Skipped);
+        assert!(outcome.post_remove_warning.is_none());
+        assert!(!create_result.path.exists(), "worktree dir should be deleted");
+
+        // Verify no hook events were recorded
+        let wt_record = db.get_worktree(wt.id).unwrap().unwrap();
+        let hook_events = db.count_events(wt_record.id, Some("hook:pre_remove")).unwrap();
+        assert_eq!(hook_events, 0, "no hook events should be recorded when --no-hooks");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -349,11 +349,16 @@ fn run_remove(identifier: &str, force: bool, prune: bool, no_hooks: bool) -> any
     let db_path = paths::data_dir()?.join("trench.db");
     let db = state::Database::open(&db_path)?;
 
-    // Load config for hooks
     let repo_info = git::discover_repo(&cwd)?;
-    let project_config = config::load_project_config(&repo_info.path)?;
-    let global_config = config::load_global_config()?;
-    let resolved_config = config::resolve_config(None, project_config.as_ref(), &global_config);
+
+    // Skip config I/O when --no-hooks is set (escape hatch)
+    let hooks_config = if no_hooks {
+        None
+    } else {
+        let project_config = config::load_project_config(&repo_info.path)?;
+        let global_config = config::load_global_config()?;
+        config::resolve_config(None, project_config.as_ref(), &global_config).hooks
+    };
 
     // If not forced, resolve the worktree (adopting if unmanaged) for the prompt
     let resolved = if !force {
@@ -397,7 +402,7 @@ fn run_remove(identifier: &str, force: bool, prune: bool, no_hooks: bool) -> any
         &repo_info,
         &db,
         prune,
-        resolved_config.hooks.as_ref(),
+        hooks_config.as_ref(),
         no_hooks,
     )) {
         Ok(outcome) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,6 +77,10 @@ enum Commands {
         /// Also delete the corresponding remote branch
         #[arg(long)]
         prune: bool,
+
+        /// Skip all lifecycle hooks (pre_remove, post_remove)
+        #[arg(long)]
+        no_hooks: bool,
     },
     /// Switch to a worktree
     Switch {
@@ -211,7 +215,8 @@ fn main() -> anyhow::Result<()> {
             branch,
             force,
             prune,
-        }) => run_remove(&branch, force, prune),
+            no_hooks,
+        }) => run_remove(&branch, force, prune, no_hooks),
         Some(Commands::Switch { branch, print_path }) => run_switch(&branch, print_path),
         Some(Commands::Tag { branch, tags }) => run_tag(&branch, &tags),
         Some(Commands::Open { branch }) => run_open(&branch),
@@ -339,14 +344,19 @@ fn run_create(
     }
 }
 
-fn run_remove(identifier: &str, force: bool, prune: bool) -> anyhow::Result<()> {
+fn run_remove(identifier: &str, force: bool, prune: bool, no_hooks: bool) -> anyhow::Result<()> {
     let cwd = std::env::current_dir().context("failed to determine current directory")?;
     let db_path = paths::data_dir()?.join("trench.db");
     let db = state::Database::open(&db_path)?;
 
+    // Load config for hooks
+    let repo_info = git::discover_repo(&cwd)?;
+    let project_config = config::load_project_config(&repo_info.path)?;
+    let global_config = config::load_global_config()?;
+    let resolved_config = config::resolve_config(None, project_config.as_ref(), &global_config);
+
     // If not forced, resolve the worktree (adopting if unmanaged) for the prompt
     let resolved = if !force {
-        let repo_info = git::discover_repo(&cwd)?;
         if let Ok((repo, wt)) = adopt::resolve_or_adopt(identifier, &repo_info, &db) {
             let prune_hint = if prune {
                 " (including remote branch)"
@@ -365,7 +375,7 @@ fn run_remove(identifier: &str, force: bool, prune: bool) -> anyhow::Result<()> 
                 eprintln!("Cancelled.");
                 return Ok(());
             }
-            Some((repo, wt, repo_info))
+            Some((repo, wt))
         } else {
             None
         }
@@ -373,23 +383,42 @@ fn run_remove(identifier: &str, force: bool, prune: bool) -> anyhow::Result<()> 
         None
     };
 
-    let remove_result = match resolved {
-        Some((repo, wt, repo_info)) => {
-            cli::commands::remove::execute_resolved(&repo, &wt, &repo_info, &db, prune)
-        }
-        None => cli::commands::remove::execute(identifier, &cwd, &db, prune),
+    // Resolve worktree if not already done by the prompt flow
+    let (repo, wt) = match resolved {
+        Some((repo, wt)) => (repo, wt),
+        None => adopt::resolve_or_adopt(identifier, &repo_info, &db)?,
     };
 
-    match remove_result {
-        Ok(result) => {
-            if result.pruned_remote {
-                eprintln!("Removed worktree '{}' and remote branch", result.name);
+    let rt = tokio::runtime::Runtime::new().context("failed to create async runtime")?;
+
+    match rt.block_on(cli::commands::remove::execute_resolved_with_hooks(
+        &repo,
+        &wt,
+        &repo_info,
+        &db,
+        prune,
+        resolved_config.hooks.as_ref(),
+        no_hooks,
+    )) {
+        Ok(outcome) => {
+            // Report post_remove hook failure as warning (FR-24: WarnOnly)
+            if let Some(ref hook_err) = outcome.post_remove_warning {
+                eprintln!("warning: post_remove hook failed: {hook_err:#}");
+            }
+
+            if outcome.result.pruned_remote {
+                eprintln!("Removed worktree '{}' and remote branch", outcome.result.name);
             } else {
-                eprintln!("Removed worktree '{}'", result.name);
+                eprintln!("Removed worktree '{}'", outcome.result.name);
             }
             Ok(())
         }
         Err(e) => {
+            // Check for pre_remove hook failure → exit code 4
+            if e.downcast_ref::<cli::commands::remove::RemoveError>().is_some() {
+                eprintln!("error: {e:#}");
+                std::process::exit(4);
+            }
             if let Some(git_err) = e.downcast_ref::<git::GitError>() {
                 if matches!(git_err, git::GitError::WorktreeNotFound { .. }) {
                     eprintln!("error: {e}");
@@ -926,10 +955,12 @@ mod tests {
                 branch,
                 force,
                 prune,
+                no_hooks,
             }) => {
                 assert_eq!(branch, "my-feature");
                 assert!(!force);
                 assert!(!prune);
+                assert!(!no_hooks);
             }
             _ => panic!("expected Commands::Remove"),
         }
@@ -944,10 +975,12 @@ mod tests {
                 branch,
                 force,
                 prune,
+                no_hooks,
             }) => {
                 assert_eq!(branch, "my-feature");
                 assert!(force);
                 assert!(!prune);
+                assert!(!no_hooks);
             }
             _ => panic!("expected Commands::Remove"),
         }
@@ -1061,10 +1094,12 @@ mod tests {
                 branch,
                 force,
                 prune,
+                no_hooks,
             }) => {
                 assert_eq!(branch, "my-feature");
                 assert!(!force);
                 assert!(prune);
+                assert!(!no_hooks);
             }
             _ => panic!("expected Commands::Remove"),
         }
@@ -1079,10 +1114,12 @@ mod tests {
                 branch,
                 force,
                 prune,
+                no_hooks,
             }) => {
                 assert_eq!(branch, "my-feature");
                 assert!(force);
                 assert!(prune);
+                assert!(!no_hooks);
             }
             _ => panic!("expected Commands::Remove"),
         }
@@ -1095,6 +1132,18 @@ mod tests {
         match cli.command {
             Some(Commands::Remove { prune, .. }) => {
                 assert!(!prune);
+            }
+            _ => panic!("expected Commands::Remove"),
+        }
+    }
+
+    #[test]
+    fn remove_subcommand_accepts_no_hooks_flag() {
+        let cli = Cli::try_parse_from(["trench", "remove", "my-feature", "--no-hooks"])
+            .expect("remove with --no-hooks should succeed");
+        match cli.command {
+            Some(Commands::Remove { no_hooks, .. }) => {
+                assert!(no_hooks);
             }
             _ => panic!("expected Commands::Remove"),
         }


### PR DESCRIPTION
Closes #40

## Summary
Integrate the hook runner into `trench remove` so that `pre_remove` hooks run before worktree deletion (cwd = worktree path) and `post_remove` hooks run after deletion (cwd = repo path). Pre_remove failure cancels removal with exit code 4; post_remove failure is a warning only since the worktree is already gone (FR-24). The `--no-hooks` flag skips all hooks (FR-25).

## User Stories Addressed
- US-8: Remove a worktree with pre-removal hooks (kill dev servers, cleanup)

## Automated Testing
- Total tests added: 7
- Tests passing: 7
- Tests failing: 0
- `cargo clippy`: pass (pre-existing warnings only)
- `cargo test`: pass (2 pre-existing failures in git::tests unrelated to this PR — they expect `master` default branch but system uses `main`)

## UAT Checklist
- [ ] Create a `.trench.toml` with `[hooks.pre_remove] run = ["echo cleanup"]` and `[hooks.post_remove] run = ["echo done"]`
- [ ] `trench create test-hooks && trench remove test-hooks --force` → see "cleanup" then "done" in output
- [ ] `trench create test-hooks && trench remove test-hooks --force --no-hooks` → no hook output, worktree removed
- [ ] Configure `[hooks.pre_remove] run = ["exit 1"]`, then `trench remove test-hooks --force` → removal cancelled, worktree still exists
- [ ] Configure `[hooks.post_remove] run = ["exit 1"]`, then `trench remove test-hooks --force` → worktree removed, warning printed to stderr
- [ ] `trench remove --help` → shows `--no-hooks` flag in help text

## Known Issues
None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Execute pre- and post-remove hooks during removals.
  * New --no-hooks flag to skip hooks and use a fast-path removal.
  * Pre-remove hook failures cancel removal and surface an error.
  * Post-remove hook failures are reported as non-fatal warnings.
  * Hook environment includes worktree and repository details for scripts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->