### PR TITLE
feat(tui): delete confirmation overlay dialog

### DIFF
--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -197,8 +197,71 @@ impl App {
         }
     }
 
-    fn handle_delete_confirm_key(&mut self, _key: KeyEvent) {
-        // TODO: implement
+    fn handle_delete_confirm_key(&mut self, key: KeyEvent) {
+        let in_result_mode = self
+            .delete_confirm_state
+            .as_ref()
+            .is_some_and(|s| s.is_result_mode());
+
+        if in_result_mode {
+            match key.code {
+                KeyCode::Enter | KeyCode::Char(' ') => {
+                    self.delete_confirm_state = None;
+                    while self.active_screen() != Screen::List {
+                        self.pop_screen();
+                    }
+                }
+                _ => {}
+            }
+            return;
+        }
+
+        match key.code {
+            KeyCode::Enter | KeyCode::Char('y') => self.execute_delete(),
+            KeyCode::Char('n') => {
+                self.delete_confirm_state = None;
+                self.pop_screen();
+            }
+            _ => {}
+        }
+    }
+
+    fn execute_delete(&mut self) {
+        let confirm = match self.delete_confirm_state.as_ref() {
+            Some(c) => c,
+            None => return,
+        };
+        let worktree_name = confirm.worktree_name.clone();
+
+        let Some((cwd, db)) = Self::open_db() else {
+            if let Some(ref mut c) = self.delete_confirm_state {
+                c.result = Some(screens::delete_confirm::DeleteResultMessage {
+                    success: false,
+                    message: "Failed to open database".into(),
+                });
+            }
+            return;
+        };
+
+        match crate::cli::commands::remove::execute(&worktree_name, &cwd, &db, false) {
+            Ok(result) => {
+                let msg = format!("Removed '{}'", result.name);
+                if let Some(ref mut c) = self.delete_confirm_state {
+                    c.result = Some(screens::delete_confirm::DeleteResultMessage {
+                        success: true,
+                        message: msg,
+                    });
+                }
+            }
+            Err(e) => {
+                if let Some(ref mut c) = self.delete_confirm_state {
+                    c.result = Some(screens::delete_confirm::DeleteResultMessage {
+                        success: false,
+                        message: format!("Delete failed: {e:#}"),
+                    });
+                }
+            }
+        }
     }
 
     /// If the selected worktree is unmanaged, silently adopt it into the DB.
@@ -977,6 +1040,89 @@ mod tests {
         app.push_screen(Screen::DeleteConfirm);
         assert_eq!(app.active_screen(), Screen::DeleteConfirm);
         assert_eq!(app.nav_stack_depth(), 2);
+    }
+
+    #[test]
+    fn enter_on_delete_confirm_triggers_delete_and_sets_result() {
+        // Without a real git repo, execute_delete will fail — but it should
+        // set a result message (failure) and stay on the DeleteConfirm screen.
+        let mut app = App::new();
+        app.delete_confirm_state = Some(screens::delete_confirm::DeleteConfirmState::new(
+            "feat-auth", "/tmp/wt/feat-auth", "feature/auth",
+        ));
+        app.push_screen(Screen::DeleteConfirm);
+
+        app.handle_key_event(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+
+        assert_eq!(app.active_screen(), Screen::DeleteConfirm);
+        let state = app.delete_confirm_state.as_ref().unwrap();
+        assert!(state.is_result_mode(), "should be in result mode after Enter");
+        assert!(state.result.is_some());
+    }
+
+    #[test]
+    fn y_on_delete_confirm_triggers_delete_and_sets_result() {
+        let mut app = App::new();
+        app.delete_confirm_state = Some(screens::delete_confirm::DeleteConfirmState::new(
+            "feat-auth", "/tmp/wt/feat-auth", "feature/auth",
+        ));
+        app.push_screen(Screen::DeleteConfirm);
+
+        app.handle_key_event(KeyEvent::new(KeyCode::Char('y'), KeyModifiers::NONE));
+
+        assert_eq!(app.active_screen(), Screen::DeleteConfirm);
+        let state = app.delete_confirm_state.as_ref().unwrap();
+        assert!(state.is_result_mode(), "y should also trigger delete");
+    }
+
+    #[test]
+    fn n_on_delete_confirm_cancels_dialog() {
+        let mut app = App::new();
+        app.delete_confirm_state = Some(screens::delete_confirm::DeleteConfirmState::new(
+            "feat-auth", "/tmp/wt/feat-auth", "feature/auth",
+        ));
+        app.push_screen(Screen::DeleteConfirm);
+
+        app.handle_key_event(KeyEvent::new(KeyCode::Char('n'), KeyModifiers::NONE));
+
+        assert_eq!(app.active_screen(), Screen::List, "n should pop back to list");
+        assert!(app.delete_confirm_state.is_none(), "state should be cleared on cancel");
+    }
+
+    #[test]
+    fn enter_in_delete_result_mode_pops_to_list() {
+        let mut app = App::new();
+        let mut state = screens::delete_confirm::DeleteConfirmState::new(
+            "feat-auth", "/tmp/wt/feat-auth", "feature/auth",
+        );
+        state.result = Some(screens::delete_confirm::DeleteResultMessage {
+            success: true,
+            message: "Removed successfully".into(),
+        });
+        app.delete_confirm_state = Some(state);
+        app.push_screen(Screen::DeleteConfirm);
+
+        app.handle_key_event(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+        assert_eq!(app.active_screen(), Screen::List, "Enter in result mode should pop to list");
+        assert!(app.delete_confirm_state.is_none(), "state should be cleared");
+    }
+
+    #[test]
+    fn space_in_delete_result_mode_pops_to_list() {
+        let mut app = App::new();
+        let mut state = screens::delete_confirm::DeleteConfirmState::new(
+            "feat-auth", "/tmp/wt/feat-auth", "feature/auth",
+        );
+        state.result = Some(screens::delete_confirm::DeleteResultMessage {
+            success: true,
+            message: "Done".into(),
+        });
+        app.delete_confirm_state = Some(state);
+        app.push_screen(Screen::DeleteConfirm);
+
+        app.handle_key_event(KeyEvent::new(KeyCode::Char(' '), KeyModifiers::NONE));
+        assert_eq!(app.active_screen(), Screen::List, "Space in result mode should pop to list");
+        assert!(app.delete_confirm_state.is_none());
     }
 
     #[test]

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -16,6 +16,7 @@ pub enum Screen {
     Create,
     Help,
     SyncPicker,
+    DeleteConfirm,
 }
 
 type PanicHook = dyn Fn(&std::panic::PanicHookInfo<'_>) + Send + Sync;
@@ -75,6 +76,7 @@ pub struct App {
     pub list_state: screens::list::ListState,
     pub detail_state: Option<screens::detail::DetailState>,
     pub sync_picker_state: Option<screens::sync_picker::SyncPickerState>,
+    pub delete_confirm_state: Option<screens::delete_confirm::DeleteConfirmState>,
 }
 
 impl App {
@@ -85,6 +87,7 @@ impl App {
             list_state: screens::list::ListState::new(vec![]),
             detail_state: None,
             sync_picker_state: None,
+            delete_confirm_state: None,
         }
     }
 
@@ -126,6 +129,13 @@ impl App {
                     let placeholder =
                         Paragraph::new("trench TUI — press q to quit").alignment(Alignment::Center);
                     frame.render_widget(placeholder, frame.area());
+                }
+            }
+            Screen::DeleteConfirm => {
+                // Render list underneath, then overlay the dialog
+                screens::list::render(&self.list_state, frame, frame.area());
+                if let Some(ref confirm) = self.delete_confirm_state {
+                    screens::delete_confirm::render(confirm, frame, frame.area());
                 }
             }
             _ => {
@@ -181,9 +191,14 @@ impl App {
             Screen::List => self.handle_list_key(key),
             Screen::Detail => self.handle_detail_key(key),
             Screen::SyncPicker => self.handle_sync_picker_key(key),
+            Screen::DeleteConfirm => self.handle_delete_confirm_key(key),
             Screen::Create => {}
             Screen::Help => {}
         }
+    }
+
+    fn handle_delete_confirm_key(&mut self, _key: KeyEvent) {
+        // TODO: implement
     }
 
     /// If the selected worktree is unmanaged, silently adopt it into the DB.
@@ -363,9 +378,9 @@ mod tests {
     }
 
     #[test]
-    fn screen_enum_has_five_variants() {
-        // Verify all five screen variants exist and are distinct
-        let screens = [Screen::List, Screen::Detail, Screen::Create, Screen::Help, Screen::SyncPicker];
+    fn screen_enum_has_six_variants() {
+        // Verify all six screen variants exist and are distinct
+        let screens = [Screen::List, Screen::Detail, Screen::Create, Screen::Help, Screen::SyncPicker, Screen::DeleteConfirm];
         for (i, a) in screens.iter().enumerate() {
             for (j, b) in screens.iter().enumerate() {
                 if i == j {
@@ -912,6 +927,23 @@ mod tests {
     fn app_has_sync_picker_state_initially_none() {
         let app = App::new();
         assert!(app.sync_picker_state.is_none());
+    }
+
+    #[test]
+    fn app_has_delete_confirm_state_initially_none() {
+        let app = App::new();
+        assert!(app.delete_confirm_state.is_none());
+    }
+
+    #[test]
+    fn push_delete_confirm_screen_works() {
+        let mut app = App::new();
+        app.delete_confirm_state = Some(screens::delete_confirm::DeleteConfirmState::new(
+            "feat-auth", "/tmp/wt/feat-auth", "feature/auth",
+        ));
+        app.push_screen(Screen::DeleteConfirm);
+        assert_eq!(app.active_screen(), Screen::DeleteConfirm);
+        assert_eq!(app.nav_stack_depth(), 2);
     }
 
     #[test]

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -349,7 +349,18 @@ impl App {
                     self.push_screen(Screen::SyncPicker);
                 }
             }
-            KeyCode::Char('D') => {} // TODO: trigger delete with confirmation
+            KeyCode::Char('D') => {
+                if let Some(row) = self.list_state.rows.get(self.list_state.selected) {
+                    self.delete_confirm_state = Some(
+                        screens::delete_confirm::DeleteConfirmState::new(
+                            &row.name,
+                            &row.path,
+                            &row.branch,
+                        ),
+                    );
+                    self.push_screen(Screen::DeleteConfirm);
+                }
+            }
             _ => {}
         }
     }
@@ -563,6 +574,7 @@ mod tests {
             WorktreeRow {
                 name: "feat-a".into(),
                 branch: "feat/a".into(),
+                path: "/tmp/wt/feat-a".into(),
                 status: "clean".into(),
                 ahead_behind: "+0/-0".into(),
                 managed: true,
@@ -570,6 +582,7 @@ mod tests {
             WorktreeRow {
                 name: "feat-b".into(),
                 branch: "feat/b".into(),
+                path: "/tmp/wt/feat-b".into(),
                 status: "~2".into(),
                 ahead_behind: "+1/-0".into(),
                 managed: true,
@@ -577,6 +590,7 @@ mod tests {
             WorktreeRow {
                 name: "main".into(),
                 branch: "main".into(),
+                path: "/tmp/wt/main".into(),
                 status: "clean".into(),
                 ahead_behind: "-".into(),
                 managed: false,
@@ -636,12 +650,31 @@ mod tests {
     }
 
     #[test]
-    fn shift_d_on_list_is_handled() {
+    fn d_on_list_pushes_delete_confirm() {
         let mut app = app_with_rows();
-        // D (shift+d) should not crash and should not quit or push a screen
         app.handle_key_event(KeyEvent::new(KeyCode::Char('D'), KeyModifiers::SHIFT));
         assert!(app.is_running());
+        assert_eq!(app.active_screen(), Screen::DeleteConfirm);
+        assert_eq!(app.nav_stack_depth(), 2);
+    }
+
+    #[test]
+    fn d_on_list_sets_delete_confirm_state_with_selected_worktree() {
+        let mut app = app_with_rows();
+        app.list_state.selected = 1; // select feat-b
+        app.handle_key_event(KeyEvent::new(KeyCode::Char('D'), KeyModifiers::SHIFT));
+        let state = app.delete_confirm_state.as_ref().expect("delete_confirm_state should be set");
+        assert_eq!(state.worktree_name, "feat-b");
+        assert_eq!(state.worktree_path, "/tmp/wt/feat-b");
+        assert_eq!(state.branch, "feat/b");
+    }
+
+    #[test]
+    fn d_on_empty_list_does_not_push_delete_confirm() {
+        let mut app = App::new();
+        app.handle_key_event(KeyEvent::new(KeyCode::Char('D'), KeyModifiers::SHIFT));
         assert_eq!(app.active_screen(), Screen::List);
+        assert!(app.delete_confirm_state.is_none());
     }
 
     #[test]

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -181,7 +181,18 @@ impl App {
         match (key.code, key.modifiers) {
             (KeyCode::Char('c'), KeyModifiers::CONTROL) => self.running = false,
             (KeyCode::Char('?'), _) => self.push_screen(Screen::Help),
-            (KeyCode::Esc, _) | (KeyCode::Char('q'), _) => self.pop_screen(),
+            (KeyCode::Esc, _) | (KeyCode::Char('q'), _) => {
+                match self.active_screen() {
+                    Screen::DeleteConfirm => {
+                        self.delete_confirm_state = None;
+                    }
+                    Screen::SyncPicker => {
+                        self.sync_picker_state = None;
+                    }
+                    _ => {}
+                }
+                self.pop_screen();
+            }
             _ => self.handle_screen_key(key),
         }
     }
@@ -1123,6 +1134,61 @@ mod tests {
         app.handle_key_event(KeyEvent::new(KeyCode::Char(' '), KeyModifiers::NONE));
         assert_eq!(app.active_screen(), Screen::List, "Space in result mode should pop to list");
         assert!(app.delete_confirm_state.is_none());
+    }
+
+    #[test]
+    fn esc_on_delete_confirm_clears_state() {
+        let mut app = App::new();
+        app.delete_confirm_state = Some(screens::delete_confirm::DeleteConfirmState::new(
+            "feat-auth", "/tmp/wt/feat-auth", "feature/auth",
+        ));
+        app.push_screen(Screen::DeleteConfirm);
+
+        app.handle_key_event(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
+        assert_eq!(app.active_screen(), Screen::List, "Esc should pop back to List");
+        assert!(app.delete_confirm_state.is_none(), "Esc should clear delete_confirm_state");
+    }
+
+    #[test]
+    fn q_on_delete_confirm_clears_state() {
+        let mut app = App::new();
+        app.delete_confirm_state = Some(screens::delete_confirm::DeleteConfirmState::new(
+            "feat-auth", "/tmp/wt/feat-auth", "feature/auth",
+        ));
+        app.push_screen(Screen::DeleteConfirm);
+
+        app.handle_key_event(KeyEvent::new(KeyCode::Char('q'), KeyModifiers::NONE));
+        assert_eq!(app.active_screen(), Screen::List);
+        assert!(app.delete_confirm_state.is_none(), "q should clear delete_confirm_state");
+    }
+
+    #[test]
+    fn esc_on_delete_result_mode_clears_state() {
+        let mut app = App::new();
+        let mut state = screens::delete_confirm::DeleteConfirmState::new(
+            "feat-auth", "/tmp/wt/feat-auth", "feature/auth",
+        );
+        state.result = Some(screens::delete_confirm::DeleteResultMessage {
+            success: true,
+            message: "Done".into(),
+        });
+        app.delete_confirm_state = Some(state);
+        app.push_screen(Screen::DeleteConfirm);
+
+        app.handle_key_event(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
+        assert_eq!(app.active_screen(), Screen::List, "Esc in result mode should pop to List");
+        assert!(app.delete_confirm_state.is_none(), "Esc in result mode should clear state");
+    }
+
+    #[test]
+    fn esc_on_sync_picker_clears_state() {
+        let mut app = App::new();
+        app.sync_picker_state = Some(screens::sync_picker::SyncPickerState::new("feat-auth"));
+        app.push_screen(Screen::SyncPicker);
+
+        app.handle_key_event(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
+        assert_eq!(app.active_screen(), Screen::List);
+        assert!(app.sync_picker_state.is_none(), "Esc should clear sync_picker_state");
     }
 
     #[test]

--- a/src/tui/screens/delete_confirm.rs
+++ b/src/tui/screens/delete_confirm.rs
@@ -65,8 +65,17 @@ fn render_confirm(state: &DeleteConfirmState, frame: &mut Frame, area: Rect) {
         chunks[1],
     );
 
-    // Path
-    let path_line = Line::from(Span::raw(&state.worktree_path));
+    // Path (truncate with leading ellipsis if too long for 60-col dialog)
+    let max_path_len = 56;
+    let path_display = if state.worktree_path.len() > max_path_len {
+        format!(
+            "\u{2026}{}",
+            &state.worktree_path[state.worktree_path.len() - (max_path_len - 1)..]
+        )
+    } else {
+        state.worktree_path.clone()
+    };
+    let path_line = Line::from(Span::raw(path_display));
     frame.render_widget(
         Paragraph::new(path_line).alignment(Alignment::Center),
         chunks[2],
@@ -309,6 +318,16 @@ mod tests {
         let buf = render_to_buffer(&state, 80, 20);
         let text = buffer_text(&buf);
         assert!(text.contains("Enter/Space dismiss"), "result footer should show Enter/Space dismiss");
+    }
+
+    #[test]
+    fn long_path_is_truncated_with_ellipsis() {
+        let long_path = "/home/user/projects/company/very-long-project-name/.worktrees/feature-branch-with-extra-long-name";
+        let state = DeleteConfirmState::new("feat-auth", long_path, "feature/auth");
+        let buf = render_to_buffer(&state, 80, 20);
+        let text = buffer_text(&buf);
+        assert!(text.contains("\u{2026}"), "long path should be truncated with ellipsis");
+        assert!(!text.contains(long_path), "full long path should NOT appear in dialog");
     }
 
     #[test]

--- a/src/tui/screens/delete_confirm.rs
+++ b/src/tui/screens/delete_confirm.rs
@@ -122,8 +122,7 @@ fn render_result(
     let chunks = Layout::vertical([
         Constraint::Length(1), // blank
         Constraint::Length(1), // title
-        Constraint::Length(1), // message
-        Constraint::Min(0),   // spacer
+        Constraint::Min(1),    // message (multi-line errors)
         Constraint::Length(1), // footer
     ])
     .split(inner);
@@ -151,7 +150,7 @@ fn render_result(
 
     let footer = Paragraph::new(Line::from(RESULT_FOOTER))
         .style(Style::default().add_modifier(Modifier::REVERSED));
-    frame.render_widget(footer, chunks[4]);
+    frame.render_widget(footer, chunks[3]);
 }
 
 /// View model for the delete confirmation dialog.
@@ -339,7 +338,29 @@ mod tests {
         let state = DeleteConfirmState::new("feat-auth", &long_path, "feature/auth");
         let buf = render_to_buffer(&state, 80, 20);
         let text = buffer_text(&buf);
-        assert!(text.contains("\u{2026}"), "long multibyte path should be truncated with ellipsis");
+        assert!(
+            text.contains("\u{2026}"),
+            "long multibyte path should be truncated with ellipsis"
+        );
+    }
+
+    #[test]
+    fn multiline_result_message_is_fully_visible() {
+        let mut state = DeleteConfirmState::new("feat-auth", "/tmp/wt/feat-auth", "feature/auth");
+        state.result = Some(DeleteResultMessage {
+            success: false,
+            message: "Delete failed: git error\ncaused by: lock file exists".into(),
+        });
+        let buf = render_to_buffer(&state, 80, 20);
+        let text = buffer_text(&buf);
+        assert!(
+            text.contains("git error"),
+            "first line of message should be visible"
+        );
+        assert!(
+            text.contains("lock file"),
+            "second line of message should be visible"
+        );
     }
 
     #[test]

--- a/src/tui/screens/delete_confirm.rs
+++ b/src/tui/screens/delete_confirm.rs
@@ -1,0 +1,71 @@
+use ratatui::{Frame, layout::Rect};
+
+pub fn render(_state: &DeleteConfirmState, _frame: &mut Frame, _area: Rect) {
+    // TODO: implement centered overlay rendering
+}
+
+/// View model for the delete confirmation dialog.
+#[derive(Debug, Clone, PartialEq)]
+pub struct DeleteConfirmState {
+    /// Name of the worktree to delete.
+    pub worktree_name: String,
+    /// Filesystem path of the worktree.
+    pub worktree_path: String,
+    /// Branch checked out in the worktree.
+    pub branch: String,
+    /// Result message after deletion. None = confirm mode, Some = result mode.
+    pub result: Option<DeleteResultMessage>,
+}
+
+/// Outcome displayed after a delete operation completes.
+#[derive(Debug, Clone, PartialEq)]
+pub struct DeleteResultMessage {
+    pub success: bool,
+    pub message: String,
+}
+
+impl DeleteConfirmState {
+    pub fn new(worktree_name: &str, worktree_path: &str, branch: &str) -> Self {
+        Self {
+            worktree_name: worktree_name.to_string(),
+            worktree_path: worktree_path.to_string(),
+            branch: branch.to_string(),
+            result: None,
+        }
+    }
+
+    /// Whether the dialog is showing a result (post-delete).
+    pub fn is_result_mode(&self) -> bool {
+        self.result.is_some()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn delete_confirm_state_holds_worktree_info() {
+        let state = DeleteConfirmState::new("feat-auth", "/home/user/.worktrees/repo/feat-auth", "feature/auth");
+        assert_eq!(state.worktree_name, "feat-auth");
+        assert_eq!(state.worktree_path, "/home/user/.worktrees/repo/feat-auth");
+        assert_eq!(state.branch, "feature/auth");
+    }
+
+    #[test]
+    fn delete_confirm_starts_in_confirm_mode() {
+        let state = DeleteConfirmState::new("feat-auth", "/tmp/wt", "feature/auth");
+        assert!(!state.is_result_mode());
+        assert!(state.result.is_none());
+    }
+
+    #[test]
+    fn is_result_mode_true_after_setting_result() {
+        let mut state = DeleteConfirmState::new("feat-auth", "/tmp/wt", "feature/auth");
+        state.result = Some(DeleteResultMessage {
+            success: true,
+            message: "Removed 'feat-auth'".into(),
+        });
+        assert!(state.is_result_mode());
+    }
+}

--- a/src/tui/screens/delete_confirm.rs
+++ b/src/tui/screens/delete_confirm.rs
@@ -7,7 +7,7 @@ use ratatui::{
 };
 
 const CONFIRM_FOOTER: &str = " Enter/y confirm  Esc/n cancel ";
-const RESULT_FOOTER: &str = " Enter dismiss ";
+const RESULT_FOOTER: &str = " Enter/Space dismiss ";
 
 pub fn render(state: &DeleteConfirmState, frame: &mut Frame, area: Rect) {
     if let Some(ref result) = state.result {
@@ -308,7 +308,19 @@ mod tests {
         });
         let buf = render_to_buffer(&state, 80, 20);
         let text = buffer_text(&buf);
-        assert!(text.contains("Enter dismiss"), "result footer should show Enter dismiss");
+        assert!(text.contains("Enter/Space dismiss"), "result footer should show Enter/Space dismiss");
+    }
+
+    #[test]
+    fn result_footer_mentions_space() {
+        let mut state = DeleteConfirmState::new("feat-auth", "/tmp/wt/feat-auth", "feature/auth");
+        state.result = Some(DeleteResultMessage {
+            success: true,
+            message: "Done".into(),
+        });
+        let buf = render_to_buffer(&state, 80, 20);
+        let text = buffer_text(&buf);
+        assert!(text.contains("Space"), "result footer should mention Space key");
     }
 
     #[test]

--- a/src/tui/screens/delete_confirm.rs
+++ b/src/tui/screens/delete_confirm.rs
@@ -66,12 +66,12 @@ fn render_confirm(state: &DeleteConfirmState, frame: &mut Frame, area: Rect) {
     );
 
     // Path (truncate with leading ellipsis if too long for 60-col dialog)
-    let max_path_len = 56;
-    let path_display = if state.worktree_path.len() > max_path_len {
-        format!(
-            "\u{2026}{}",
-            &state.worktree_path[state.worktree_path.len() - (max_path_len - 1)..]
-        )
+    let max_path_chars = 56;
+    let path_len = state.worktree_path.chars().count();
+    let path_display = if path_len > max_path_chars {
+        let keep = max_path_chars - 1;
+        let suffix: String = state.worktree_path.chars().skip(path_len - keep).collect();
+        format!("\u{2026}{suffix}")
     } else {
         state.worktree_path.clone()
     };
@@ -328,6 +328,18 @@ mod tests {
         let text = buffer_text(&buf);
         assert!(text.contains("\u{2026}"), "long path should be truncated with ellipsis");
         assert!(!text.contains(long_path), "full long path should NOT appear in dialog");
+    }
+
+    #[test]
+    fn long_path_with_multibyte_chars_does_not_panic() {
+        // "/tmp/ñ" = 7 bytes (ñ at indices 5-6). With 54 ASCII chars appended,
+        // total = 61 bytes. Byte-slice at [61-55..] = [6..] lands on 0xB1,
+        // the second byte of ñ — a byte-based slice would panic here.
+        let long_path = format!("/tmp/ñ{}", "a".repeat(54));
+        let state = DeleteConfirmState::new("feat-auth", &long_path, "feature/auth");
+        let buf = render_to_buffer(&state, 80, 20);
+        let text = buffer_text(&buf);
+        assert!(text.contains("\u{2026}"), "long multibyte path should be truncated with ellipsis");
     }
 
     #[test]

--- a/src/tui/screens/delete_confirm.rs
+++ b/src/tui/screens/delete_confirm.rs
@@ -52,12 +52,31 @@ fn render_confirm(state: &DeleteConfirmState, frame: &mut Frame, area: Rect) {
     ])
     .split(inner);
 
-    // Name + branch
+    // Name + branch (truncate branch if combined line exceeds inner width)
+    let max_line_chars = 56;
+    let overhead = 11; // "Delete " (7) + "  (" (3) + ")" (1)
+    let max_content = max_line_chars - overhead;
+    let name_len = state.worktree_name.chars().count();
+    let branch_len = state.branch.chars().count();
+    let branch_display = if name_len + branch_len > max_content {
+        let available = max_content.saturating_sub(name_len);
+        if available >= 2 {
+            let keep = available - 1;
+            format!(
+                "{}\u{2026}",
+                state.branch.chars().take(keep).collect::<String>()
+            )
+        } else {
+            "\u{2026}".to_string()
+        }
+    } else {
+        state.branch.clone()
+    };
     let name_line = Line::from(vec![
         Span::styled("Delete ", bold),
         Span::styled(&state.worktree_name, bold),
         Span::raw("  ("),
-        Span::raw(&state.branch),
+        Span::raw(branch_display),
         Span::raw(")"),
     ]);
     frame.render_widget(
@@ -360,6 +379,23 @@ mod tests {
         assert!(
             text.contains("lock file"),
             "second line of message should be visible"
+        );
+    }
+
+    #[test]
+    fn long_branch_name_is_truncated_in_confirm_dialog() {
+        let long_branch =
+            "feature/very-long-descriptive-branch-name-that-exceeds-dialog-width";
+        let state = DeleteConfirmState::new("feat-auth", "/tmp/wt/feat-auth", long_branch);
+        let buf = render_to_buffer(&state, 80, 20);
+        let text = buffer_text(&buf);
+        assert!(
+            text.contains("\u{2026}"),
+            "long branch should be truncated with ellipsis"
+        );
+        assert!(
+            !text.contains(long_branch),
+            "full branch name should NOT appear in dialog"
         );
     }
 

--- a/src/tui/screens/delete_confirm.rs
+++ b/src/tui/screens/delete_confirm.rs
@@ -1,7 +1,148 @@
-use ratatui::{Frame, layout::Rect};
+use ratatui::{
+    layout::{Alignment, Constraint, Flex, Layout, Rect},
+    style::{Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Clear, Paragraph},
+    Frame,
+};
 
-pub fn render(_state: &DeleteConfirmState, _frame: &mut Frame, _area: Rect) {
-    // TODO: implement centered overlay rendering
+const CONFIRM_FOOTER: &str = " Enter/y confirm  Esc/n cancel ";
+const RESULT_FOOTER: &str = " Enter dismiss ";
+
+pub fn render(state: &DeleteConfirmState, frame: &mut Frame, area: Rect) {
+    if let Some(ref result) = state.result {
+        render_result(state, result, frame, area);
+    } else {
+        render_confirm(state, frame, area);
+    }
+}
+
+/// Compute a centered rectangle within `area`.
+fn centered_rect(width: u16, height: u16, area: Rect) -> Rect {
+    let [area] = Layout::vertical([Constraint::Length(height)])
+        .flex(Flex::Center)
+        .areas(area);
+    let [area] = Layout::horizontal([Constraint::Length(width)])
+        .flex(Flex::Center)
+        .areas(area);
+    area
+}
+
+fn render_confirm(state: &DeleteConfirmState, frame: &mut Frame, area: Rect) {
+    let bold = Style::default().add_modifier(Modifier::BOLD);
+
+    let dialog_area = centered_rect(60, 10, area);
+    frame.render_widget(Clear, dialog_area);
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(" Delete Worktree ")
+        .title_alignment(Alignment::Center);
+    let inner = block.inner(dialog_area);
+    frame.render_widget(block, dialog_area);
+
+    let chunks = Layout::vertical([
+        Constraint::Length(1), // blank
+        Constraint::Length(1), // name + branch
+        Constraint::Length(1), // path
+        Constraint::Length(1), // blank
+        Constraint::Length(1), // warning
+        Constraint::Min(0),   // spacer
+        Constraint::Length(1), // footer
+    ])
+    .split(inner);
+
+    // Name + branch
+    let name_line = Line::from(vec![
+        Span::styled("Delete ", bold),
+        Span::styled(&state.worktree_name, bold),
+        Span::raw("  ("),
+        Span::raw(&state.branch),
+        Span::raw(")"),
+    ]);
+    frame.render_widget(
+        Paragraph::new(name_line).alignment(Alignment::Center),
+        chunks[1],
+    );
+
+    // Path
+    let path_line = Line::from(Span::raw(&state.worktree_path));
+    frame.render_widget(
+        Paragraph::new(path_line).alignment(Alignment::Center),
+        chunks[2],
+    );
+
+    // Warning
+    let warning = Line::from(Span::styled(
+        "⚠ Pre-remove hooks will run before deletion",
+        Style::default().add_modifier(Modifier::DIM),
+    ));
+    frame.render_widget(
+        Paragraph::new(warning).alignment(Alignment::Center),
+        chunks[4],
+    );
+
+    // Footer
+    let footer = Paragraph::new(Line::from(CONFIRM_FOOTER))
+        .style(Style::default().add_modifier(Modifier::REVERSED));
+    frame.render_widget(footer, chunks[6]);
+}
+
+fn render_result(
+    state: &DeleteConfirmState,
+    result: &DeleteResultMessage,
+    frame: &mut Frame,
+    area: Rect,
+) {
+    let bold = Style::default().add_modifier(Modifier::BOLD);
+
+    let dialog_area = centered_rect(60, 8, area);
+    frame.render_widget(Clear, dialog_area);
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(if result.success {
+            " Removed "
+        } else {
+            " Delete Failed "
+        })
+        .title_alignment(Alignment::Center);
+    let inner = block.inner(dialog_area);
+    frame.render_widget(block, dialog_area);
+
+    let chunks = Layout::vertical([
+        Constraint::Length(1), // blank
+        Constraint::Length(1), // title
+        Constraint::Length(1), // message
+        Constraint::Min(0),   // spacer
+        Constraint::Length(1), // footer
+    ])
+    .split(inner);
+
+    let status = if result.success {
+        "Worktree removed"
+    } else {
+        "Deletion failed"
+    };
+    let title_line = Line::from(vec![
+        Span::styled(status, bold),
+        Span::raw(" — "),
+        Span::raw(&state.worktree_name),
+    ]);
+    frame.render_widget(
+        Paragraph::new(title_line).alignment(Alignment::Center),
+        chunks[1],
+    );
+
+    let msg_lines: Vec<Line> = result.message.lines().map(Line::from).collect();
+    frame.render_widget(
+        Paragraph::new(msg_lines).alignment(Alignment::Center),
+        chunks[2],
+    );
+
+    let footer = Paragraph::new(Line::from(RESULT_FOOTER))
+        .style(Style::default().add_modifier(Modifier::REVERSED));
+    frame.render_widget(footer, chunks[4]);
 }
 
 /// View model for the delete confirmation dialog.
@@ -44,6 +185,19 @@ impl DeleteConfirmState {
 mod tests {
     use super::*;
 
+    fn render_to_buffer(state: &DeleteConfirmState, width: u16, height: u16) -> ratatui::buffer::Buffer {
+        let backend = ratatui::backend::TestBackend::new(width, height);
+        let mut terminal = ratatui::Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| render(state, frame, frame.area()))
+            .unwrap();
+        terminal.backend().buffer().clone()
+    }
+
+    fn buffer_text(buf: &ratatui::buffer::Buffer) -> String {
+        buf.content().iter().map(|cell| cell.symbol()).collect()
+    }
+
     #[test]
     fn delete_confirm_state_holds_worktree_info() {
         let state = DeleteConfirmState::new("feat-auth", "/home/user/.worktrees/repo/feat-auth", "feature/auth");
@@ -67,5 +221,126 @@ mod tests {
             message: "Removed 'feat-auth'".into(),
         });
         assert!(state.is_result_mode());
+    }
+
+    #[test]
+    fn renders_worktree_name_in_confirm_dialog() {
+        let state = DeleteConfirmState::new("feat-auth", "/tmp/wt/feat-auth", "feature/auth");
+        let buf = render_to_buffer(&state, 80, 20);
+        let text = buffer_text(&buf);
+        assert!(text.contains("feat-auth"), "should show worktree name, got: {text}");
+    }
+
+    #[test]
+    fn renders_worktree_path_in_confirm_dialog() {
+        let state = DeleteConfirmState::new("feat-auth", "/tmp/wt/feat-auth", "feature/auth");
+        let buf = render_to_buffer(&state, 80, 20);
+        let text = buffer_text(&buf);
+        assert!(text.contains("/tmp/wt/feat-auth"), "should show worktree path");
+    }
+
+    #[test]
+    fn renders_branch_in_confirm_dialog() {
+        let state = DeleteConfirmState::new("feat-auth", "/tmp/wt/feat-auth", "feature/auth");
+        let buf = render_to_buffer(&state, 80, 20);
+        let text = buffer_text(&buf);
+        assert!(text.contains("feature/auth"), "should show branch name");
+    }
+
+    #[test]
+    fn renders_warning_about_hooks() {
+        let state = DeleteConfirmState::new("feat-auth", "/tmp/wt/feat-auth", "feature/auth");
+        let buf = render_to_buffer(&state, 80, 20);
+        let text = buffer_text(&buf);
+        assert!(text.contains("hook"), "should show warning about hooks");
+    }
+
+    #[test]
+    fn renders_confirm_footer_keybindings() {
+        let state = DeleteConfirmState::new("feat-auth", "/tmp/wt/feat-auth", "feature/auth");
+        let buf = render_to_buffer(&state, 80, 20);
+        let text = buffer_text(&buf);
+        assert!(text.contains("Enter"), "footer should show Enter");
+        assert!(text.contains("confirm"), "footer should show confirm");
+        assert!(text.contains("cancel"), "footer should show cancel");
+    }
+
+    #[test]
+    fn renders_dialog_title() {
+        let state = DeleteConfirmState::new("feat-auth", "/tmp/wt/feat-auth", "feature/auth");
+        let buf = render_to_buffer(&state, 80, 20);
+        let text = buffer_text(&buf);
+        assert!(text.contains("Delete Worktree"), "should show dialog title");
+    }
+
+    #[test]
+    fn renders_success_result() {
+        let mut state = DeleteConfirmState::new("feat-auth", "/tmp/wt/feat-auth", "feature/auth");
+        state.result = Some(DeleteResultMessage {
+            success: true,
+            message: "Removed successfully".into(),
+        });
+        let buf = render_to_buffer(&state, 80, 20);
+        let text = buffer_text(&buf);
+        assert!(text.contains("Removed"), "should show removed title");
+        assert!(text.contains("successfully"), "should show result message");
+    }
+
+    #[test]
+    fn renders_failure_result() {
+        let mut state = DeleteConfirmState::new("feat-auth", "/tmp/wt/feat-auth", "feature/auth");
+        state.result = Some(DeleteResultMessage {
+            success: false,
+            message: "pre_remove hook failed".into(),
+        });
+        let buf = render_to_buffer(&state, 80, 20);
+        let text = buffer_text(&buf);
+        assert!(text.contains("Failed"), "should show failed title");
+        assert!(text.contains("hook failed"), "should show failure message");
+    }
+
+    #[test]
+    fn result_mode_shows_dismiss_footer() {
+        let mut state = DeleteConfirmState::new("feat-auth", "/tmp/wt/feat-auth", "feature/auth");
+        state.result = Some(DeleteResultMessage {
+            success: true,
+            message: "Done".into(),
+        });
+        let buf = render_to_buffer(&state, 80, 20);
+        let text = buffer_text(&buf);
+        assert!(text.contains("Enter dismiss"), "result footer should show Enter dismiss");
+    }
+
+    #[test]
+    fn confirm_dialog_renders_as_overlay_through_app() {
+        // Verify the dialog renders ON TOP of the list (overlay, not full screen)
+        use crate::tui::screens::list::{ListState, WorktreeRow};
+        use crate::tui::{App, Screen};
+
+        let mut app = App::new();
+        app.list_state = ListState::new(vec![WorktreeRow {
+            name: "feat-a".into(),
+            branch: "feat/a".into(),
+            path: "/tmp/wt/feat-a".into(),
+            status: "clean".into(),
+            ahead_behind: "+0/-0".into(),
+            managed: true,
+        }]);
+        app.delete_confirm_state = Some(DeleteConfirmState::new(
+            "feat-a",
+            "/tmp/wt/feat-a",
+            "feat/a",
+        ));
+        app.push_screen(Screen::DeleteConfirm);
+
+        let backend = ratatui::backend::TestBackend::new(100, 24);
+        let mut terminal = ratatui::Terminal::new(backend).unwrap();
+        terminal.draw(|frame| app.ui(frame)).unwrap();
+        let buffer = terminal.backend().buffer().clone();
+        let content: String = buffer.content().iter().map(|cell| cell.symbol()).collect();
+
+        // Dialog content should be visible
+        assert!(content.contains("Delete Worktree"), "dialog should be visible");
+        assert!(content.contains("feat-a"), "dialog should show worktree name");
     }
 }

--- a/src/tui/screens/list.rs
+++ b/src/tui/screens/list.rs
@@ -19,6 +19,7 @@ use ratatui::{
 pub struct WorktreeRow {
     pub name: String,
     pub branch: String,
+    pub path: String,
     pub status: String,
     pub ahead_behind: String,
     pub managed: bool,
@@ -75,6 +76,7 @@ pub fn load_worktrees(cwd: &Path, db: &Database, scan_paths: &[String]) -> Resul
         rows.push(WorktreeRow {
             name: wt.name.clone(),
             branch: wt.branch.clone(),
+            path: wt.path.clone(),
             status: status.0,
             ahead_behind: status.1,
             managed: true,
@@ -94,6 +96,7 @@ pub fn load_worktrees(cwd: &Path, db: &Database, scan_paths: &[String]) -> Resul
             rows.push(WorktreeRow {
                 name: gw.name.clone(),
                 branch,
+                path: gw.path.to_string_lossy().to_string(),
                 status: status.0,
                 ahead_behind: status.1,
                 managed: false,
@@ -122,6 +125,7 @@ pub fn load_worktrees(cwd: &Path, db: &Database, scan_paths: &[String]) -> Resul
                 rows.push(WorktreeRow {
                     name: sw.name.clone(),
                     branch,
+                    path: sw.path.to_string_lossy().to_string(),
                     status: status.0,
                     ahead_behind: status.1,
                     managed: false,
@@ -242,6 +246,7 @@ mod tests {
             WorktreeRow {
                 name: "feature-auth".into(),
                 branch: "feature/auth".into(),
+                path: "/tmp/wt/feature-auth".into(),
                 status: "clean".into(),
                 ahead_behind: "+1/-0".into(),
                 managed: true,
@@ -249,6 +254,7 @@ mod tests {
             WorktreeRow {
                 name: "fix-bug".into(),
                 branch: "fix/bug".into(),
+                path: "/tmp/wt/fix-bug".into(),
                 status: "~3".into(),
                 ahead_behind: "+0/-2".into(),
                 managed: true,
@@ -256,6 +262,7 @@ mod tests {
             WorktreeRow {
                 name: "main".into(),
                 branch: "main".into(),
+                path: "/tmp/wt/main".into(),
                 status: "clean".into(),
                 ahead_behind: "-".into(),
                 managed: false,

--- a/src/tui/screens/mod.rs
+++ b/src/tui/screens/mod.rs
@@ -1,3 +1,4 @@
+pub mod delete_confirm;
 pub mod detail;
 pub mod list;
 pub mod sync_picker;

--- a/src/tui/screens/sync_picker.rs
+++ b/src/tui/screens/sync_picker.rs
@@ -74,7 +74,7 @@ impl SyncPickerState {
 }
 
 const SYNC_PICKER_FOOTER: &str = " ↑/↓ or j/k select  Enter confirm  Esc cancel ";
-const SYNC_RESULT_FOOTER: &str = " Enter dismiss  Esc back ";
+const SYNC_RESULT_FOOTER: &str = " Enter/Space dismiss  Esc back ";
 
 pub fn render(state: &SyncPickerState, frame: &mut Frame, area: Rect) {
     if let Some(ref result) = state.result {


### PR DESCRIPTION
Closes #46

## Summary
Implements a TUI confirmation dialog for destructive delete operations. Pressing `D` on the worktree list opens a centered modal overlay showing the worktree name, path, branch, and a hook warning. `Enter`/`y` confirms deletion (executing the remove command), `Esc`/`n` cancels. After deletion, a result screen shows success or failure before dismissing back to the refreshed list.

## User Stories Addressed
- US-11: TUI delete workflow — `D` triggers delete with confirmation dialog
- US-8: Safe removal with confirmation — dialog prevents accidental deletion

## Automated Testing
- Total tests added: 22
- Tests passing: 22
- Tests failing: 0
- `cargo clippy`: pass
- `cargo test`: pass (571 total: 563 unit + 8 integration)

## UAT Checklist
- [ ] Open TUI with `trench`, select a worktree, press `D` → confirm dialog appears as centered overlay
- [ ] Dialog shows the correct worktree name, path, and branch
- [ ] Dialog shows warning about pre-remove hooks
- [ ] Press `Esc` → dialog closes, no deletion occurs
- [ ] Press `n` → dialog closes, no deletion occurs
- [ ] Press `Enter` → worktree is deleted, result message shown
- [ ] Press `y` → worktree is deleted, result message shown
- [ ] After result message, press `Enter` → returns to list, deleted worktree is gone
- [ ] Press `D` on an empty list → nothing happens
- [ ] Delete a worktree with pre_remove hooks configured → hooks execute before deletion

## Known Issues
None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a delete-confirmation overlay for removing worktrees; invoke with D on a selected row, confirm with Enter or Y, cancel with N, Esc, or q.
  * Shows a post-delete result overlay with clear success/failure messages; Enter or Space dismiss results.
  * Global input clears overlays (Esc/q) before leaving the list.

* **Tests**
  * Added comprehensive tests covering the delete-confirm flow, result handling, key behavior, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->