### PR TITLE
feat(sync): add --dry-run and --no-hooks support to trench sync

### DIFF
--- a/src/adopt.rs
+++ b/src/adopt.rs
@@ -53,6 +53,13 @@ pub fn resolve_only(
         }
     }
 
+    // Check DB for the repo (read-only) before git fallback — preserves stored defaults
+    let db_repo = if let Some(db) = db {
+        db.get_repo_by_path(repo_path_str)?
+    } else {
+        None
+    };
+
     // Fall back to git worktrees — construct virtual structs (no writes)
     let git_worktrees = git::list_worktrees(&repo_info.path)?;
     let sanitized = paths::sanitize_branch(identifier);
@@ -69,16 +76,19 @@ pub fn resolve_only(
             let branch = gw.branch.clone().unwrap_or_else(|| identifier.to_string());
             let name = paths::sanitize_branch(&branch);
 
-            let repo = Repo {
-                id: 0,
-                name: repo_info.name.clone(),
-                path: repo_path_str.to_string(),
-                default_base: Some(repo_info.default_branch.clone()),
-                created_at: 0,
+            let repo = match db_repo {
+                Some(ref r) => r.clone(),
+                None => Repo {
+                    id: 0,
+                    name: repo_info.name.clone(),
+                    path: repo_path_str.to_string(),
+                    default_base: Some(repo_info.default_branch.clone()),
+                    created_at: 0,
+                },
             };
             let wt = Worktree {
                 id: 0,
-                repo_id: 0,
+                repo_id: repo.id,
                 name,
                 branch,
                 path: gw.path.to_string_lossy().to_string(),
@@ -432,6 +442,67 @@ mod tests {
         assert_eq!(repo.id, 0);
         assert_eq!(wt.id, 0);
         assert_eq!(wt.branch, "no-db-feat");
+    }
+
+    #[test]
+    fn resolve_only_reuses_db_repo_defaults_in_git_fallback() {
+        let repo_dir = tempfile::tempdir().unwrap();
+        let git_repo = init_repo_with_commit(repo_dir.path());
+        let db = Database::open_in_memory().unwrap();
+
+        // Insert repo in DB with a non-default base branch
+        let repo_path = repo_dir.path().canonicalize().unwrap();
+        let repo_path_str = repo_path.to_str().unwrap();
+        let db_repo = db
+            .insert_repo("my-project", repo_path_str, Some("develop"))
+            .unwrap();
+
+        // Create a git worktree NOT registered in DB
+        let wt_dir = tempfile::tempdir().unwrap();
+        let wt_path = wt_dir.path().join("db-base-feat");
+        git_repo
+            .branch(
+                "db-base-feat",
+                &git_repo.head().unwrap().peel_to_commit().unwrap(),
+                false,
+            )
+            .unwrap();
+        let branch_ref = git_repo
+            .find_branch("db-base-feat", git2::BranchType::Local)
+            .unwrap();
+        let mut opts = git2::WorktreeAddOptions::new();
+        opts.reference(Some(branch_ref.get()));
+        git_repo
+            .worktree("db-base-feat", &wt_path, Some(&opts))
+            .unwrap();
+
+        let repo_info = git::discover_repo(repo_dir.path()).unwrap();
+
+        // resolve_only should use DB repo (with default_base = "develop")
+        let (repo, wt) =
+            resolve_only("db-base-feat", &repo_info, Some(&db)).expect("should resolve");
+
+        // Should get the DB repo's default_base, not git's default branch
+        assert_eq!(
+            repo.default_base.as_deref(),
+            Some("develop"),
+            "should preserve DB-stored default_base"
+        );
+        assert_eq!(repo.id, db_repo.id, "should use DB repo (id > 0)");
+
+        // Worktree should still be virtual (not in DB)
+        assert_eq!(wt.id, 0, "worktree should be virtual");
+        assert_eq!(wt.repo_id, db_repo.id, "worktree should reference DB repo");
+        assert_eq!(wt.branch, "db-base-feat");
+
+        // DB must NOT have a worktree row (resolve_only doesn't write)
+        let found_wt = db
+            .find_worktree_by_identifier(db_repo.id, "db-base-feat")
+            .unwrap();
+        assert!(
+            found_wt.is_none(),
+            "resolve_only must not insert worktree into DB"
+        );
     }
 
     #[test]

--- a/src/adopt.rs
+++ b/src/adopt.rs
@@ -22,6 +22,80 @@ fn ensure_repo(db: &Database, repo_info: &RepoInfo) -> Result<Repo> {
     )
 }
 
+/// Resolve a worktree by identifier without writing to the database.
+///
+/// Like [`resolve_or_adopt`], tries the DB first (if provided) then falls back
+/// to git worktree discovery. However, the git fallback constructs virtual
+/// `Repo` and `Worktree` structs with placeholder IDs (id=0) instead of
+/// inserting rows. Safe for read-only contexts like `--dry-run`.
+pub fn resolve_only(
+    identifier: &str,
+    repo_info: &RepoInfo,
+    db: Option<&Database>,
+) -> Result<(Repo, Worktree)> {
+    let repo_path_str = repo_info
+        .path
+        .to_str()
+        .ok_or_else(|| anyhow::anyhow!("repo path is not valid UTF-8"))?;
+
+    // Try DB first (read-only)
+    if let Some(db) = db {
+        if let Some(repo) = db.get_repo_by_path(repo_path_str)? {
+            if let Some(wt) = db.find_worktree_by_identifier(repo.id, identifier)? {
+                return Ok((repo, wt));
+            }
+            let sanitized = paths::sanitize_branch(identifier);
+            if sanitized != identifier {
+                if let Some(wt) = db.find_worktree_by_identifier(repo.id, &sanitized)? {
+                    return Ok((repo, wt));
+                }
+            }
+        }
+    }
+
+    // Fall back to git worktrees — construct virtual structs (no writes)
+    let git_worktrees = git::list_worktrees(&repo_info.path)?;
+    let sanitized = paths::sanitize_branch(identifier);
+
+    for gw in &git_worktrees {
+        let branch_match = gw.branch.as_deref() == Some(identifier);
+        let name_match = gw.name == identifier || gw.name == sanitized;
+        let sanitized_branch_match = gw
+            .branch
+            .as_deref()
+            .is_some_and(|b| paths::sanitize_branch(b) == sanitized);
+
+        if branch_match || name_match || sanitized_branch_match {
+            let branch = gw.branch.clone().unwrap_or_else(|| identifier.to_string());
+            let name = paths::sanitize_branch(&branch);
+
+            let repo = Repo {
+                id: 0,
+                name: repo_info.name.clone(),
+                path: repo_path_str.to_string(),
+                default_base: Some(repo_info.default_branch.clone()),
+                created_at: 0,
+            };
+            let wt = Worktree {
+                id: 0,
+                repo_id: 0,
+                name,
+                branch,
+                path: gw.path.to_string_lossy().to_string(),
+                base_branch: None,
+                managed: false,
+                adopted_at: None,
+                last_accessed: None,
+                removed_at: None,
+                created_at: 0,
+            };
+            return Ok((repo, wt));
+        }
+    }
+
+    anyhow::bail!("worktree not found: {identifier}")
+}
+
 /// Resolve a worktree by identifier, adopting it if unmanaged.
 ///
 /// Tries the DB first (exact match, then sanitized fallback). If not found,
@@ -66,10 +140,7 @@ pub fn resolve_or_adopt(
 
         if branch_match || name_match || sanitized_branch_match {
             let repo = ensure_repo(db, repo_info)?;
-            let branch = gw
-                .branch
-                .clone()
-                .unwrap_or_else(|| identifier.to_string());
+            let branch = gw.branch.clone().unwrap_or_else(|| identifier.to_string());
             let name = paths::sanitize_branch(&branch);
             let path = gw.path.to_string_lossy();
 
@@ -126,7 +197,10 @@ mod tests {
 
         assert_eq!(repo.id, db_repo.id);
         assert_eq!(wt.id, inserted.id);
-        assert!(wt.adopted_at.is_none(), "existing worktree should not be adopted");
+        assert!(
+            wt.adopted_at.is_none(),
+            "existing worktree should not be adopted"
+        );
     }
 
     #[test]
@@ -244,6 +318,123 @@ mod tests {
     }
 
     #[test]
+    fn resolve_only_does_not_write_for_unmanaged_worktree() {
+        let repo_dir = tempfile::tempdir().unwrap();
+        let git_repo = init_repo_with_commit(repo_dir.path());
+        let db = Database::open_in_memory().unwrap();
+
+        // Do NOT insert repo or worktree into DB — completely unmanaged
+
+        // Create a git worktree manually
+        let wt_dir = tempfile::tempdir().unwrap();
+        let wt_path = wt_dir.path().join("virtual-feat");
+        git_repo
+            .branch(
+                "virtual-feat",
+                &git_repo.head().unwrap().peel_to_commit().unwrap(),
+                false,
+            )
+            .unwrap();
+        let branch_ref = git_repo
+            .find_branch("virtual-feat", git2::BranchType::Local)
+            .unwrap();
+        let mut opts = git2::WorktreeAddOptions::new();
+        opts.reference(Some(branch_ref.get()));
+        git_repo
+            .worktree("virtual-feat", &wt_path, Some(&opts))
+            .unwrap();
+
+        let repo_info = git::discover_repo(repo_dir.path()).unwrap();
+
+        // resolve_only should return virtual structs without writing to DB
+        let (repo, wt) =
+            resolve_only("virtual-feat", &repo_info, Some(&db)).expect("should resolve");
+
+        // Virtual structs should have placeholder id=0
+        assert_eq!(repo.id, 0, "virtual repo should have id=0");
+        assert_eq!(wt.id, 0, "virtual worktree should have id=0");
+
+        // Should carry correct info from git
+        assert_eq!(repo.name, repo_info.name);
+        assert_eq!(wt.branch, "virtual-feat");
+        assert_eq!(wt.name, "virtual-feat");
+
+        // DB must have NO repo or worktree rows
+        let repo_path_str = repo_dir.path().canonicalize().unwrap();
+        let found_repo = db
+            .get_repo_by_path(repo_path_str.to_str().unwrap())
+            .unwrap();
+        assert!(
+            found_repo.is_none(),
+            "resolve_only must not insert repo into DB"
+        );
+    }
+
+    #[test]
+    fn resolve_only_returns_managed_worktree_from_db() {
+        let repo_dir = tempfile::tempdir().unwrap();
+        let _repo = init_repo_with_commit(repo_dir.path());
+        let db = Database::open_in_memory().unwrap();
+
+        let repo_path = repo_dir.path().canonicalize().unwrap();
+        let repo_path_str = repo_path.to_str().unwrap();
+        let db_repo = db
+            .insert_repo("my-project", repo_path_str, Some("main"))
+            .unwrap();
+        let inserted = db
+            .insert_worktree(
+                db_repo.id,
+                "my-feature",
+                "my-feature",
+                "/wt/my-feature",
+                Some("main"),
+            )
+            .unwrap();
+
+        let repo_info = git::discover_repo(repo_dir.path()).unwrap();
+        let (repo, wt) =
+            resolve_only("my-feature", &repo_info, Some(&db)).expect("should resolve existing");
+
+        assert_eq!(repo.id, db_repo.id);
+        assert_eq!(wt.id, inserted.id);
+    }
+
+    #[test]
+    fn resolve_only_without_db_resolves_from_git() {
+        let repo_dir = tempfile::tempdir().unwrap();
+        let git_repo = init_repo_with_commit(repo_dir.path());
+
+        // Create a git worktree manually
+        let wt_dir = tempfile::tempdir().unwrap();
+        let wt_path = wt_dir.path().join("no-db-feat");
+        git_repo
+            .branch(
+                "no-db-feat",
+                &git_repo.head().unwrap().peel_to_commit().unwrap(),
+                false,
+            )
+            .unwrap();
+        let branch_ref = git_repo
+            .find_branch("no-db-feat", git2::BranchType::Local)
+            .unwrap();
+        let mut opts = git2::WorktreeAddOptions::new();
+        opts.reference(Some(branch_ref.get()));
+        git_repo
+            .worktree("no-db-feat", &wt_path, Some(&opts))
+            .unwrap();
+
+        let repo_info = git::discover_repo(repo_dir.path()).unwrap();
+
+        // Call with db=None
+        let (repo, wt) =
+            resolve_only("no-db-feat", &repo_info, None).expect("should resolve from git");
+
+        assert_eq!(repo.id, 0);
+        assert_eq!(wt.id, 0);
+        assert_eq!(wt.branch, "no-db-feat");
+    }
+
+    #[test]
     fn resolve_or_adopt_idempotent_on_already_adopted() {
         let repo_dir = tempfile::tempdir().unwrap();
         let git_repo = init_repo_with_commit(repo_dir.path());
@@ -282,6 +473,9 @@ mod tests {
         // Second call: returns same DB record (no re-adoption)
         let (_, wt2) = resolve_or_adopt("idempotent-wt", &repo_info, &db).unwrap();
         assert_eq!(wt2.id, wt1.id, "should return same worktree");
-        assert_eq!(wt2.adopted_at, wt1.adopted_at, "adopted_at should not change");
+        assert_eq!(
+            wt2.adopted_at, wt1.adopted_at,
+            "adopted_at should not change"
+        );
     }
 }

--- a/src/cli/commands/sync.rs
+++ b/src/cli/commands/sync.rs
@@ -1,3 +1,4 @@
+use std::fmt;
 use std::path::Path;
 
 use anyhow::Result;
@@ -292,6 +293,51 @@ pub struct SyncDryRunHooks {
     pub pre_sync: Option<crate::config::HookDef>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub post_sync: Option<crate::config::HookDef>,
+}
+
+impl fmt::Display for SyncDryRunPlan {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "Dry run — no changes will be made\n")?;
+        writeln!(f, "  Worktree:  {}", self.name)?;
+        writeln!(f, "  Branch:    {}", self.branch)?;
+        writeln!(f, "  Base:      {}", self.base_branch)?;
+        writeln!(f, "  Strategy:  {}", self.strategy)?;
+
+        match &self.hooks {
+            Some(hooks) if hooks.pre_sync.is_some() || hooks.post_sync.is_some() => {
+                writeln!(f, "  Hooks:")?;
+                if let Some(h) = &hooks.pre_sync {
+                    writeln!(f, "    pre_sync:")?;
+                    format_hook_def(f, h)?;
+                }
+                if let Some(h) = &hooks.post_sync {
+                    writeln!(f, "    post_sync:")?;
+                    format_hook_def(f, h)?;
+                }
+            }
+            _ => {
+                writeln!(f, "  Hooks:     (none)")?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+fn format_hook_def(f: &mut fmt::Formatter<'_>, hook: &crate::config::HookDef) -> fmt::Result {
+    if let Some(copy) = &hook.copy {
+        writeln!(f, "      copy: {}", copy.join(", "))?;
+    }
+    if let Some(run) = &hook.run {
+        writeln!(f, "      run:  {}", run.join(", "))?;
+    }
+    if let Some(shell) = &hook.shell {
+        writeln!(f, "      shell: {shell}")?;
+    }
+    if let Some(timeout) = &hook.timeout_secs {
+        writeln!(f, "      timeout: {timeout}s")?;
+    }
+    Ok(())
 }
 
 /// Execute a dry-run of `trench sync <identifier>`.
@@ -1913,5 +1959,24 @@ mod tests {
         assert_eq!(json_val["base_branch"], "main");
         assert_eq!(json_val["strategy"], "rebase");
         assert!(json_val["hooks"].is_null(), "hooks should be null when None");
+    }
+
+    #[test]
+    fn dry_run_plan_display_shows_human_readable_text() {
+        let plan = SyncDryRunPlan {
+            dry_run: true,
+            name: "my-feature".to_string(),
+            branch: "my-feature".to_string(),
+            base_branch: "main".to_string(),
+            strategy: "rebase".to_string(),
+            hooks: None,
+        };
+
+        let output = format!("{plan}");
+        assert!(output.contains("Dry run"), "should mention dry run");
+        assert!(output.contains("my-feature"), "should contain worktree name");
+        assert!(output.contains("main"), "should contain base branch");
+        assert!(output.contains("rebase"), "should contain strategy");
+        assert!(output.contains("(none)"), "should show (none) for hooks");
     }
 }

--- a/src/cli/commands/sync.rs
+++ b/src/cli/commands/sync.rs
@@ -347,13 +347,13 @@ fn format_hook_def(f: &mut fmt::Formatter<'_>, hook: &crate::config::HookDef) ->
 pub fn execute_dry_run(
     identifier: &str,
     cwd: &Path,
-    db: &Database,
+    db: Option<&Database>,
     strategy: Strategy,
     hooks_config: Option<&HooksConfig>,
     no_hooks: bool,
 ) -> Result<SyncDryRunPlan> {
     let repo_info = crate::git::discover_repo(cwd)?;
-    let (repo, wt) = crate::adopt::resolve_or_adopt(identifier, &repo_info, db)?;
+    let (repo, wt) = crate::adopt::resolve_only(identifier, &repo_info, db)?;
 
     let base_branch = wt
         .base_branch
@@ -1274,11 +1274,20 @@ mod tests {
 
         // Verify no hook events were recorded
         let db_repo = f.db.get_repo_by_path(&f.repo_path_str).unwrap().unwrap();
-        let wt = f.db.find_worktree_by_identifier(db_repo.id, "feature").unwrap().unwrap();
+        let wt =
+            f.db.find_worktree_by_identifier(db_repo.id, "feature")
+                .unwrap()
+                .unwrap();
         let pre_hook_events = f.db.count_events(wt.id, Some("hook:pre_sync")).unwrap();
         let post_hook_events = f.db.count_events(wt.id, Some("hook:post_sync")).unwrap();
-        assert_eq!(pre_hook_events, 0, "no pre_sync hook events should be recorded");
-        assert_eq!(post_hook_events, 0, "no post_sync hook events should be recorded");
+        assert_eq!(
+            pre_hook_events, 0,
+            "no pre_sync hook events should be recorded"
+        );
+        assert_eq!(
+            post_hook_events, 0,
+            "no post_sync hook events should be recorded"
+        );
     }
 
     #[tokio::test(flavor = "current_thread")]
@@ -1313,13 +1322,19 @@ mod tests {
 
         // Verify pre_sync hook event was logged
         let db_repo = f.db.get_repo_by_path(&f.repo_path_str).unwrap().unwrap();
-        let wt = f.db.find_worktree_by_identifier(db_repo.id, "feature").unwrap().unwrap();
+        let wt =
+            f.db.find_worktree_by_identifier(db_repo.id, "feature")
+                .unwrap()
+                .unwrap();
         let hook_events = f.db.count_events(wt.id, Some("hook:pre_sync")).unwrap();
         assert_eq!(hook_events, 1, "pre_sync hook event should be logged");
 
         // Verify hook output was captured in logs
         let events = f.db.list_events(wt.id, 10).unwrap();
-        let hook_event = events.iter().find(|e| e.event_type == "hook:pre_sync").unwrap();
+        let hook_event = events
+            .iter()
+            .find(|e| e.event_type == "hook:pre_sync")
+            .unwrap();
         let logs = f.db.get_logs(hook_event.id).unwrap();
         let stdout_lines: Vec<&str> = logs
             .iter()
@@ -1365,20 +1380,26 @@ mod tests {
         );
 
         // Verify sync did NOT happen — feature branch should still be behind
-        let (_, behind) = crate::git::ahead_behind(
-            Path::new(&f.repo_path_str),
-            "feature",
-            Some("main"),
-        )
-        .unwrap()
-        .unwrap();
-        assert_eq!(behind, 1, "feature should still be 1 behind main (sync cancelled)");
+        let (_, behind) =
+            crate::git::ahead_behind(Path::new(&f.repo_path_str), "feature", Some("main"))
+                .unwrap()
+                .unwrap();
+        assert_eq!(
+            behind, 1,
+            "feature should still be 1 behind main (sync cancelled)"
+        );
 
         // Verify no "synced" event was recorded
         let db_repo = f.db.get_repo_by_path(&f.repo_path_str).unwrap().unwrap();
-        let wt = f.db.find_worktree_by_identifier(db_repo.id, "feature").unwrap().unwrap();
+        let wt =
+            f.db.find_worktree_by_identifier(db_repo.id, "feature")
+                .unwrap()
+                .unwrap();
         let synced_events = f.db.count_events(wt.id, Some("synced")).unwrap();
-        assert_eq!(synced_events, 0, "no synced event should be recorded when pre_sync fails");
+        assert_eq!(
+            synced_events, 0,
+            "no synced event should be recorded when pre_sync fails"
+        );
     }
 
     #[tokio::test(flavor = "current_thread")]
@@ -1413,11 +1434,17 @@ mod tests {
         assert!(outcome.post_sync_error.is_none());
 
         // Verify post_sync hook ran
-        assert!(marker.exists(), "post_sync marker should exist (proves hook ran)");
+        assert!(
+            marker.exists(),
+            "post_sync marker should exist (proves hook ran)"
+        );
 
         // Verify hook event logged
         let db_repo = f.db.get_repo_by_path(&f.repo_path_str).unwrap().unwrap();
-        let wt = f.db.find_worktree_by_identifier(db_repo.id, "feature").unwrap().unwrap();
+        let wt =
+            f.db.find_worktree_by_identifier(db_repo.id, "feature")
+                .unwrap()
+                .unwrap();
         let hook_events = f.db.count_events(wt.id, Some("hook:post_sync")).unwrap();
         assert_eq!(hook_events, 1, "post_sync hook event should be logged");
 
@@ -1464,9 +1491,15 @@ mod tests {
 
         // Verify sync DID happen (synced event recorded)
         let db_repo = f.db.get_repo_by_path(&f.repo_path_str).unwrap().unwrap();
-        let wt = f.db.find_worktree_by_identifier(db_repo.id, "feature").unwrap().unwrap();
+        let wt =
+            f.db.find_worktree_by_identifier(db_repo.id, "feature")
+                .unwrap()
+                .unwrap();
         let synced_events = f.db.count_events(wt.id, Some("synced")).unwrap();
-        assert_eq!(synced_events, 1, "synced event should be recorded (sync completed)");
+        assert_eq!(
+            synced_events, 1,
+            "synced event should be recorded (sync completed)"
+        );
 
         // Verify upstream file exists (sync applied)
         assert!(
@@ -1481,8 +1514,7 @@ mod tests {
 
         // Resolve the worktree manually (simulating what execute_with_hooks does)
         let repo_info = crate::git::discover_repo(f._repo_dir.path()).unwrap();
-        let (repo, wt) =
-            crate::adopt::resolve_or_adopt("feature", &repo_info, &f.db).unwrap();
+        let (repo, wt) = crate::adopt::resolve_or_adopt("feature", &repo_info, &f.db).unwrap();
 
         // Call execute_resolved with the pre-resolved data
         let result = execute_resolved(&repo, &wt, &repo_info, &f.db, Strategy::Rebase)
@@ -1530,8 +1562,7 @@ mod tests {
         assert!(outcome.post_sync_error.is_none());
 
         // Verify execution order: pre_sync before post_sync
-        let order = std::fs::read_to_string(&order_file)
-            .expect("order file should exist");
+        let order = std::fs::read_to_string(&order_file).expect("order file should exist");
         let lines: Vec<&str> = order.lines().collect();
         assert_eq!(lines.len(), 2, "should have exactly 2 lines");
         assert_eq!(lines[0], "pre_sync", "pre_sync should run first");
@@ -1539,7 +1570,10 @@ mod tests {
 
         // Verify both hook events logged
         let db_repo = f.db.get_repo_by_path(&f.repo_path_str).unwrap().unwrap();
-        let wt = f.db.find_worktree_by_identifier(db_repo.id, "feature").unwrap().unwrap();
+        let wt =
+            f.db.find_worktree_by_identifier(db_repo.id, "feature")
+                .unwrap()
+                .unwrap();
         let pre_events = f.db.count_events(wt.id, Some("hook:pre_sync")).unwrap();
         let post_events = f.db.count_events(wt.id, Some("hook:post_sync")).unwrap();
         let synced_events = f.db.count_events(wt.id, Some("synced")).unwrap();
@@ -1549,9 +1583,17 @@ mod tests {
 
         // Verify event ordering in DB: hook:pre_sync < synced < hook:post_sync
         let events = f.db.list_events(wt.id, 10).unwrap();
-        let pre_id = events.iter().find(|e| e.event_type == "hook:pre_sync").unwrap().id;
+        let pre_id = events
+            .iter()
+            .find(|e| e.event_type == "hook:pre_sync")
+            .unwrap()
+            .id;
         let synced_id = events.iter().find(|e| e.event_type == "synced").unwrap().id;
-        let post_id = events.iter().find(|e| e.event_type == "hook:post_sync").unwrap().id;
+        let post_id = events
+            .iter()
+            .find(|e| e.event_type == "hook:post_sync")
+            .unwrap()
+            .id;
         assert!(
             pre_id < synced_id,
             "pre_sync event (id={pre_id}) should come before synced event (id={synced_id})"
@@ -1609,7 +1651,9 @@ mod tests {
                     .unwrap();
                 let mut opts = git2::WorktreeAddOptions::new();
                 opts.reference(Some(branch_ref.get()));
-                git_repo.worktree(branch_name, &wt_path, Some(&opts)).unwrap();
+                git_repo
+                    .worktree(branch_name, &wt_path, Some(&opts))
+                    .unwrap();
             }
 
             // Add a commit on the feature branch
@@ -1687,12 +1731,20 @@ mod tests {
                 entry.error
             );
             let result = entry.result.as_ref().unwrap();
-            assert_eq!(result.after_behind, 0, "'{}' should be 0 behind after sync", entry.name);
+            assert_eq!(
+                result.after_behind, 0,
+                "'{}' should be 0 behind after sync",
+                entry.name
+            );
         }
 
         // Verify upstream.txt exists in both worktrees
         for wt_path in &f.wt_paths {
-            assert!(wt_path.join("upstream.txt").exists(), "upstream.txt should exist in {}", wt_path.display());
+            assert!(
+                wt_path.join("upstream.txt").exists(),
+                "upstream.txt should exist in {}",
+                wt_path.display()
+            );
         }
     }
 
@@ -1717,7 +1769,10 @@ mod tests {
 
         // feat-a should fail (dirty)
         let feat_a = results.iter().find(|r| r.name == "feat-a").unwrap();
-        assert!(feat_a.error.is_some(), "feat-a should have an error (dirty worktree)");
+        assert!(
+            feat_a.error.is_some(),
+            "feat-a should have an error (dirty worktree)"
+        );
         assert!(feat_a.result.is_none());
 
         // feat-b should succeed despite feat-a failure
@@ -1792,7 +1847,12 @@ mod tests {
         for wt_path in &f.wt_paths {
             let wt_repo = git2::Repository::open(wt_path).unwrap();
             let head = wt_repo.head().unwrap().peel_to_commit().unwrap();
-            assert_eq!(head.parent_count(), 2, "merge commit should have 2 parents in {}", wt_path.display());
+            assert_eq!(
+                head.parent_count(),
+                2,
+                "merge commit should have 2 parents in {}",
+                wt_path.display()
+            );
         }
     }
 
@@ -1839,7 +1899,10 @@ mod tests {
         };
 
         let results = execute_all(&[], &repo, &repo_info, &db, Strategy::Rebase);
-        assert!(results.is_empty(), "empty input should produce empty output");
+        assert!(
+            results.is_empty(),
+            "empty input should produce empty output"
+        );
     }
 
     #[test]
@@ -1925,7 +1988,7 @@ mod tests {
         let plan = execute_dry_run(
             "feature",
             f._repo_dir.path(),
-            &f.db,
+            Some(&f.db),
             Strategy::Rebase,
             None,
             false,
@@ -1945,11 +2008,10 @@ mod tests {
 
         // Capture state before dry-run
         let db_repo = f.db.get_repo_by_path(&f.repo_path_str).unwrap().unwrap();
-        let wt = f
-            .db
-            .find_worktree_by_identifier(db_repo.id, "feature")
-            .unwrap()
-            .unwrap();
+        let wt =
+            f.db.find_worktree_by_identifier(db_repo.id, "feature")
+                .unwrap()
+                .unwrap();
         let events_before = f.db.list_events(wt.id, 100).unwrap();
         let wt_repo = git2::Repository::open(&f.wt_path).unwrap();
         let head_before = wt_repo.head().unwrap().target().unwrap();
@@ -1958,7 +2020,7 @@ mod tests {
         execute_dry_run(
             "feature",
             f._repo_dir.path(),
-            &f.db,
+            Some(&f.db),
             Strategy::Rebase,
             None,
             false,
@@ -1975,10 +2037,7 @@ mod tests {
 
         // Verify git HEAD unchanged
         let head_after = wt_repo.head().unwrap().target().unwrap();
-        assert_eq!(
-            head_before, head_after,
-            "dry-run must not change git HEAD"
-        );
+        assert_eq!(head_before, head_after, "dry-run must not change git HEAD");
     }
 
     #[test]
@@ -1999,7 +2058,10 @@ mod tests {
         assert_eq!(json_val["branch"], "my-feature");
         assert_eq!(json_val["base_branch"], "main");
         assert_eq!(json_val["strategy"], "rebase");
-        assert!(json_val["hooks"].is_null(), "hooks should be null when None");
+        assert!(
+            json_val["hooks"].is_null(),
+            "hooks should be null when None"
+        );
     }
 
     #[test]
@@ -2015,7 +2077,10 @@ mod tests {
 
         let output = format!("{plan}");
         assert!(output.contains("Dry run"), "should mention dry run");
-        assert!(output.contains("my-feature"), "should contain worktree name");
+        assert!(
+            output.contains("my-feature"),
+            "should contain worktree name"
+        );
         assert!(output.contains("main"), "should contain base branch");
         assert!(output.contains("rebase"), "should contain strategy");
         assert!(output.contains("(none)"), "should show (none) for hooks");
@@ -2046,7 +2111,7 @@ mod tests {
         let plan = execute_dry_run(
             "feature",
             f._repo_dir.path(),
-            &f.db,
+            Some(&f.db),
             Strategy::Merge,
             Some(&hooks),
             false,
@@ -2056,11 +2121,11 @@ mod tests {
         assert!(plan.hooks.is_some(), "hooks should be present in plan");
         let plan_hooks = plan.hooks.unwrap();
         assert!(plan_hooks.pre_sync.is_some(), "pre_sync should be present");
-        assert!(plan_hooks.post_sync.is_some(), "post_sync should be present");
-        assert_eq!(
-            plan_hooks.pre_sync.unwrap().run.unwrap(),
-            vec!["echo pre"],
+        assert!(
+            plan_hooks.post_sync.is_some(),
+            "post_sync should be present"
         );
+        assert_eq!(plan_hooks.pre_sync.unwrap().run.unwrap(), vec!["echo pre"],);
     }
 
     #[test]
@@ -2082,7 +2147,7 @@ mod tests {
         let plan = execute_dry_run(
             "feature",
             f._repo_dir.path(),
-            &f.db,
+            Some(&f.db),
             Strategy::Rebase,
             Some(&hooks),
             true, // no_hooks = true

--- a/src/cli/commands/sync.rs
+++ b/src/cli/commands/sync.rs
@@ -273,6 +273,67 @@ pub fn execute_resolved(
     })
 }
 
+/// Plan produced by `--dry-run` showing what `trench sync` would do.
+#[derive(Debug, Serialize)]
+pub struct SyncDryRunPlan {
+    /// Always `true` — signals this is a preview, not a real operation.
+    pub dry_run: bool,
+    pub name: String,
+    pub branch: String,
+    pub base_branch: String,
+    pub strategy: String,
+    pub hooks: Option<SyncDryRunHooks>,
+}
+
+/// Hook definitions included in a dry-run plan.
+#[derive(Debug, Serialize)]
+pub struct SyncDryRunHooks {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pre_sync: Option<crate::config::HookDef>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub post_sync: Option<crate::config::HookDef>,
+}
+
+/// Execute a dry-run of `trench sync <identifier>`.
+///
+/// Resolves the worktree and builds a plan, but performs no git operations,
+/// no DB writes, and no hook execution.
+pub fn execute_dry_run(
+    identifier: &str,
+    cwd: &Path,
+    db: &Database,
+    strategy: Strategy,
+    hooks_config: Option<&HooksConfig>,
+    no_hooks: bool,
+) -> Result<SyncDryRunPlan> {
+    let repo_info = crate::git::discover_repo(cwd)?;
+    let (repo, wt) = crate::adopt::resolve_or_adopt(identifier, &repo_info, db)?;
+
+    let base_branch = wt
+        .base_branch
+        .as_deref()
+        .or(repo.default_base.as_deref())
+        .unwrap_or(repo_info.default_branch.as_str());
+
+    let hooks = if no_hooks {
+        None
+    } else {
+        hooks_config.map(|h| SyncDryRunHooks {
+            pre_sync: h.pre_sync.clone(),
+            post_sync: h.post_sync.clone(),
+        })
+    };
+
+    Ok(SyncDryRunPlan {
+        dry_run: true,
+        name: wt.name.clone(),
+        branch: wt.branch.clone(),
+        base_branch: base_branch.to_string(),
+        strategy: strategy.to_string(),
+        hooks,
+    })
+}
+
 /// Execute `trench sync <identifier>` with lifecycle hooks.
 ///
 /// Orchestrates: pre_sync hook → sync → post_sync hook.
@@ -1766,5 +1827,28 @@ mod tests {
             msg.contains("--strategy rebase") && msg.contains("--strategy merge"),
             "error should mention both strategies, got: {msg}"
         );
+    }
+
+    // ── dry-run tests ──────────────────────────────────────────────────
+
+    #[test]
+    fn dry_run_returns_plan_with_correct_fields() {
+        let f = setup_diverged_repo();
+
+        let plan = execute_dry_run(
+            "feature",
+            f._repo_dir.path(),
+            &f.db,
+            Strategy::Rebase,
+            None,
+            false,
+        )
+        .expect("dry-run should succeed");
+
+        assert!(plan.dry_run, "plan should have dry_run=true");
+        assert_eq!(plan.name, "feature");
+        assert_eq!(plan.branch, "feature");
+        assert_eq!(plan.base_branch, "main");
+        assert_eq!(plan.strategy, "rebase");
     }
 }

--- a/src/cli/commands/sync.rs
+++ b/src/cli/commands/sync.rs
@@ -2021,4 +2021,36 @@ mod tests {
             vec!["echo pre"],
         );
     }
+
+    #[test]
+    fn dry_run_with_no_hooks_excludes_hooks_from_plan() {
+        use crate::config::{HookDef, HooksConfig};
+
+        let f = setup_diverged_repo();
+
+        let hooks = HooksConfig {
+            pre_sync: Some(HookDef {
+                copy: None,
+                run: Some(vec!["echo pre".to_string()]),
+                shell: None,
+                timeout_secs: None,
+            }),
+            ..Default::default()
+        };
+
+        let plan = execute_dry_run(
+            "feature",
+            f._repo_dir.path(),
+            &f.db,
+            Strategy::Rebase,
+            Some(&hooks),
+            true, // no_hooks = true
+        )
+        .expect("dry-run with --no-hooks should succeed");
+
+        assert!(
+            plan.hooks.is_none(),
+            "hooks should be None when --no-hooks is set"
+        );
+    }
 }

--- a/src/cli/commands/sync.rs
+++ b/src/cli/commands/sync.rs
@@ -1893,4 +1893,25 @@ mod tests {
             "dry-run must not change git HEAD"
         );
     }
+
+    #[test]
+    fn dry_run_plan_serializes_to_json_with_expected_structure() {
+        let plan = SyncDryRunPlan {
+            dry_run: true,
+            name: "my-feature".to_string(),
+            branch: "my-feature".to_string(),
+            base_branch: "main".to_string(),
+            strategy: "rebase".to_string(),
+            hooks: None,
+        };
+
+        let json_val: serde_json::Value = serde_json::to_value(&plan).unwrap();
+
+        assert_eq!(json_val["dry_run"], true);
+        assert_eq!(json_val["name"], "my-feature");
+        assert_eq!(json_val["branch"], "my-feature");
+        assert_eq!(json_val["base_branch"], "main");
+        assert_eq!(json_val["strategy"], "rebase");
+        assert!(json_val["hooks"].is_null(), "hooks should be null when None");
+    }
 }

--- a/src/cli/commands/sync.rs
+++ b/src/cli/commands/sync.rs
@@ -1979,4 +1979,46 @@ mod tests {
         assert!(output.contains("rebase"), "should contain strategy");
         assert!(output.contains("(none)"), "should show (none) for hooks");
     }
+
+    #[test]
+    fn dry_run_with_hooks_includes_hooks_in_plan() {
+        use crate::config::{HookDef, HooksConfig};
+
+        let f = setup_diverged_repo();
+
+        let hooks = HooksConfig {
+            pre_sync: Some(HookDef {
+                copy: None,
+                run: Some(vec!["echo pre".to_string()]),
+                shell: None,
+                timeout_secs: None,
+            }),
+            post_sync: Some(HookDef {
+                copy: None,
+                run: Some(vec!["echo post".to_string()]),
+                shell: None,
+                timeout_secs: None,
+            }),
+            ..Default::default()
+        };
+
+        let plan = execute_dry_run(
+            "feature",
+            f._repo_dir.path(),
+            &f.db,
+            Strategy::Merge,
+            Some(&hooks),
+            false,
+        )
+        .expect("dry-run with hooks should succeed");
+
+        assert!(plan.hooks.is_some(), "hooks should be present in plan");
+        let plan_hooks = plan.hooks.unwrap();
+        assert!(plan_hooks.pre_sync.is_some(), "pre_sync should be present");
+        assert!(plan_hooks.post_sync.is_some(), "post_sync should be present");
+        assert_eq!(
+            plan_hooks.pre_sync.unwrap().run.unwrap(),
+            vec!["echo pre"],
+        );
+    }
 }

--- a/src/cli/commands/sync.rs
+++ b/src/cli/commands/sync.rs
@@ -287,7 +287,7 @@ pub struct SyncDryRunPlan {
 }
 
 /// Hook definitions included in a dry-run plan.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Clone, Serialize)]
 pub struct SyncDryRunHooks {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pre_sync: Option<crate::config::HookDef>,
@@ -378,6 +378,47 @@ pub fn execute_dry_run(
         strategy: strategy.to_string(),
         hooks,
     })
+}
+
+/// Execute a dry-run of `trench sync --all`.
+///
+/// Builds a plan for each worktree without performing any operations.
+pub fn execute_all_dry_run(
+    worktrees: &[Worktree],
+    repo: &crate::state::Repo,
+    repo_info: &RepoInfo,
+    strategy: Strategy,
+    hooks_config: Option<&HooksConfig>,
+    no_hooks: bool,
+) -> Vec<SyncDryRunPlan> {
+    let hooks = if no_hooks {
+        None
+    } else {
+        hooks_config.map(|h| SyncDryRunHooks {
+            pre_sync: h.pre_sync.clone(),
+            post_sync: h.post_sync.clone(),
+        })
+    };
+
+    worktrees
+        .iter()
+        .map(|wt| {
+            let base_branch = wt
+                .base_branch
+                .as_deref()
+                .or(repo.default_base.as_deref())
+                .unwrap_or(repo_info.default_branch.as_str());
+
+            SyncDryRunPlan {
+                dry_run: true,
+                name: wt.name.clone(),
+                branch: wt.branch.clone(),
+                base_branch: base_branch.to_string(),
+                strategy: strategy.to_string(),
+                hooks: hooks.clone(),
+            }
+        })
+        .collect()
 }
 
 /// Execute `trench sync <identifier>` with lifecycle hooks.
@@ -2052,5 +2093,37 @@ mod tests {
             plan.hooks.is_none(),
             "hooks should be None when --no-hooks is set"
         );
+    }
+
+    #[test]
+    fn batch_dry_run_returns_plan_per_worktree() {
+        let f = setup_multi_worktree_repo();
+        let db_repo = f.db.get_repo_by_path(&f.repo_path_str).unwrap().unwrap();
+        let repo_info = crate::git::RepoInfo {
+            name: "test-repo".to_string(),
+            path: std::path::PathBuf::from(&f.repo_path_str),
+            remote_url: None,
+            default_branch: "main".to_string(),
+        };
+        let worktrees = f.db.list_worktrees(db_repo.id).unwrap();
+
+        let plans = execute_all_dry_run(
+            &worktrees,
+            &db_repo,
+            &repo_info,
+            Strategy::Rebase,
+            None,
+            false,
+        );
+
+        assert_eq!(plans.len(), 2, "should return a plan for each worktree");
+        let names: Vec<&str> = plans.iter().map(|p| p.name.as_str()).collect();
+        assert!(names.contains(&"feat-a"), "should include feat-a");
+        assert!(names.contains(&"feat-b"), "should include feat-b");
+        for plan in &plans {
+            assert!(plan.dry_run);
+            assert_eq!(plan.strategy, "rebase");
+            assert_eq!(plan.base_branch, "main");
+        }
     }
 }

--- a/src/cli/commands/sync.rs
+++ b/src/cli/commands/sync.rs
@@ -2161,6 +2161,65 @@ mod tests {
     }
 
     #[test]
+    fn dry_run_with_unmanaged_worktree_does_not_create_db_rows() {
+        let repo_dir = tempfile::tempdir().unwrap();
+        let git_repo = init_repo_with_commit(repo_dir.path());
+        let db = Database::open_in_memory().unwrap();
+
+        // Rename HEAD to "main"
+        {
+            let head_branch_name = git_repo.head().unwrap().shorthand().unwrap().to_string();
+            git_repo
+                .find_branch(&head_branch_name, git2::BranchType::Local)
+                .unwrap()
+                .rename("main", true)
+                .unwrap();
+        }
+
+        // Create a git worktree manually (NOT registered in DB at all)
+        let wt_dir = tempfile::tempdir().unwrap();
+        let wt_path = wt_dir.path().join("dry-feat");
+        {
+            let head_commit = git_repo.head().unwrap().peel_to_commit().unwrap();
+            git_repo.branch("dry-feat", &head_commit, false).unwrap();
+        }
+        {
+            let branch_ref = git_repo
+                .find_branch("dry-feat", git2::BranchType::Local)
+                .unwrap();
+            let mut opts = git2::WorktreeAddOptions::new();
+            opts.reference(Some(branch_ref.get()));
+            git_repo
+                .worktree("dry-feat", &wt_path, Some(&opts))
+                .unwrap();
+        }
+
+        // execute_dry_run with db=None (simulating deferred DB opening)
+        let plan = execute_dry_run(
+            "dry-feat",
+            repo_dir.path(),
+            None,
+            Strategy::Rebase,
+            None,
+            false,
+        )
+        .expect("dry-run should succeed without DB");
+
+        assert!(plan.dry_run);
+        assert_eq!(plan.name, "dry-feat");
+        assert_eq!(plan.branch, "dry-feat");
+        assert_eq!(plan.base_branch, "main");
+
+        // DB must have no repo or worktree rows
+        let repo_path = repo_dir.path().canonicalize().unwrap();
+        let found_repo = db.get_repo_by_path(repo_path.to_str().unwrap()).unwrap();
+        assert!(
+            found_repo.is_none(),
+            "dry-run must not create repo rows in DB"
+        );
+    }
+
+    #[test]
     fn batch_dry_run_returns_plan_per_worktree() {
         let f = setup_multi_worktree_repo();
         let db_repo = f.db.get_repo_by_path(&f.repo_path_str).unwrap().unwrap();

--- a/src/cli/commands/sync.rs
+++ b/src/cli/commands/sync.rs
@@ -1851,4 +1851,46 @@ mod tests {
         assert_eq!(plan.base_branch, "main");
         assert_eq!(plan.strategy, "rebase");
     }
+
+    #[test]
+    fn dry_run_does_not_write_events_or_modify_git() {
+        let f = setup_diverged_repo();
+
+        // Capture state before dry-run
+        let db_repo = f.db.get_repo_by_path(&f.repo_path_str).unwrap().unwrap();
+        let wt = f
+            .db
+            .find_worktree_by_identifier(db_repo.id, "feature")
+            .unwrap()
+            .unwrap();
+        let events_before = f.db.list_events(wt.id, 100).unwrap();
+        let wt_repo = git2::Repository::open(&f.wt_path).unwrap();
+        let head_before = wt_repo.head().unwrap().target().unwrap();
+
+        // Execute dry-run
+        execute_dry_run(
+            "feature",
+            f._repo_dir.path(),
+            &f.db,
+            Strategy::Rebase,
+            None,
+            false,
+        )
+        .expect("dry-run should succeed");
+
+        // Verify no new events
+        let events_after = f.db.list_events(wt.id, 100).unwrap();
+        assert_eq!(
+            events_before.len(),
+            events_after.len(),
+            "dry-run must not write events to DB"
+        );
+
+        // Verify git HEAD unchanged
+        let head_after = wt_repo.head().unwrap().target().unwrap();
+        assert_eq!(
+            head_before, head_after,
+            "dry-run must not change git HEAD"
+        );
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -636,14 +636,17 @@ fn run_sync(
     no_hooks: bool,
 ) -> anyhow::Result<()> {
     let cwd = std::env::current_dir().context("failed to determine current directory")?;
-    let db_path = paths::data_dir()?.join("trench.db");
-    let db = state::Database::open(&db_path)?;
 
     // Determine strategy: use CLI flag, or prompt interactively
+    // This runs BEFORE any DB work so dry-run can fail fast.
     let resolved_strategy = match strategy {
         Some(s) => s,
         None => {
-            if dry_run || !std::io::stdin().is_terminal() {
+            if dry_run {
+                eprintln!("error: --strategy is required with --dry-run (use --strategy rebase or --strategy merge)");
+                std::process::exit(8);
+            }
+            if !std::io::stdin().is_terminal() {
                 eprintln!("error: --strategy is required in non-interactive mode (use --strategy rebase or --strategy merge)");
                 std::process::exit(8);
             }
@@ -678,12 +681,12 @@ fn run_sync(
         config::resolve_config(None, project_config.as_ref(), &global_config).hooks
     };
 
-    // Dry-run: show plan and exit
+    // Dry-run: show plan and exit — NO Database::open() needed
     if dry_run {
         let plan = cli::commands::sync::execute_dry_run(
             identifier,
             &cwd,
-            Some(&db),
+            None,
             sync_strategy,
             hooks_config.as_ref(),
             no_hooks,
@@ -695,6 +698,10 @@ fn run_sync(
         }
         return Ok(());
     }
+
+    // Real execution path — open DB here (after dry-run early-return)
+    let db_path = paths::data_dir()?.join("trench.db");
+    let db = state::Database::open(&db_path)?;
 
     let rt = tokio::runtime::Runtime::new().context("failed to create async runtime")?;
 
@@ -765,7 +772,18 @@ fn run_sync_all(
     no_hooks: bool,
 ) -> anyhow::Result<()> {
     let cwd = std::env::current_dir().context("failed to determine current directory")?;
-    let db_path = paths::data_dir()?.join("trench.db");
+    let db_path = paths::data_dir_path()?.join("trench.db");
+
+    // If dry-run and DB doesn't exist yet, there are no tracked worktrees
+    if dry_run && !db_path.exists() {
+        if json {
+            println!("[]");
+        } else {
+            eprintln!("No active worktrees to sync.");
+        }
+        return Ok(());
+    }
+
     let db = state::Database::open(&db_path)?;
     let repo_info = git::discover_repo(&cwd)?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -681,12 +681,18 @@ fn run_sync(
         config::resolve_config(None, project_config.as_ref(), &global_config).hooks
     };
 
-    // Dry-run: show plan and exit — NO Database::open() needed
+    // Dry-run: open existing DB (read-only) for accurate base-branch metadata
     if dry_run {
+        let db_path = paths::data_dir_path()?.join("trench.db");
+        let db = if db_path.exists() {
+            Some(state::Database::open(&db_path)?)
+        } else {
+            None
+        };
         let plan = cli::commands::sync::execute_dry_run(
             identifier,
             &cwd,
-            None,
+            db.as_ref(),
             sync_strategy,
             hooks_config.as_ref(),
             no_hooks,

--- a/src/main.rs
+++ b/src/main.rs
@@ -255,13 +255,13 @@ fn main() -> anyhow::Result<()> {
                     eprintln!("error: {}", cli::commands::sync::BatchSyncMissingStrategy);
                     std::process::exit(8);
                 }
-                run_sync_all(strategy.unwrap(), json, no_hooks)
+                run_sync_all(strategy.unwrap(), json, dry_run, no_hooks)
             } else {
                 let branch = branch.unwrap_or_else(|| {
                     eprintln!("error: <BRANCH> is required when --all is not set");
                     std::process::exit(1);
                 });
-                run_sync(&branch, strategy, json, no_hooks)
+                run_sync(&branch, strategy, json, dry_run, no_hooks)
             }
         }
         Some(Commands::Log) => {
@@ -611,7 +611,7 @@ fn run_status(
     }
 }
 
-fn run_sync(identifier: &str, strategy: Option<SyncStrategy>, json: bool, no_hooks: bool) -> anyhow::Result<()> {
+fn run_sync(identifier: &str, strategy: Option<SyncStrategy>, json: bool, dry_run: bool, no_hooks: bool) -> anyhow::Result<()> {
     let cwd = std::env::current_dir().context("failed to determine current directory")?;
     let db_path = paths::data_dir()?.join("trench.db");
     let db = state::Database::open(&db_path)?;
@@ -620,7 +620,7 @@ fn run_sync(identifier: &str, strategy: Option<SyncStrategy>, json: bool, no_hoo
     let resolved_strategy = match strategy {
         Some(s) => s,
         None => {
-            if !std::io::stdin().is_terminal() {
+            if dry_run || !std::io::stdin().is_terminal() {
                 eprintln!("error: --strategy is required in non-interactive mode (use --strategy rebase or --strategy merge)");
                 std::process::exit(8);
             }
@@ -645,7 +645,7 @@ fn run_sync(identifier: &str, strategy: Option<SyncStrategy>, json: bool, no_hoo
         SyncStrategy::Merge => cli::commands::sync::Strategy::Merge,
     };
 
-    // Skip config I/O when --no-hooks is set (escape hatch)
+    // Load hooks config (needed for both dry-run preview and actual execution)
     let hooks_config = if no_hooks {
         None
     } else {
@@ -654,6 +654,24 @@ fn run_sync(identifier: &str, strategy: Option<SyncStrategy>, json: bool, no_hoo
         let global_config = config::load_global_config()?;
         config::resolve_config(None, project_config.as_ref(), &global_config).hooks
     };
+
+    // Dry-run: show plan and exit
+    if dry_run {
+        let plan = cli::commands::sync::execute_dry_run(
+            identifier,
+            &cwd,
+            &db,
+            sync_strategy,
+            hooks_config.as_ref(),
+            no_hooks,
+        )?;
+        if json {
+            println!("{}", serde_json::to_string_pretty(&plan)?);
+        } else {
+            print!("{plan}");
+        }
+        return Ok(());
+    }
 
     let rt = tokio::runtime::Runtime::new().context("failed to create async runtime")?;
 
@@ -713,7 +731,7 @@ fn run_sync(identifier: &str, strategy: Option<SyncStrategy>, json: bool, no_hoo
     }
 }
 
-fn run_sync_all(strategy: SyncStrategy, json: bool, no_hooks: bool) -> anyhow::Result<()> {
+fn run_sync_all(strategy: SyncStrategy, json: bool, dry_run: bool, no_hooks: bool) -> anyhow::Result<()> {
     let cwd = std::env::current_dir().context("failed to determine current directory")?;
     let db_path = paths::data_dir()?.join("trench.db");
     let db = state::Database::open(&db_path)?;
@@ -739,7 +757,7 @@ fn run_sync_all(strategy: SyncStrategy, json: bool, no_hooks: bool) -> anyhow::R
         SyncStrategy::Merge => cli::commands::sync::Strategy::Merge,
     };
 
-    // If hooks are enabled, load config once for all worktrees
+    // Load hooks config (needed for both dry-run preview and actual execution)
     let hooks_config = if no_hooks {
         None
     } else {
@@ -747,6 +765,26 @@ fn run_sync_all(strategy: SyncStrategy, json: bool, no_hooks: bool) -> anyhow::R
         let global_config = config::load_global_config()?;
         config::resolve_config(None, project_config.as_ref(), &global_config).hooks
     };
+
+    // Dry-run: show per-worktree plans and exit
+    if dry_run {
+        let plans = cli::commands::sync::execute_all_dry_run(
+            &worktrees,
+            &db_repo,
+            &repo_info,
+            sync_strategy,
+            hooks_config.as_ref(),
+            no_hooks,
+        );
+        if json {
+            println!("{}", serde_json::to_string_pretty(&plans)?);
+        } else {
+            for plan in &plans {
+                print!("{plan}");
+            }
+        }
+        return Ok(());
+    }
 
     let has_hooks = !no_hooks
         && hooks_config

--- a/src/main.rs
+++ b/src/main.rs
@@ -245,7 +245,12 @@ fn main() -> anyhow::Result<()> {
             cli::commands::completions::generate::<Cli>(shell, &mut std::io::stdout());
             Ok(())
         }
-        Some(Commands::Sync { branch, all, strategy, no_hooks }) => {
+        Some(Commands::Sync {
+            branch,
+            all,
+            strategy,
+            no_hooks,
+        }) => {
             if all && branch.is_some() {
                 eprintln!("error: <BRANCH> cannot be used with --all");
                 std::process::exit(1);
@@ -348,7 +353,9 @@ fn run_create(
         }
         Err(e) => {
             // Check for hook failure (pre_create) via typed error
-            if e.downcast_ref::<cli::commands::create::CreateError>().is_some() {
+            if e.downcast_ref::<cli::commands::create::CreateError>()
+                .is_some()
+            {
                 eprintln!("error: {e:#}");
                 std::process::exit(4);
             }
@@ -439,7 +446,10 @@ fn run_remove(identifier: &str, force: bool, prune: bool, no_hooks: bool) -> any
             }
 
             if outcome.result.pruned_remote {
-                eprintln!("Removed worktree '{}' and remote branch", outcome.result.name);
+                eprintln!(
+                    "Removed worktree '{}' and remote branch",
+                    outcome.result.name
+                );
             } else {
                 eprintln!("Removed worktree '{}'", outcome.result.name);
             }
@@ -447,7 +457,9 @@ fn run_remove(identifier: &str, force: bool, prune: bool, no_hooks: bool) -> any
         }
         Err(e) => {
             // Check for pre_remove hook failure → exit code 4
-            if e.downcast_ref::<cli::commands::remove::RemoveError>().is_some() {
+            if e.downcast_ref::<cli::commands::remove::RemoveError>()
+                .is_some()
+            {
                 eprintln!("error: {e:#}");
                 std::process::exit(4);
             }
@@ -556,7 +568,12 @@ fn run_list(tag: Option<&str>, json: bool, porcelain: bool) -> anyhow::Result<()
     let project_config = config::load_project_config(&repo_info.path)?;
     let global_config = config::load_global_config()?;
     let resolved = config::resolve_config(None, project_config.as_ref(), &global_config);
-    let scan_paths: Vec<String> = resolved.worktrees.scan.iter().map(|p| paths::expand_tilde(p)).collect();
+    let scan_paths: Vec<String> = resolved
+        .worktrees
+        .scan
+        .iter()
+        .map(|p| paths::expand_tilde(p))
+        .collect();
 
     let output = if json {
         cli::commands::list::execute_json(&cwd, &db, tag, &scan_paths)?
@@ -611,7 +628,13 @@ fn run_status(
     }
 }
 
-fn run_sync(identifier: &str, strategy: Option<SyncStrategy>, json: bool, dry_run: bool, no_hooks: bool) -> anyhow::Result<()> {
+fn run_sync(
+    identifier: &str,
+    strategy: Option<SyncStrategy>,
+    json: bool,
+    dry_run: bool,
+    no_hooks: bool,
+) -> anyhow::Result<()> {
     let cwd = std::env::current_dir().context("failed to determine current directory")?;
     let db_path = paths::data_dir()?.join("trench.db");
     let db = state::Database::open(&db_path)?;
@@ -660,7 +683,7 @@ fn run_sync(identifier: &str, strategy: Option<SyncStrategy>, json: bool, dry_ru
         let plan = cli::commands::sync::execute_dry_run(
             identifier,
             &cwd,
-            &db,
+            Some(&db),
             sync_strategy,
             hooks_config.as_ref(),
             no_hooks,
@@ -690,9 +713,15 @@ fn run_sync(identifier: &str, strategy: Option<SyncStrategy>, json: bool, dry_ru
             }
 
             if json {
-                println!("{}", output::json::format_json_value(&outcome.result.to_json())?);
+                println!(
+                    "{}",
+                    output::json::format_json_value(&outcome.result.to_json())?
+                );
             } else {
-                eprintln!("Synced '{}' via {}", outcome.result.name, outcome.result.strategy);
+                eprintln!(
+                    "Synced '{}' via {}",
+                    outcome.result.name, outcome.result.strategy
+                );
                 eprintln!(
                     "  before: ahead={}, behind={}",
                     outcome.result.before_ahead, outcome.result.before_behind
@@ -715,9 +744,7 @@ fn run_sync(identifier: &str, strategy: Option<SyncStrategy>, json: bool, dry_ru
                 eprintln!("error: {e:#}");
                 std::process::exit(4);
             }
-            if let Some(git::GitError::MergeConflict { .. }) =
-                e.downcast_ref::<git::GitError>()
-            {
+            if let Some(git::GitError::MergeConflict { .. }) = e.downcast_ref::<git::GitError>() {
                 eprintln!("error: {e}");
                 std::process::exit(5);
             }
@@ -731,7 +758,12 @@ fn run_sync(identifier: &str, strategy: Option<SyncStrategy>, json: bool, dry_ru
     }
 }
 
-fn run_sync_all(strategy: SyncStrategy, json: bool, dry_run: bool, no_hooks: bool) -> anyhow::Result<()> {
+fn run_sync_all(
+    strategy: SyncStrategy,
+    json: bool,
+    dry_run: bool,
+    no_hooks: bool,
+) -> anyhow::Result<()> {
     let cwd = std::env::current_dir().context("failed to determine current directory")?;
     let db_path = paths::data_dir()?.join("trench.db");
     let db = state::Database::open(&db_path)?;
@@ -876,7 +908,10 @@ fn run_sync_all(strategy: SyncStrategy, json: bool, dry_run: bool, no_hooks: boo
             .iter()
             .filter(|r| r.status == cli::commands::sync::BatchSyncStatus::Failure)
             .count();
-        eprintln!("\nBatch sync: {success} succeeded, {failed} failed ({} total)", results.len());
+        eprintln!(
+            "\nBatch sync: {success} succeeded, {failed} failed ({} total)",
+            results.len()
+        );
     }
 
     if has_failures {
@@ -1515,7 +1550,9 @@ mod tests {
         let cli = Cli::try_parse_from(["trench", "sync", "foo", "--strategy", "rebase"])
             .expect("sync with --strategy rebase should parse");
         match cli.command {
-            Some(Commands::Sync { branch, strategy, .. }) => {
+            Some(Commands::Sync {
+                branch, strategy, ..
+            }) => {
                 assert_eq!(branch, Some("foo".to_string()));
                 assert_eq!(strategy, Some(SyncStrategy::Rebase));
             }
@@ -1528,7 +1565,9 @@ mod tests {
         let cli = Cli::try_parse_from(["trench", "sync", "foo", "--strategy", "merge"])
             .expect("sync with --strategy merge should parse");
         match cli.command {
-            Some(Commands::Sync { branch, strategy, .. }) => {
+            Some(Commands::Sync {
+                branch, strategy, ..
+            }) => {
                 assert_eq!(branch, Some("foo".to_string()));
                 assert_eq!(strategy, Some(SyncStrategy::Merge));
             }
@@ -1541,7 +1580,9 @@ mod tests {
         let cli = Cli::try_parse_from(["trench", "sync", "foo"])
             .expect("sync without --strategy should parse");
         match cli.command {
-            Some(Commands::Sync { branch, strategy, .. }) => {
+            Some(Commands::Sync {
+                branch, strategy, ..
+            }) => {
                 assert_eq!(branch, Some("foo".to_string()));
                 assert!(strategy.is_none());
             }
@@ -1557,10 +1598,19 @@ mod tests {
 
     #[test]
     fn sync_subcommand_accepts_no_hooks_flag() {
-        let cli = Cli::try_parse_from(["trench", "sync", "foo", "--strategy", "rebase", "--no-hooks"])
-            .expect("sync with --no-hooks should parse");
+        let cli = Cli::try_parse_from([
+            "trench",
+            "sync",
+            "foo",
+            "--strategy",
+            "rebase",
+            "--no-hooks",
+        ])
+        .expect("sync with --no-hooks should parse");
         match cli.command {
-            Some(Commands::Sync { branch, no_hooks, .. }) => {
+            Some(Commands::Sync {
+                branch, no_hooks, ..
+            }) => {
                 assert_eq!(branch, Some("foo".to_string()));
                 assert!(no_hooks, "--no-hooks should be true");
             }
@@ -1585,7 +1635,12 @@ mod tests {
         let cli = Cli::try_parse_from(["trench", "sync", "--all", "--strategy", "rebase"])
             .expect("sync --all --strategy rebase should parse");
         match cli.command {
-            Some(Commands::Sync { branch, all, strategy, .. }) => {
+            Some(Commands::Sync {
+                branch,
+                all,
+                strategy,
+                ..
+            }) => {
                 assert!(branch.is_none(), "branch should be None when --all is used");
                 assert!(all, "--all should be true");
                 assert_eq!(strategy, Some(SyncStrategy::Rebase));
@@ -1599,7 +1654,12 @@ mod tests {
         let cli = Cli::try_parse_from(["trench", "sync", "--all", "--strategy", "merge"])
             .expect("sync --all --strategy merge should parse");
         match cli.command {
-            Some(Commands::Sync { branch, all, strategy, .. }) => {
+            Some(Commands::Sync {
+                branch,
+                all,
+                strategy,
+                ..
+            }) => {
                 assert!(branch.is_none());
                 assert!(all);
                 assert_eq!(strategy, Some(SyncStrategy::Merge));

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -9,7 +9,8 @@ const STATE_DIR_FALLBACK_SEGMENTS: &[&str] = &[".local", "state"];
 
 /// Ensure a directory exists, creating it (and parents) if needed.
 fn ensure_dir(path: &Path) -> Result<()> {
-    std::fs::create_dir_all(path).with_context(|| format!("failed to create directory: {}", path.display()))?;
+    std::fs::create_dir_all(path)
+        .with_context(|| format!("failed to create directory: {}", path.display()))?;
     Ok(())
 }
 
@@ -30,6 +31,16 @@ pub fn config_dir() -> Result<PathBuf> {
     let path = config_dir_path()?;
     ensure_dir(&path)?;
     Ok(path)
+}
+
+/// Return the trench data directory path (`~/.local/share/trench/`) without creating it.
+///
+/// Use this in read-only contexts (e.g. `--dry-run`) where no side effects
+/// are allowed. For contexts that need the directory to exist, use [`data_dir`].
+pub fn data_dir_path() -> Result<PathBuf> {
+    Ok(dirs::data_dir()
+        .context("could not determine data directory")?
+        .join(APP_NAME))
 }
 
 /// Return the trench data directory (`~/.local/share/trench/`), creating it if needed.
@@ -184,12 +195,8 @@ mod tests {
     fn state_dir_ends_with_trench() {
         let path = state_dir().unwrap();
         assert!(path.ends_with("trench"));
-        let expected_base = dirs::state_dir().unwrap_or_else(|| {
-            dirs::home_dir()
-                .unwrap()
-                .join(".local")
-                .join("state")
-        });
+        let expected_base = dirs::state_dir()
+            .unwrap_or_else(|| dirs::home_dir().unwrap().join(".local").join("state"));
         assert!(path.starts_with(expected_base));
         assert!(path.exists());
     }
@@ -221,8 +228,16 @@ mod tests {
     }
 
     #[test]
+    fn data_dir_path_returns_path_without_creating_it() {
+        let path = data_dir_path().unwrap();
+        assert!(path.ends_with("trench"));
+        assert!(path.starts_with(dirs::data_dir().unwrap()));
+    }
+
+    #[test]
     fn render_default_template_with_repo_and_branch() {
-        let path = render_worktree_path(DEFAULT_WORKTREE_TEMPLATE, "my-project", "feature/auth").unwrap();
+        let path =
+            render_worktree_path(DEFAULT_WORKTREE_TEMPLATE, "my-project", "feature/auth").unwrap();
         assert_eq!(path, PathBuf::from("my-project/feature-auth"));
     }
 
@@ -246,7 +261,10 @@ mod tests {
         let result = render_worktree_path("/absolute/{{ repo }}", "trench", "main");
         assert!(result.is_err());
         let msg = result.unwrap_err().to_string();
-        assert!(msg.contains("relative"), "expected 'relative' in error: {msg}");
+        assert!(
+            msg.contains("relative"),
+            "expected 'relative' in error: {msg}"
+        );
     }
 
     #[test]
@@ -316,14 +334,20 @@ mod tests {
         // Empty after stripping
         assert_eq!(sanitize_branch(".."), "");
         // Nested double dots with other chars
-        assert_eq!(sanitize_branch("feature/..secret/auth"), "feature-secret-auth");
+        assert_eq!(
+            sanitize_branch("feature/..secret/auth"),
+            "feature-secret-auth"
+        );
     }
 
     #[test]
     fn expand_tilde_replaces_home_prefix() {
         let expanded = expand_tilde("~/projects");
         let home = dirs::home_dir().unwrap();
-        assert_eq!(expanded, home.join("projects").to_string_lossy().to_string());
+        assert_eq!(
+            expanded,
+            home.join("projects").to_string_lossy().to_string()
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #43

## Summary
Add `--dry-run` support to `trench sync` that shows what would happen (worktree, strategy, hooks) without executing anything. The `--no-hooks` flag was already implemented for actual sync operations; this PR ensures it also correctly excludes hooks from dry-run plans. Both flags work with `--all` batch mode and `--json` output.

## User Stories Addressed
- US-6: Preview sync before executing (dry-run shows plan without syncing)

## Automated Testing
- Total tests added: 7
- Tests passing: 7
- Tests failing: 0
- `cargo clippy`: pass (31 pre-existing warnings, 0 new)
- `cargo test`: 498 pass, 2 fail (pre-existing git::tests failures unrelated to this PR)

## UAT Checklist
- [ ] `trench sync my-feature --strategy rebase --dry-run` → shows plan with worktree name, branch, base, strategy, hooks
- [ ] `trench sync my-feature --strategy merge --dry-run --json` → outputs valid JSON with `dry_run: true`
- [ ] `trench sync --all --strategy rebase --dry-run` → shows per-worktree plans for all active worktrees
- [ ] `trench sync --all --strategy rebase --dry-run --json` → outputs JSON array of plans
- [ ] `trench sync my-feature --strategy rebase --dry-run --no-hooks` → plan shows no hooks even if hooks are configured
- [ ] `trench sync my-feature --no-hooks --strategy rebase` → syncs successfully without running hooks
- [ ] After dry-run: verify `trench log` shows no new events (no side effects)
- [ ] `trench sync my-feature --dry-run` (no --strategy) → exits with code 8 and hint message

## Known Issues
None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dry-run mode for sync: preview planned actions without performing git, DB, or hook side effects (single and batch), with JSON or plain-text output.
  * Per-worktree dry-run previews to inspect plans for each worktree.
  * Read-only helpers for resolving worktrees and retrieving the data directory path without creating or modifying state.

* **Tests**
  * Expanded coverage for dry-run plans, output formatting, hook inclusion/exclusion, and read-only resolution behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->