### PR TITLE
feat(cli): enforce exit codes 0-8 consistently across all commands

### DIFF
--- a/src/exit_code.rs
+++ b/src/exit_code.rs
@@ -1,0 +1,119 @@
+/// Typed exit codes for the trench CLI (FR-37).
+///
+/// Every process exit must use one of these variants instead of raw integers.
+/// This ensures consistent, documented exit codes across all commands.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExitCode {
+    /// 0 — Success
+    Success,
+    /// 1 — General error
+    GeneralError,
+    /// 2 — Not found
+    NotFound,
+    /// 3 — Branch exists
+    BranchExists,
+    /// 4 — Hook failed
+    HookFailed,
+    /// 5 — Git error
+    GitError,
+    /// 6 — Config error
+    ConfigError,
+    /// 7 — Hook timeout
+    HookTimeout,
+    /// 8 — Missing required flag
+    MissingRequiredFlag,
+}
+
+impl ExitCode {
+    /// Return the numeric exit code for this variant.
+    pub fn code(self) -> i32 {
+        match self {
+            Self::Success => 0,
+            Self::GeneralError => 1,
+            Self::NotFound => 2,
+            Self::BranchExists => 3,
+            Self::HookFailed => 4,
+            Self::GitError => 5,
+            Self::ConfigError => 6,
+            Self::HookTimeout => 7,
+            Self::MissingRequiredFlag => 8,
+        }
+    }
+
+    /// Terminate the process with this exit code.
+    pub fn exit(self) -> ! {
+        std::process::exit(self.code())
+    }
+}
+
+impl std::fmt::Display for ExitCode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let desc = match self {
+            Self::Success => "success",
+            Self::GeneralError => "general error",
+            Self::NotFound => "not found",
+            Self::BranchExists => "branch exists",
+            Self::HookFailed => "hook failed",
+            Self::GitError => "git error",
+            Self::ConfigError => "config error",
+            Self::HookTimeout => "hook timeout",
+            Self::MissingRequiredFlag => "missing required flag",
+        };
+        write!(f, "{} ({desc})", self.code())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn all_variants_map_to_documented_exit_codes() {
+        assert_eq!(ExitCode::Success.code(), 0);
+        assert_eq!(ExitCode::GeneralError.code(), 1);
+        assert_eq!(ExitCode::NotFound.code(), 2);
+        assert_eq!(ExitCode::BranchExists.code(), 3);
+        assert_eq!(ExitCode::HookFailed.code(), 4);
+        assert_eq!(ExitCode::GitError.code(), 5);
+        assert_eq!(ExitCode::ConfigError.code(), 6);
+        assert_eq!(ExitCode::HookTimeout.code(), 7);
+        assert_eq!(ExitCode::MissingRequiredFlag.code(), 8);
+    }
+
+    #[test]
+    fn display_includes_code_and_description() {
+        assert_eq!(format!("{}", ExitCode::Success), "0 (success)");
+        assert_eq!(format!("{}", ExitCode::GeneralError), "1 (general error)");
+        assert_eq!(format!("{}", ExitCode::NotFound), "2 (not found)");
+        assert_eq!(format!("{}", ExitCode::BranchExists), "3 (branch exists)");
+        assert_eq!(format!("{}", ExitCode::HookFailed), "4 (hook failed)");
+        assert_eq!(format!("{}", ExitCode::GitError), "5 (git error)");
+        assert_eq!(format!("{}", ExitCode::ConfigError), "6 (config error)");
+        assert_eq!(format!("{}", ExitCode::HookTimeout), "7 (hook timeout)");
+        assert_eq!(
+            format!("{}", ExitCode::MissingRequiredFlag),
+            "8 (missing required flag)"
+        );
+    }
+
+    #[test]
+    fn enum_has_exactly_nine_variants() {
+        // Verify all 9 codes are distinct
+        let codes: Vec<i32> = vec![
+            ExitCode::Success.code(),
+            ExitCode::GeneralError.code(),
+            ExitCode::NotFound.code(),
+            ExitCode::BranchExists.code(),
+            ExitCode::HookFailed.code(),
+            ExitCode::GitError.code(),
+            ExitCode::ConfigError.code(),
+            ExitCode::HookTimeout.code(),
+            ExitCode::MissingRequiredFlag.code(),
+        ];
+        let mut unique = codes.clone();
+        unique.sort();
+        unique.dedup();
+        assert_eq!(unique.len(), 9);
+        assert_eq!(unique, vec![0, 1, 2, 3, 4, 5, 6, 7, 8]);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,8 @@ use anyhow::Context;
 use clap::{Parser, Subcommand, ValueEnum};
 use std::io::IsTerminal;
 
+use exit_code::ExitCode;
+
 use output::OutputConfig;
 
 #[derive(Parser, Debug)]
@@ -254,18 +256,18 @@ fn main() -> anyhow::Result<()> {
         }) => {
             if all && branch.is_some() {
                 eprintln!("error: <BRANCH> cannot be used with --all");
-                std::process::exit(1);
+                ExitCode::GeneralError.exit();
             }
             if all {
                 if strategy.is_none() {
                     eprintln!("error: {}", cli::commands::sync::BatchSyncMissingStrategy);
-                    std::process::exit(8);
+                    ExitCode::MissingRequiredFlag.exit();
                 }
                 run_sync_all(strategy.unwrap(), json, dry_run, no_hooks)
             } else {
                 let branch = branch.unwrap_or_else(|| {
                     eprintln!("error: <BRANCH> is required when --all is not set");
-                    std::process::exit(1);
+                    ExitCode::GeneralError.exit();
                 });
                 run_sync(&branch, strategy, json, dry_run, no_hooks)
             }
@@ -347,29 +349,42 @@ fn run_create(
             }
 
             // Exit 4 if post_create hook failed (FR-24: hard stop)
-            if outcome.post_create_error.is_some() {
-                std::process::exit(4);
+            if let Some(ref hook_err) = outcome.post_create_error {
+                if hook_err
+                    .chain()
+                    .any(|c| c.downcast_ref::<hooks::runner::HookTimeoutError>().is_some())
+                {
+                    ExitCode::HookTimeout.exit();
+                }
+                ExitCode::HookFailed.exit();
             }
             Ok(())
         }
         Err(e) => {
+            // Check for hook timeout first (more specific than hook failure)
+            if e.chain()
+                .any(|c| c.downcast_ref::<hooks::runner::HookTimeoutError>().is_some())
+            {
+                eprintln!("error: {e:#}");
+                ExitCode::HookTimeout.exit();
+            }
             // Check for hook failure (pre_create) via typed error
             if e.downcast_ref::<cli::commands::create::CreateError>()
                 .is_some()
             {
                 eprintln!("error: {e:#}");
-                std::process::exit(4);
+                ExitCode::HookFailed.exit();
             }
             if let Some(git_err) = e.downcast_ref::<git::GitError>() {
                 match git_err {
                     git::GitError::BranchAlreadyExists { .. }
                     | git::GitError::RemoteBranchAlreadyExists { .. } => {
                         eprintln!("error: {e}");
-                        std::process::exit(3);
+                        ExitCode::BranchExists.exit();
                     }
                     git::GitError::BaseBranchNotFound { .. } => {
                         eprintln!("error: {e}");
-                        std::process::exit(2);
+                        ExitCode::NotFound.exit();
                     }
                     _ => {}
                 }
@@ -457,23 +472,30 @@ fn run_remove(identifier: &str, force: bool, prune: bool, no_hooks: bool) -> any
             Ok(())
         }
         Err(e) => {
+            // Check for hook timeout first (more specific than hook failure)
+            if e.chain()
+                .any(|c| c.downcast_ref::<hooks::runner::HookTimeoutError>().is_some())
+            {
+                eprintln!("error: {e:#}");
+                ExitCode::HookTimeout.exit();
+            }
             // Check for pre_remove hook failure → exit code 4
             if e.downcast_ref::<cli::commands::remove::RemoveError>()
                 .is_some()
             {
                 eprintln!("error: {e:#}");
-                std::process::exit(4);
+                ExitCode::HookFailed.exit();
             }
             if let Some(git_err) = e.downcast_ref::<git::GitError>() {
                 if matches!(git_err, git::GitError::WorktreeNotFound { .. }) {
                     eprintln!("error: {e}");
-                    std::process::exit(2);
+                    ExitCode::NotFound.exit();
                 }
             }
             let msg = e.to_string();
             if msg.contains("not found") || msg.contains("not tracked") {
                 eprintln!("error: {e}");
-                std::process::exit(2);
+                ExitCode::NotFound.exit();
             }
             Err(e)
         }
@@ -498,7 +520,7 @@ fn run_switch(identifier: &str, print_path: bool) -> anyhow::Result<()> {
             let msg = e.to_string();
             if msg.contains("not found") || msg.contains("not tracked") {
                 eprintln!("error: {e}");
-                std::process::exit(2);
+                ExitCode::NotFound.exit();
             }
             Err(e)
         }
@@ -542,7 +564,7 @@ fn run_open(identifier: &str) -> anyhow::Result<()> {
             let msg = e.to_string();
             if msg.contains("not found") || msg.contains("not tracked") {
                 eprintln!("error: {e}");
-                std::process::exit(2);
+                ExitCode::NotFound.exit();
             }
             Err(e)
         }
@@ -622,7 +644,7 @@ fn run_status(
             let msg = e.to_string();
             if msg.contains("not found") {
                 eprintln!("error: {e}");
-                std::process::exit(2);
+                ExitCode::NotFound.exit();
             }
             Err(e)
         }
@@ -645,11 +667,11 @@ fn run_sync(
         None => {
             if dry_run {
                 eprintln!("error: --strategy is required with --dry-run (use --strategy rebase or --strategy merge)");
-                std::process::exit(8);
+                ExitCode::MissingRequiredFlag.exit();
             }
             if !std::io::stdin().is_terminal() {
                 eprintln!("error: --strategy is required in non-interactive mode (use --strategy rebase or --strategy merge)");
-                std::process::exit(8);
+                ExitCode::MissingRequiredFlag.exit();
             }
             eprint!("Sync strategy — (r)ebase or (m)erge? ");
             let mut input = String::new();
@@ -661,7 +683,7 @@ fn run_sync(
                 "m" | "merge" => SyncStrategy::Merge,
                 other => {
                     eprintln!("error: unknown strategy '{other}'. Use 'rebase' or 'merge'.");
-                    std::process::exit(1);
+                    ExitCode::GeneralError.exit();
                 }
             }
         }
@@ -747,25 +769,38 @@ fn run_sync(
             }
 
             // Exit 4 if post_sync hook failed (FR-24: Report — non-zero exit but sync completed)
-            if outcome.post_sync_error.is_some() {
-                std::process::exit(4);
+            if let Some(ref hook_err) = outcome.post_sync_error {
+                if hook_err
+                    .chain()
+                    .any(|c| c.downcast_ref::<hooks::runner::HookTimeoutError>().is_some())
+                {
+                    ExitCode::HookTimeout.exit();
+                }
+                ExitCode::HookFailed.exit();
             }
             Ok(())
         }
         Err(e) => {
+            // Check for hook timeout first (more specific than hook failure)
+            if e.chain()
+                .any(|c| c.downcast_ref::<hooks::runner::HookTimeoutError>().is_some())
+            {
+                eprintln!("error: {e:#}");
+                ExitCode::HookTimeout.exit();
+            }
             // Check for hook failure (pre_sync) via typed error
             if e.downcast_ref::<cli::commands::sync::SyncError>().is_some() {
                 eprintln!("error: {e:#}");
-                std::process::exit(4);
+                ExitCode::HookFailed.exit();
             }
             if let Some(git::GitError::MergeConflict { .. }) = e.downcast_ref::<git::GitError>() {
                 eprintln!("error: {e}");
-                std::process::exit(5);
+                ExitCode::GitError.exit();
             }
             let msg = e.to_string();
             if msg.contains("not found") || msg.contains("not tracked") {
                 eprintln!("error: {e}");
-                std::process::exit(2);
+                ExitCode::NotFound.exit();
             }
             Err(e)
         }
@@ -940,7 +975,7 @@ fn run_sync_all(
     }
 
     if has_failures {
-        std::process::exit(1);
+        ExitCode::GeneralError.exit();
     }
 
     Ok(())
@@ -958,7 +993,7 @@ fn run_init(force: bool) -> anyhow::Result<()> {
         Err(e) => {
             if e.downcast_ref::<cli::commands::init::InitError>().is_some() {
                 eprintln!("error: {e}");
-                std::process::exit(6);
+                ExitCode::ConfigError.exit();
             }
             Err(e)
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -563,7 +563,7 @@ fn run_open(identifier: &str) -> anyhow::Result<()> {
                 .with_context(|| format!("failed to launch editor '{}'", result.editor))?;
 
             if !status.success() {
-                std::process::exit(status.code().unwrap_or(1));
+                ExitCode::GeneralError.exit();
             }
 
             // Record DB side-effects only after a successful launch

--- a/src/main.rs
+++ b/src/main.rs
@@ -217,7 +217,7 @@ fn main() -> anyhow::Result<()> {
     let json = cli.json;
     let porcelain = cli.porcelain;
 
-    match cli.command {
+    let result = match cli.command {
         Some(Commands::Create {
             branch,
             from,
@@ -279,7 +279,18 @@ fn main() -> anyhow::Result<()> {
         None => {
             anyhow::bail!("TUI requires an interactive terminal (stdin and stdout must be a TTY)");
         }
+    };
+
+    // Catch-all: map unhandled typed errors to their exit codes before
+    // they fall through to anyhow's default "Error: ..." formatter.
+    if let Err(ref e) = result {
+        if e.downcast_ref::<git::GitError>().is_some() {
+            eprintln!("Error: {e}");
+            ExitCode::GitError.exit();
+        }
     }
+
+    result
 }
 
 fn run_create(

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 mod adopt;
 mod cli;
 mod config;
+mod exit_code;
 mod git;
 mod hooks;
 mod output;

--- a/tests/exit_codes.rs
+++ b/tests/exit_codes.rs
@@ -187,7 +187,7 @@ fn exit_code_7_hook_timeout() {
         tmp.path().join(".trench.toml"),
         r#"
 [hooks.pre_create]
-run = ["sleep 30"]
+run = ["sleep 5"]
 timeout_secs = 1
 "#,
     )

--- a/tests/exit_codes.rs
+++ b/tests/exit_codes.rs
@@ -1,0 +1,250 @@
+//! Integration tests verifying exit codes (FR-37) for each error scenario.
+//!
+//! Exit code map:
+//!   0: Success
+//!   1: General error
+//!   2: Not found
+//!   3: Branch exists
+//!   4: Hook failed
+//!   5: Git error
+//!   6: Config error
+//!   7: Hook timeout
+//!   8: Missing required flag
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn trench_bin() -> PathBuf {
+    // CARGO_BIN_EXE_<name> is set by cargo for integration tests
+    PathBuf::from(env!("CARGO_BIN_EXE_trench"))
+}
+
+/// Initialize a temporary git repo with an initial commit.
+fn init_git_repo(dir: &std::path::Path) {
+    Command::new("git")
+        .args(["init", "-b", "main"])
+        .current_dir(dir)
+        .output()
+        .expect("git init failed");
+    Command::new("git")
+        .args(["config", "user.email", "test@test.com"])
+        .current_dir(dir)
+        .output()
+        .expect("git config email failed");
+    Command::new("git")
+        .args(["config", "user.name", "Test"])
+        .current_dir(dir)
+        .output()
+        .expect("git config name failed");
+    std::fs::write(dir.join("README.md"), "# test\n").unwrap();
+    Command::new("git")
+        .args(["add", "."])
+        .current_dir(dir)
+        .output()
+        .expect("git add failed");
+    Command::new("git")
+        .args(["commit", "-m", "init"])
+        .current_dir(dir)
+        .output()
+        .expect("git commit failed");
+}
+
+// ── Exit code 8: Missing required flag ─────────────────────────────────
+
+#[test]
+fn exit_code_8_sync_all_without_strategy() {
+    let tmp = tempfile::tempdir().unwrap();
+    init_git_repo(tmp.path());
+
+    let output = Command::new(trench_bin())
+        .args(["sync", "--all"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("failed to run trench");
+
+    assert_eq!(
+        output.status.code(),
+        Some(8),
+        "sync --all without --strategy should exit 8, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+// ── Exit code 6: Config error ──────────────────────────────────────────
+
+#[test]
+fn exit_code_6_init_when_file_exists() {
+    let tmp = tempfile::tempdir().unwrap();
+    init_git_repo(tmp.path());
+
+    // Create .trench.toml first
+    std::fs::write(tmp.path().join(".trench.toml"), "[hooks]\n").unwrap();
+
+    let output = Command::new(trench_bin())
+        .args(["init"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("failed to run trench");
+
+    assert_eq!(
+        output.status.code(),
+        Some(6),
+        "init when .trench.toml exists should exit 6, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+// ── Exit code 2: Not found ────────────────────────────────────────────
+
+#[test]
+fn exit_code_2_switch_nonexistent() {
+    let tmp = tempfile::tempdir().unwrap();
+    init_git_repo(tmp.path());
+
+    let output = Command::new(trench_bin())
+        .args(["switch", "nonexistent-branch-xyz"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("failed to run trench");
+
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "switch nonexistent should exit 2, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+// ── Exit code 3: Branch exists ─────────────────────────────────────────
+
+#[test]
+fn exit_code_3_create_existing_branch() {
+    let tmp = tempfile::tempdir().unwrap();
+    init_git_repo(tmp.path());
+
+    // Create a branch that already exists
+    Command::new("git")
+        .args(["branch", "existing-feature"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("git branch failed");
+
+    let output = Command::new(trench_bin())
+        .args(["create", "existing-feature"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("failed to run trench");
+
+    assert_eq!(
+        output.status.code(),
+        Some(3),
+        "create existing branch should exit 3, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+// ── Exit code 4: Hook failed ──────────────────────────────────────────
+
+#[test]
+fn exit_code_4_pre_create_hook_fails() {
+    let tmp = tempfile::tempdir().unwrap();
+    init_git_repo(tmp.path());
+
+    // Write .trench.toml with a pre_create hook that fails
+    std::fs::write(
+        tmp.path().join(".trench.toml"),
+        r#"
+[hooks.pre_create]
+run = ["false"]
+timeout_secs = 10
+"#,
+    )
+    .unwrap();
+
+    let output = Command::new(trench_bin())
+        .args(["create", "hook-fail-test"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("failed to run trench");
+
+    assert_eq!(
+        output.status.code(),
+        Some(4),
+        "pre_create hook failure should exit 4, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+// ── Exit code 7: Hook timeout ─────────────────────────────────────────
+
+#[test]
+fn exit_code_7_hook_timeout() {
+    let tmp = tempfile::tempdir().unwrap();
+    init_git_repo(tmp.path());
+
+    // Write .trench.toml with a pre_create hook that times out
+    std::fs::write(
+        tmp.path().join(".trench.toml"),
+        r#"
+[hooks.pre_create]
+run = ["sleep 30"]
+timeout_secs = 1
+"#,
+    )
+    .unwrap();
+
+    let output = Command::new(trench_bin())
+        .args(["create", "timeout-test"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("failed to run trench");
+
+    assert_eq!(
+        output.status.code(),
+        Some(7),
+        "hook timeout should exit 7, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+// ── Exit code 5: Git error ────────────────────────────────────────────
+
+#[test]
+fn exit_code_5_git_error_not_a_repo() {
+    let tmp = tempfile::tempdir().unwrap();
+    // Do NOT init git — tmp is not a git repo
+
+    let output = Command::new(trench_bin())
+        .args(["list"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("failed to run trench");
+
+    assert_eq!(
+        output.status.code(),
+        Some(5),
+        "git error (not a repo) should exit 5, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+// ── Exit code 1: General error ─────────────────────────────────────────
+
+#[test]
+fn exit_code_1_sync_branch_with_all_flag() {
+    let tmp = tempfile::tempdir().unwrap();
+    init_git_repo(tmp.path());
+
+    let output = Command::new(trench_bin())
+        .args(["sync", "--all", "some-branch"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("failed to run trench");
+
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "sync with both --all and <BRANCH> should exit 1, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}


### PR DESCRIPTION
Closes #44

## Summary
Adds a typed `ExitCode` enum mapping all 9 documented exit codes (0-8) to named variants (FR-37). Replaces every raw `std::process::exit(N)` call in main.rs with typed exit code usage, adds hook timeout detection (exit 7) before generic hook failure checks (exit 4), and adds a catch-all `GitError` → exit 5 mapping so unhandled git errors don't fall through to the generic error handler.

## User Stories Addressed
- US-4: Documented exit codes for AI agent consumption — all commands now return documented exit codes (0-8)

## Automated Testing
- Total tests added: 11 (3 unit + 8 integration)
- Tests passing: 517 (509 unit + 8 integration)
- Tests failing: 0
- `cargo clippy`: pass (warnings only — all pre-existing)
- `cargo test`: pass

## UAT Checklist
- [ ] Run `trench create my-feature` in a repo → creates worktree, exits 0
- [ ] Run `trench create my-feature` again → fails with exit code 3 (branch exists)
- [ ] Run `trench switch nonexistent-branch` → fails with exit code 2 (not found)
- [ ] Run `trench sync --all` without `--strategy` → fails with exit code 8 (missing required flag)
- [ ] Run `trench init` when `.trench.toml` exists → fails with exit code 6 (config error)
- [ ] Run `trench list` outside a git repo → fails with exit code 5 (git error)
- [ ] Configure a `.trench.toml` with `[hooks.pre_create] run = ["false"]`, then `trench create test` → fails with exit code 4 (hook failed)
- [ ] Configure a `.trench.toml` with `[hooks.pre_create] run = ["sleep 30"]` and `timeout_secs = 1`, then `trench create test` → fails with exit code 7 (hook timeout)
- [ ] Run `trench --json create my-feature` and verify JSON output includes proper structure on success

## Known Issues
None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a standardized exit-code system (codes 0–8) with human-friendly descriptions to improve CLI behavior and enable reliable automation.
  * Replaced ad-hoc process exits with the new exit codes across commands to provide consistent error signaling.

* **Tests**
  * Added integration tests that validate exit codes for a range of error scenarios (missing flags, config issues, branch conflicts, git errors, hook failures/timeouts, etc.).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->