### PR TITLE
feat(tui): sync strategy picker — rebase/merge selection

### DIFF
--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -15,6 +15,7 @@ pub enum Screen {
     Detail,
     Create,
     Help,
+    SyncPicker,
 }
 
 type PanicHook = dyn Fn(&std::panic::PanicHookInfo<'_>) + Send + Sync;
@@ -73,6 +74,7 @@ pub struct App {
     nav_stack: Vec<Screen>,
     pub list_state: screens::list::ListState,
     pub detail_state: Option<screens::detail::DetailState>,
+    pub sync_picker_state: Option<screens::sync_picker::SyncPickerState>,
 }
 
 impl App {
@@ -82,6 +84,7 @@ impl App {
             nav_stack: vec![Screen::List],
             list_state: screens::list::ListState::new(vec![]),
             detail_state: None,
+            sync_picker_state: None,
         }
     }
 
@@ -168,6 +171,7 @@ impl App {
         match self.active_screen() {
             Screen::List => self.handle_list_key(key),
             Screen::Detail => self.handle_detail_key(key),
+            Screen::SyncPicker => self.handle_sync_picker_key(key),
             Screen::Create => {}
             Screen::Help => {}
         }
@@ -207,6 +211,9 @@ impl App {
             KeyCode::Char('o') => {} // TODO: open in $EDITOR
             _ => {}
         }
+    }
+
+    fn handle_sync_picker_key(&mut self, _key: KeyEvent) {
     }
 
     fn handle_list_key(&mut self, key: KeyEvent) {
@@ -263,9 +270,9 @@ mod tests {
     }
 
     #[test]
-    fn screen_enum_has_four_variants() {
-        // Verify all four screen variants exist and are distinct
-        let screens = [Screen::List, Screen::Detail, Screen::Create, Screen::Help];
+    fn screen_enum_has_five_variants() {
+        // Verify all five screen variants exist and are distinct
+        let screens = [Screen::List, Screen::Detail, Screen::Create, Screen::Help, Screen::SyncPicker];
         for (i, a) in screens.iter().enumerate() {
             for (j, b) in screens.iter().enumerate() {
                 if i == j {
@@ -671,5 +678,27 @@ mod tests {
         app.handle_key_event(KeyEvent::new(KeyCode::Char('o'), KeyModifiers::NONE));
         assert!(app.is_running(), "o on detail should not crash or quit");
         assert_eq!(app.active_screen(), Screen::Detail);
+    }
+
+    #[test]
+    fn screen_enum_has_sync_picker_variant() {
+        let screen = Screen::SyncPicker;
+        assert_ne!(screen, Screen::List);
+        assert_ne!(screen, Screen::Detail);
+    }
+
+    #[test]
+    fn app_has_sync_picker_state_initially_none() {
+        let app = App::new();
+        assert!(app.sync_picker_state.is_none());
+    }
+
+    #[test]
+    fn push_sync_picker_screen_works() {
+        let mut app = App::new();
+        app.sync_picker_state = Some(screens::sync_picker::SyncPickerState::new("feat-auth"));
+        app.push_screen(Screen::SyncPicker);
+        assert_eq!(app.active_screen(), Screen::SyncPicker);
+        assert_eq!(app.nav_stack_depth(), 2);
     }
 }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -229,15 +229,24 @@ impl App {
     }
 
     fn handle_sync_picker_key(&mut self, key: KeyEvent) {
-        if let Some(ref mut picker) = self.sync_picker_state {
-            // In result mode, any key dismisses back to list
-            if picker.is_result_mode() {
-                match key.code {
-                    KeyCode::Enter | KeyCode::Char(' ') => self.pop_screen(),
-                    _ => {}
+        let in_result_mode = self
+            .sync_picker_state
+            .as_ref()
+            .is_some_and(|p| p.is_result_mode());
+        if in_result_mode {
+            match key.code {
+                KeyCode::Enter | KeyCode::Char(' ') => {
+                    while self.active_screen() != Screen::List {
+                        self.pop_screen();
+                    }
+                    self.sync_picker_state = None;
                 }
-                return;
+                _ => {}
             }
+            return;
+        }
+
+        if let Some(ref mut picker) = self.sync_picker_state {
             match key.code {
                 KeyCode::Down | KeyCode::Char('j') => picker.select_next(),
                 KeyCode::Up | KeyCode::Char('k') => picker.select_previous(),
@@ -852,6 +861,27 @@ mod tests {
 
         app.handle_key_event(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
         assert_eq!(app.active_screen(), Screen::List, "Enter in result mode should pop to list");
+        assert!(app.sync_picker_state.is_none(), "sync_picker_state should be cleared");
+    }
+
+    #[test]
+    fn enter_in_result_mode_pops_to_list_from_detail_path() {
+        let mut app = app_with_rows();
+        // Simulate Detail → SyncPicker flow: nav stack = [List, Detail, SyncPicker]
+        app.detail_state = Some(sample_detail_state());
+        app.push_screen(Screen::Detail);
+        let mut state = screens::sync_picker::SyncPickerState::new("feat-a");
+        state.result = Some(screens::sync_picker::SyncResultMessage {
+            success: true,
+            message: "Synced successfully".into(),
+        });
+        app.sync_picker_state = Some(state);
+        app.push_screen(Screen::SyncPicker);
+        assert_eq!(app.nav_stack_depth(), 3);
+
+        app.handle_key_event(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+        assert_eq!(app.active_screen(), Screen::List, "should pop all the way to List, not Detail");
+        assert!(app.sync_picker_state.is_none(), "sync_picker_state should be cleared");
     }
 
     #[test]

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -222,7 +222,14 @@ impl App {
         }
     }
 
-    fn handle_sync_picker_key(&mut self, _key: KeyEvent) {
+    fn handle_sync_picker_key(&mut self, key: KeyEvent) {
+        if let Some(ref mut picker) = self.sync_picker_state {
+            match key.code {
+                KeyCode::Down | KeyCode::Char('j') => picker.select_next(),
+                KeyCode::Up | KeyCode::Char('k') => picker.select_previous(),
+                _ => {}
+            }
+        }
     }
 
     fn handle_list_key(&mut self, key: KeyEvent) {
@@ -703,6 +710,42 @@ mod tests {
         app.handle_key_event(KeyEvent::new(KeyCode::Char('o'), KeyModifiers::NONE));
         assert!(app.is_running(), "o on detail should not crash or quit");
         assert_eq!(app.active_screen(), Screen::Detail);
+    }
+
+    #[test]
+    fn arrow_down_on_sync_picker_selects_merge() {
+        let mut app = App::new();
+        app.sync_picker_state = Some(screens::sync_picker::SyncPickerState::new("feat-auth"));
+        app.push_screen(Screen::SyncPicker);
+        assert_eq!(app.sync_picker_state.as_ref().unwrap().selected, 0);
+
+        app.handle_key_event(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE));
+        assert_eq!(app.sync_picker_state.as_ref().unwrap().selected, 1, "down should select Merge");
+    }
+
+    #[test]
+    fn arrow_up_on_sync_picker_selects_rebase() {
+        let mut app = App::new();
+        let mut state = screens::sync_picker::SyncPickerState::new("feat-auth");
+        state.selected = 1;
+        app.sync_picker_state = Some(state);
+        app.push_screen(Screen::SyncPicker);
+
+        app.handle_key_event(KeyEvent::new(KeyCode::Up, KeyModifiers::NONE));
+        assert_eq!(app.sync_picker_state.as_ref().unwrap().selected, 0, "up should select Rebase");
+    }
+
+    #[test]
+    fn j_k_keys_work_on_sync_picker() {
+        let mut app = App::new();
+        app.sync_picker_state = Some(screens::sync_picker::SyncPickerState::new("feat-auth"));
+        app.push_screen(Screen::SyncPicker);
+
+        app.handle_key_event(KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE));
+        assert_eq!(app.sync_picker_state.as_ref().unwrap().selected, 1, "j should move down");
+
+        app.handle_key_event(KeyEvent::new(KeyCode::Char('k'), KeyModifiers::NONE));
+        assert_eq!(app.sync_picker_state.as_ref().unwrap().selected, 0, "k should move up");
     }
 
     #[test]

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -224,10 +224,66 @@ impl App {
 
     fn handle_sync_picker_key(&mut self, key: KeyEvent) {
         if let Some(ref mut picker) = self.sync_picker_state {
+            // In result mode, any key dismisses back to list
+            if picker.is_result_mode() {
+                match key.code {
+                    KeyCode::Enter | KeyCode::Char(' ') => self.pop_screen(),
+                    _ => {}
+                }
+                return;
+            }
             match key.code {
                 KeyCode::Down | KeyCode::Char('j') => picker.select_next(),
                 KeyCode::Up | KeyCode::Char('k') => picker.select_previous(),
+                KeyCode::Enter => self.execute_sync(),
                 _ => {}
+            }
+        }
+    }
+
+    fn execute_sync(&mut self) {
+        let picker = match self.sync_picker_state.as_ref() {
+            Some(p) => p,
+            None => return,
+        };
+        let strategy = picker.confirmed_strategy();
+        let worktree_name = picker.worktree_name.clone();
+
+        let Some((cwd, db)) = Self::open_db() else {
+            if let Some(ref mut p) = self.sync_picker_state {
+                p.result = Some(screens::sync_picker::SyncResultMessage {
+                    success: false,
+                    message: "Failed to open database".into(),
+                });
+            }
+            return;
+        };
+
+        match crate::cli::commands::sync::execute(&worktree_name, &cwd, &db, strategy) {
+            Ok(result) => {
+                let msg = format!(
+                    "Synced '{}' via {}\nBefore: +{}/-{}  After: +{}/-{}",
+                    result.name,
+                    result.strategy,
+                    result.before_ahead,
+                    result.before_behind,
+                    result.after_ahead,
+                    result.after_behind,
+                );
+                if let Some(ref mut p) = self.sync_picker_state {
+                    p.result = Some(screens::sync_picker::SyncResultMessage {
+                        success: true,
+                        message: msg,
+                    });
+                }
+            }
+            Err(e) => {
+                if let Some(ref mut p) = self.sync_picker_state {
+                    p.result = Some(screens::sync_picker::SyncResultMessage {
+                        success: false,
+                        message: format!("Sync failed: {e:#}"),
+                    });
+                }
             }
         }
     }
@@ -746,6 +802,38 @@ mod tests {
 
         app.handle_key_event(KeyEvent::new(KeyCode::Char('k'), KeyModifiers::NONE));
         assert_eq!(app.sync_picker_state.as_ref().unwrap().selected, 0, "k should move up");
+    }
+
+    #[test]
+    fn enter_on_sync_picker_triggers_sync_and_sets_result() {
+        // Without a real git repo, execute_sync will fail — but it should
+        // set a result message (failure) and stay on the SyncPicker screen.
+        let mut app = App::new();
+        app.sync_picker_state = Some(screens::sync_picker::SyncPickerState::new("feat-auth"));
+        app.push_screen(Screen::SyncPicker);
+
+        app.handle_key_event(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+
+        // Should still be on SyncPicker (showing result)
+        assert_eq!(app.active_screen(), Screen::SyncPicker);
+        let picker = app.sync_picker_state.as_ref().unwrap();
+        assert!(picker.is_result_mode(), "should be in result mode after Enter");
+        assert!(picker.result.is_some());
+    }
+
+    #[test]
+    fn enter_in_result_mode_pops_back_to_list() {
+        let mut app = App::new();
+        let mut state = screens::sync_picker::SyncPickerState::new("feat-auth");
+        state.result = Some(screens::sync_picker::SyncResultMessage {
+            success: true,
+            message: "Synced successfully".into(),
+        });
+        app.sync_picker_state = Some(state);
+        app.push_screen(Screen::SyncPicker);
+
+        app.handle_key_event(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+        assert_eq!(app.active_screen(), Screen::List, "Enter in result mode should pop to list");
     }
 
     #[test]

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -757,6 +757,15 @@ mod tests {
     }
 
     #[test]
+    fn s_on_empty_list_does_not_push_sync_picker() {
+        let mut app = App::new();
+        // Empty list — no rows
+        app.handle_key_event(KeyEvent::new(KeyCode::Char('s'), KeyModifiers::NONE));
+        assert_eq!(app.active_screen(), Screen::List, "s on empty list should stay on List");
+        assert!(app.sync_picker_state.is_none(), "sync_picker_state should remain None");
+    }
+
+    #[test]
     fn s_on_detail_pushes_sync_picker() {
         let mut app = App::new();
         app.detail_state = Some(sample_detail_state());

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -119,6 +119,15 @@ impl App {
                     frame.render_widget(placeholder, frame.area());
                 }
             }
+            Screen::SyncPicker => {
+                if let Some(ref picker) = self.sync_picker_state {
+                    screens::sync_picker::render(picker, frame, frame.area());
+                } else {
+                    let placeholder =
+                        Paragraph::new("trench TUI — press q to quit").alignment(Alignment::Center);
+                    frame.render_widget(placeholder, frame.area());
+                }
+            }
             _ => {
                 let placeholder =
                     Paragraph::new("trench TUI — press q to quit").alignment(Alignment::Center);
@@ -694,6 +703,23 @@ mod tests {
         app.handle_key_event(KeyEvent::new(KeyCode::Char('o'), KeyModifiers::NONE));
         assert!(app.is_running(), "o on detail should not crash or quit");
         assert_eq!(app.active_screen(), Screen::Detail);
+    }
+
+    #[test]
+    fn sync_picker_screen_renders_options_through_app() {
+        let mut app = App::new();
+        app.sync_picker_state = Some(screens::sync_picker::SyncPickerState::new("feat-auth"));
+        app.push_screen(Screen::SyncPicker);
+
+        let backend = ratatui::backend::TestBackend::new(80, 15);
+        let mut terminal = ratatui::Terminal::new(backend).unwrap();
+        terminal.draw(|frame| app.ui(frame)).unwrap();
+        let buffer = terminal.backend().buffer().clone();
+        let content: String = buffer.content().iter().map(|cell| cell.symbol()).collect();
+
+        assert!(content.contains("Rebase"), "should render Rebase option");
+        assert!(content.contains("Merge"), "should render Merge option");
+        assert!(content.contains("feat-auth"), "should show worktree name");
     }
 
     #[test]

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -240,7 +240,13 @@ impl App {
             KeyCode::Char('n') => self.push_screen(Screen::Create),
             KeyCode::Down | KeyCode::Char('j') => self.list_state.select_next(),
             KeyCode::Up | KeyCode::Char('k') => self.list_state.select_previous(),
-            KeyCode::Char('s') => {} // TODO: trigger sync
+            KeyCode::Char('s') => {
+                if let Some(row) = self.list_state.rows.get(self.list_state.selected) {
+                    self.sync_picker_state =
+                        Some(screens::sync_picker::SyncPickerState::new(&row.name));
+                    self.push_screen(Screen::SyncPicker);
+                }
+            }
             KeyCode::Char('D') => {} // TODO: trigger delete with confirmation
             _ => {}
         }
@@ -509,12 +515,22 @@ mod tests {
     }
 
     #[test]
-    fn s_on_list_is_handled() {
+    fn s_on_list_pushes_sync_picker() {
         let mut app = app_with_rows();
-        // s should not crash and should not quit or push a screen
         app.handle_key_event(KeyEvent::new(KeyCode::Char('s'), KeyModifiers::NONE));
         assert!(app.is_running());
-        assert_eq!(app.active_screen(), Screen::List);
+        assert_eq!(app.active_screen(), Screen::SyncPicker);
+        assert_eq!(app.nav_stack_depth(), 2);
+    }
+
+    #[test]
+    fn s_on_list_sets_sync_picker_state_with_selected_worktree() {
+        let mut app = app_with_rows();
+        // Select second row
+        app.list_state.selected = 1;
+        app.handle_key_event(KeyEvent::new(KeyCode::Char('s'), KeyModifiers::NONE));
+        let state = app.sync_picker_state.as_ref().expect("sync_picker_state should be set");
+        assert_eq!(state.worktree_name, "feat-b");
     }
 
     #[test]

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -216,7 +216,13 @@ impl App {
 
     fn handle_detail_key(&mut self, key: KeyEvent) {
         match key.code {
-            KeyCode::Char('s') => {} // TODO: trigger sync
+            KeyCode::Char('s') => {
+                if let Some(ref detail) = self.detail_state {
+                    self.sync_picker_state =
+                        Some(screens::sync_picker::SyncPickerState::new(&detail.name));
+                    self.push_screen(Screen::SyncPicker);
+                }
+            }
             KeyCode::Char('o') => {} // TODO: open in $EDITOR
             _ => {}
         }
@@ -751,12 +757,15 @@ mod tests {
     }
 
     #[test]
-    fn s_on_detail_is_handled_without_crash() {
+    fn s_on_detail_pushes_sync_picker() {
         let mut app = App::new();
+        app.detail_state = Some(sample_detail_state());
         app.push_screen(Screen::Detail);
+
         app.handle_key_event(KeyEvent::new(KeyCode::Char('s'), KeyModifiers::NONE));
-        assert!(app.is_running(), "s on detail should not crash or quit");
-        assert_eq!(app.active_screen(), Screen::Detail);
+        assert_eq!(app.active_screen(), Screen::SyncPicker);
+        let picker = app.sync_picker_state.as_ref().expect("sync_picker_state should be set");
+        assert_eq!(picker.worktree_name, "feat-a");
     }
 
     #[test]

--- a/src/tui/screens/mod.rs
+++ b/src/tui/screens/mod.rs
@@ -1,2 +1,3 @@
 pub mod detail;
 pub mod list;
+pub mod sync_picker;

--- a/src/tui/screens/sync_picker.rs
+++ b/src/tui/screens/sync_picker.rs
@@ -59,7 +59,7 @@ impl SyncPickerState {
     }
 
     pub fn select_next(&mut self) {
-        if self.selected < 1 {
+        if self.selected < SYNC_OPTIONS.len() - 1 {
             self.selected += 1;
         }
     }

--- a/src/tui/screens/sync_picker.rs
+++ b/src/tui/screens/sync_picker.rs
@@ -73,7 +73,7 @@ impl SyncPickerState {
     }
 }
 
-const SYNC_PICKER_FOOTER: &str = " ↑/↓ select  Enter confirm  Esc cancel ";
+const SYNC_PICKER_FOOTER: &str = " ↑/↓ or j/k select  Enter confirm  Esc cancel ";
 const SYNC_RESULT_FOOTER: &str = " Enter dismiss  Esc back ";
 
 pub fn render(state: &SyncPickerState, frame: &mut Frame, area: Rect) {

--- a/src/tui/screens/sync_picker.rs
+++ b/src/tui/screens/sync_picker.rs
@@ -1,3 +1,11 @@
+use ratatui::{
+    layout::{Alignment, Constraint, Layout, Rect},
+    style::{Modifier, Style},
+    text::{Line, Span},
+    widgets::Paragraph,
+    Frame,
+};
+
 /// View model for the sync strategy picker screen.
 #[derive(Debug, Clone, PartialEq)]
 pub struct SyncPickerState {
@@ -32,6 +40,56 @@ impl SyncPickerState {
     pub fn select_previous(&mut self) {
         self.selected = self.selected.saturating_sub(1);
     }
+}
+
+const SYNC_PICKER_FOOTER: &str = " ↑/↓ select  Enter confirm  Esc cancel ";
+
+pub fn render(state: &SyncPickerState, frame: &mut Frame, area: Rect) {
+    let bold = Style::default().add_modifier(Modifier::BOLD);
+
+    let chunks = Layout::vertical([
+        Constraint::Length(3), // title + blank line
+        Constraint::Min(1),   // options
+        Constraint::Length(1), // footer
+    ])
+    .split(area);
+
+    // Title
+    let title = Line::from(vec![
+        Span::styled("Sync strategy for ", bold),
+        Span::styled(&state.worktree_name, bold),
+    ]);
+    frame.render_widget(
+        Paragraph::new(title).alignment(Alignment::Center),
+        chunks[0],
+    );
+
+    // Options
+    let options = state.options();
+    let mut lines: Vec<Line> = Vec::new();
+    for (i, (label, desc)) in options.iter().enumerate() {
+        let marker = if i == state.selected { "▸ " } else { "  " };
+        let style = if i == state.selected {
+            Style::default().add_modifier(Modifier::BOLD | Modifier::REVERSED)
+        } else {
+            Style::default()
+        };
+        lines.push(Line::from(Span::styled(
+            format!("{marker}{label}"),
+            style,
+        )));
+        lines.push(Line::from(format!("    {desc}")));
+        lines.push(Line::from(""));
+    }
+    frame.render_widget(
+        Paragraph::new(lines).alignment(Alignment::Center),
+        chunks[1],
+    );
+
+    // Footer
+    let footer = Paragraph::new(Line::from(SYNC_PICKER_FOOTER))
+        .style(Style::default().add_modifier(Modifier::REVERSED));
+    frame.render_widget(footer, chunks[2]);
 }
 
 #[cfg(test)]
@@ -91,5 +149,62 @@ mod tests {
         let mut state = SyncPickerState::new("feat-auth");
         state.select_previous();
         assert_eq!(state.selected, 0, "should stay at Rebase");
+    }
+
+    fn render_to_buffer(state: &SyncPickerState, width: u16, height: u16) -> ratatui::buffer::Buffer {
+        let backend = ratatui::backend::TestBackend::new(width, height);
+        let mut terminal = ratatui::Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| render(state, frame, frame.area()))
+            .unwrap();
+        terminal.backend().buffer().clone()
+    }
+
+    fn buffer_text(buf: &ratatui::buffer::Buffer) -> String {
+        buf.content().iter().map(|cell| cell.symbol()).collect()
+    }
+
+    #[test]
+    fn renders_title_with_worktree_name() {
+        let state = SyncPickerState::new("feat-auth");
+        let buf = render_to_buffer(&state, 80, 15);
+        let text = buffer_text(&buf);
+        assert!(text.contains("Sync strategy"), "should show title");
+        assert!(text.contains("feat-auth"), "should show worktree name");
+    }
+
+    #[test]
+    fn renders_rebase_and_merge_options() {
+        let state = SyncPickerState::new("feat-auth");
+        let buf = render_to_buffer(&state, 80, 15);
+        let text = buffer_text(&buf);
+        assert!(text.contains("Rebase"), "should show Rebase option");
+        assert!(text.contains("Merge"), "should show Merge option");
+    }
+
+    #[test]
+    fn renders_option_descriptions() {
+        let state = SyncPickerState::new("feat-auth");
+        let buf = render_to_buffer(&state, 80, 15);
+        let text = buffer_text(&buf);
+        assert!(text.contains("Replay your commits"), "should show Rebase description");
+        assert!(text.contains("merge commit"), "should show Merge description");
+    }
+
+    #[test]
+    fn renders_footer_with_keybindings() {
+        let state = SyncPickerState::new("feat-auth");
+        let buf = render_to_buffer(&state, 80, 15);
+        let text = buffer_text(&buf);
+        assert!(text.contains("Enter confirm"), "footer should show Enter confirm");
+        assert!(text.contains("Esc cancel"), "footer should show Esc cancel");
+    }
+
+    #[test]
+    fn selected_option_has_marker() {
+        let state = SyncPickerState::new("feat-auth");
+        let buf = render_to_buffer(&state, 80, 15);
+        let text = buffer_text(&buf);
+        assert!(text.contains("▸"), "should show selection marker");
     }
 }

--- a/src/tui/screens/sync_picker.rs
+++ b/src/tui/screens/sync_picker.rs
@@ -1,0 +1,54 @@
+/// View model for the sync strategy picker screen.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SyncPickerState {
+    /// Name of the worktree being synced.
+    pub worktree_name: String,
+    /// Currently selected option: 0 = Rebase, 1 = Merge.
+    pub selected: usize,
+}
+
+impl SyncPickerState {
+    pub fn new(worktree_name: &str) -> Self {
+        Self {
+            worktree_name: worktree_name.to_string(),
+            selected: 0,
+        }
+    }
+
+    /// Returns the two strategy options as (label, description) pairs.
+    pub fn options(&self) -> Vec<(&'static str, &'static str)> {
+        vec![
+            ("Rebase", "Replay your commits on top of the base branch"),
+            ("Merge", "Create a merge commit combining both branches"),
+        ]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sync_picker_state_holds_worktree_name_and_defaults_to_rebase() {
+        let state = SyncPickerState::new("feat-auth");
+        assert_eq!(state.worktree_name, "feat-auth");
+        assert_eq!(state.selected, 0, "should default to Rebase (index 0)");
+    }
+
+    #[test]
+    fn sync_picker_has_exactly_two_options() {
+        let state = SyncPickerState::new("feat-auth");
+        let options = state.options();
+        assert_eq!(options.len(), 2);
+        assert_eq!(options[0].0, "Rebase");
+        assert_eq!(options[1].0, "Merge");
+    }
+
+    #[test]
+    fn sync_picker_options_have_descriptions() {
+        let state = SyncPickerState::new("feat-auth");
+        let options = state.options();
+        assert!(!options[0].1.is_empty(), "Rebase should have a description");
+        assert!(!options[1].1.is_empty(), "Merge should have a description");
+    }
+}

--- a/src/tui/screens/sync_picker.rs
+++ b/src/tui/screens/sync_picker.rs
@@ -68,8 +68,57 @@ impl SyncPickerState {
 }
 
 const SYNC_PICKER_FOOTER: &str = " ↑/↓ select  Enter confirm  Esc cancel ";
+const SYNC_RESULT_FOOTER: &str = " Enter dismiss  Esc back ";
 
 pub fn render(state: &SyncPickerState, frame: &mut Frame, area: Rect) {
+    if let Some(ref result) = state.result {
+        render_result(state, result, frame, area);
+    } else {
+        render_picker(state, frame, area);
+    }
+}
+
+fn render_result(
+    state: &SyncPickerState,
+    result: &SyncResultMessage,
+    frame: &mut Frame,
+    area: Rect,
+) {
+    let bold = Style::default().add_modifier(Modifier::BOLD);
+
+    let chunks = Layout::vertical([
+        Constraint::Length(3), // title
+        Constraint::Min(1),   // result message
+        Constraint::Length(1), // footer
+    ])
+    .split(area);
+
+    // Title
+    let status = if result.success { "Sync Complete" } else { "Sync Failed" };
+    let title = Line::from(vec![
+        Span::styled(status, bold),
+        Span::raw(" — "),
+        Span::raw(&state.worktree_name),
+    ]);
+    frame.render_widget(
+        Paragraph::new(title).alignment(Alignment::Center),
+        chunks[0],
+    );
+
+    // Result message
+    let lines: Vec<Line> = result.message.lines().map(Line::from).collect();
+    frame.render_widget(
+        Paragraph::new(lines).alignment(Alignment::Center),
+        chunks[1],
+    );
+
+    // Footer
+    let footer = Paragraph::new(Line::from(SYNC_RESULT_FOOTER))
+        .style(Style::default().add_modifier(Modifier::REVERSED));
+    frame.render_widget(footer, chunks[2]);
+}
+
+fn render_picker(state: &SyncPickerState, frame: &mut Frame, area: Rect) {
     let bold = Style::default().add_modifier(Modifier::BOLD);
 
     let chunks = Layout::vertical([
@@ -260,5 +309,43 @@ mod tests {
         let buf = render_to_buffer(&state, 80, 15);
         let text = buffer_text(&buf);
         assert!(text.contains("▸"), "should show selection marker");
+    }
+
+    #[test]
+    fn renders_success_result_message() {
+        let mut state = SyncPickerState::new("feat-auth");
+        state.result = Some(SyncResultMessage {
+            success: true,
+            message: "Synced 'feat-auth' via rebase".into(),
+        });
+        let buf = render_to_buffer(&state, 80, 15);
+        let text = buffer_text(&buf);
+        assert!(text.contains("Synced"), "should show sync result message");
+        assert!(text.contains("rebase"), "should show strategy used");
+        assert!(!text.contains("▸"), "should NOT show picker marker in result mode");
+    }
+
+    #[test]
+    fn renders_failure_result_message() {
+        let mut state = SyncPickerState::new("feat-auth");
+        state.result = Some(SyncResultMessage {
+            success: false,
+            message: "Sync failed: worktree has uncommitted changes".into(),
+        });
+        let buf = render_to_buffer(&state, 80, 15);
+        let text = buffer_text(&buf);
+        assert!(text.contains("failed"), "should show failure message");
+    }
+
+    #[test]
+    fn result_mode_shows_dismiss_footer() {
+        let mut state = SyncPickerState::new("feat-auth");
+        state.result = Some(SyncResultMessage {
+            success: true,
+            message: "Done".into(),
+        });
+        let buf = render_to_buffer(&state, 80, 15);
+        let text = buffer_text(&buf);
+        assert!(text.contains("Enter"), "result footer should show Enter to dismiss");
     }
 }

--- a/src/tui/screens/sync_picker.rs
+++ b/src/tui/screens/sync_picker.rs
@@ -44,7 +44,11 @@ impl SyncPickerState {
     pub fn confirmed_strategy(&self) -> Strategy {
         match self.selected {
             0 => Strategy::Rebase,
-            _ => Strategy::Merge,
+            1 => Strategy::Merge,
+            _ => {
+                debug_assert!(false, "invalid sync option index: {}", self.selected);
+                Strategy::Rebase
+            }
         }
     }
 
@@ -287,6 +291,14 @@ mod tests {
         let mut state = SyncPickerState::new("feat-auth");
         state.selected = 1;
         assert_eq!(state.confirmed_strategy(), Strategy::Merge);
+    }
+
+    #[test]
+    #[should_panic(expected = "invalid sync option index")]
+    fn confirmed_strategy_panics_in_debug_for_invalid_index() {
+        let mut state = SyncPickerState::new("feat-auth");
+        state.selected = 99;
+        let _ = state.confirmed_strategy();
     }
 
     #[test]

--- a/src/tui/screens/sync_picker.rs
+++ b/src/tui/screens/sync_picker.rs
@@ -8,6 +8,11 @@ use ratatui::{
 
 use crate::cli::commands::sync::Strategy;
 
+const SYNC_OPTIONS: [(&str, &str); 2] = [
+    ("Rebase", "Replay your commits on top of the base branch"),
+    ("Merge", "Create a merge commit combining both branches"),
+];
+
 /// View model for the sync strategy picker screen.
 #[derive(Debug, Clone, PartialEq)]
 pub struct SyncPickerState {
@@ -49,11 +54,8 @@ impl SyncPickerState {
     }
 
     /// Returns the two strategy options as (label, description) pairs.
-    pub fn options(&self) -> Vec<(&'static str, &'static str)> {
-        vec![
-            ("Rebase", "Replay your commits on top of the base branch"),
-            ("Merge", "Create a merge commit combining both branches"),
-        ]
+    pub fn options(&self) -> &'static [(&'static str, &'static str)] {
+        &SYNC_OPTIONS
     }
 
     pub fn select_next(&mut self) {

--- a/src/tui/screens/sync_picker.rs
+++ b/src/tui/screens/sync_picker.rs
@@ -22,6 +22,16 @@ impl SyncPickerState {
             ("Merge", "Create a merge commit combining both branches"),
         ]
     }
+
+    pub fn select_next(&mut self) {
+        if self.selected < 1 {
+            self.selected += 1;
+        }
+    }
+
+    pub fn select_previous(&mut self) {
+        self.selected = self.selected.saturating_sub(1);
+    }
 }
 
 #[cfg(test)]
@@ -50,5 +60,36 @@ mod tests {
         let options = state.options();
         assert!(!options[0].1.is_empty(), "Rebase should have a description");
         assert!(!options[1].1.is_empty(), "Merge should have a description");
+    }
+
+    #[test]
+    fn select_next_moves_from_rebase_to_merge() {
+        let mut state = SyncPickerState::new("feat-auth");
+        assert_eq!(state.selected, 0);
+        state.select_next();
+        assert_eq!(state.selected, 1, "should move to Merge");
+    }
+
+    #[test]
+    fn select_next_clamps_at_merge() {
+        let mut state = SyncPickerState::new("feat-auth");
+        state.selected = 1;
+        state.select_next();
+        assert_eq!(state.selected, 1, "should stay at Merge");
+    }
+
+    #[test]
+    fn select_previous_moves_from_merge_to_rebase() {
+        let mut state = SyncPickerState::new("feat-auth");
+        state.selected = 1;
+        state.select_previous();
+        assert_eq!(state.selected, 0, "should move to Rebase");
+    }
+
+    #[test]
+    fn select_previous_clamps_at_rebase() {
+        let mut state = SyncPickerState::new("feat-auth");
+        state.select_previous();
+        assert_eq!(state.selected, 0, "should stay at Rebase");
     }
 }

--- a/src/tui/screens/sync_picker.rs
+++ b/src/tui/screens/sync_picker.rs
@@ -6,6 +6,8 @@ use ratatui::{
     Frame,
 };
 
+use crate::cli::commands::sync::Strategy;
+
 /// View model for the sync strategy picker screen.
 #[derive(Debug, Clone, PartialEq)]
 pub struct SyncPickerState {
@@ -13,6 +15,15 @@ pub struct SyncPickerState {
     pub worktree_name: String,
     /// Currently selected option: 0 = Rebase, 1 = Merge.
     pub selected: usize,
+    /// Result message after sync execution. None = picker mode, Some = result mode.
+    pub result: Option<SyncResultMessage>,
+}
+
+/// Outcome displayed after a sync operation completes.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SyncResultMessage {
+    pub success: bool,
+    pub message: String,
 }
 
 impl SyncPickerState {
@@ -20,7 +31,21 @@ impl SyncPickerState {
         Self {
             worktree_name: worktree_name.to_string(),
             selected: 0,
+            result: None,
         }
+    }
+
+    /// Returns the Strategy corresponding to the current selection.
+    pub fn confirmed_strategy(&self) -> Strategy {
+        match self.selected {
+            0 => Strategy::Rebase,
+            _ => Strategy::Merge,
+        }
+    }
+
+    /// Whether the picker is showing a result (post-sync).
+    pub fn is_result_mode(&self) -> bool {
+        self.result.is_some()
     }
 
     /// Returns the two strategy options as (label, description) pairs.
@@ -198,6 +223,35 @@ mod tests {
         let text = buffer_text(&buf);
         assert!(text.contains("Enter confirm"), "footer should show Enter confirm");
         assert!(text.contains("Esc cancel"), "footer should show Esc cancel");
+    }
+
+    #[test]
+    fn confirmed_strategy_returns_rebase_when_selected_is_zero() {
+        let state = SyncPickerState::new("feat-auth");
+        assert_eq!(state.confirmed_strategy(), Strategy::Rebase);
+    }
+
+    #[test]
+    fn confirmed_strategy_returns_merge_when_selected_is_one() {
+        let mut state = SyncPickerState::new("feat-auth");
+        state.selected = 1;
+        assert_eq!(state.confirmed_strategy(), Strategy::Merge);
+    }
+
+    #[test]
+    fn is_result_mode_false_initially() {
+        let state = SyncPickerState::new("feat-auth");
+        assert!(!state.is_result_mode());
+    }
+
+    #[test]
+    fn is_result_mode_true_after_setting_result() {
+        let mut state = SyncPickerState::new("feat-auth");
+        state.result = Some(SyncResultMessage {
+            success: true,
+            message: "Synced successfully".into(),
+        });
+        assert!(state.is_result_mode());
     }
 
     #[test]


### PR DESCRIPTION
Closes #45

## Summary
Implements the TUI sync strategy picker screen (FR-47). Pressing `s` on the list or detail view opens a centered picker with Rebase and Merge options, each with a brief description. Arrow keys navigate, Enter confirms and executes the sync, Esc cancels. After sync, the result (success/failure with details) is displayed before returning to the list.

## User Stories Addressed
- US-11: TUI sync workflow — `s` triggers sync from list and detail views
- US-6: Interactive sync — strategy picker with rebase/merge selection

## Automated Testing
- Total tests added: 32
- Tests passing: 32
- Tests failing: 0
- `cargo clippy`: pass (only pre-existing warnings)
- `cargo test`: pass (547 total: 539 unit + 8 integration)

## UAT Checklist
- [ ] Launch TUI with `trench`, select a worktree, press `s` → sync strategy picker appears
- [ ] Arrow keys (↑/↓) and vim keys (j/k) toggle between Rebase and Merge
- [ ] Esc dismisses the picker and returns to the list
- [ ] Enter confirms selection and executes sync on the worktree
- [ ] After sync, success message shows before/after ahead/behind counts
- [ ] After sync failure, error message is displayed clearly
- [ ] Press Enter on result screen to return to the list
- [ ] Press `s` on the detail view → same sync picker flow works
- [ ] `s` on an empty list does nothing (no crash)
- [ ] `q` on the sync picker pops back to the previous screen

## Known Issues
None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New Sync Picker screen accessible from list and detail views (press 's') to start sync workflows.
  * Choose Rebase or Merge strategies; navigate with arrow keys or j/k and confirm with Enter.
  * Displays sync execution results (success/failure) with a result mode and simple return interaction.

* **Tests**
  * Added comprehensive tests for picker navigation, rendering, state transitions, and result handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->