### PR TITLE
feat(remove): add --dry-run support to trench remove

### DIFF
--- a/src/cli/commands/remove.rs
+++ b/src/cli/commands/remove.rs
@@ -1,3 +1,4 @@
+use std::fmt;
 use std::path::Path;
 
 use anyhow::{Context, Result};
@@ -44,6 +45,61 @@ pub struct RemoveResult {
     /// Whether the remote branch was pruned (only `true` if `--prune` was
     /// requested and the remote branch existed).
     pub pruned_remote: bool,
+}
+
+/// Plan produced by `--dry-run` showing what `trench remove` would do.
+#[derive(Debug, serde::Serialize)]
+pub struct RemoveDryRunPlan {
+    /// Always `true` — signals this is a preview, not a real operation.
+    pub dry_run: bool,
+    pub name: String,
+    pub branch: String,
+    pub path: String,
+    pub prune: bool,
+    pub hooks: Option<RemoveDryRunHooks>,
+}
+
+/// Hook definitions included in a remove dry-run plan.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct RemoveDryRunHooks {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pre_remove: Option<crate::config::HookDef>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub post_remove: Option<crate::config::HookDef>,
+}
+
+/// Execute a dry-run of `trench remove <identifier>`.
+///
+/// Resolves the worktree and builds a plan, but performs no git operations,
+/// no DB writes, and no hook execution.
+pub fn execute_dry_run(
+    identifier: &str,
+    cwd: &Path,
+    db: Option<&Database>,
+    prune: bool,
+    hooks_config: Option<&HooksConfig>,
+    no_hooks: bool,
+) -> Result<RemoveDryRunPlan> {
+    let repo_info = crate::git::discover_repo(cwd)?;
+    let (_repo, wt) = crate::adopt::resolve_only(identifier, &repo_info, db)?;
+
+    let hooks = if no_hooks {
+        None
+    } else {
+        hooks_config.map(|h| RemoveDryRunHooks {
+            pre_remove: h.pre_remove.clone(),
+            post_remove: h.post_remove.clone(),
+        })
+    };
+
+    Ok(RemoveDryRunPlan {
+        dry_run: true,
+        name: wt.name.clone(),
+        branch: wt.branch.clone(),
+        path: wt.path.clone(),
+        prune,
+        hooks,
+    })
 }
 
 /// Execute the `trench remove <identifier>` command.
@@ -1073,5 +1129,49 @@ mod tests {
         // DB should still have removed_at set
         let wt_record = db.get_worktree(wt.id).unwrap().unwrap();
         assert!(wt_record.removed_at.is_some(), "removed_at should be set");
+    }
+
+    // ── Dry-run tests ──────────────────────────────────────────────────
+
+    #[test]
+    fn dry_run_returns_plan_with_worktree_details_and_hooks() {
+        let repo_dir = tempfile::tempdir().unwrap();
+        let _repo = init_repo_with_commit(repo_dir.path());
+        let wt_root = tempfile::tempdir().unwrap();
+        let db_dir = tempfile::tempdir().unwrap();
+        let db = Database::open(&db_dir.path().join("test.db")).unwrap();
+
+        // Create a worktree first
+        crate::cli::commands::create::execute(
+            "dry-run-test",
+            None,
+            repo_dir.path(),
+            wt_root.path(),
+            crate::paths::DEFAULT_WORKTREE_TEMPLATE,
+            &db,
+        )
+        .expect("create should succeed");
+
+        let hooks = sample_hooks_config();
+
+        let plan = execute_dry_run(
+            "dry-run-test",
+            repo_dir.path(),
+            Some(&db),
+            false, // prune
+            Some(&hooks),
+            false, // no_hooks
+        )
+        .expect("dry-run should succeed");
+
+        assert!(plan.dry_run);
+        assert_eq!(plan.name, "dry-run-test");
+        assert_eq!(plan.branch, "dry-run-test");
+        assert!(!plan.prune);
+        assert!(plan.hooks.is_some());
+
+        let plan_hooks = plan.hooks.unwrap();
+        assert!(plan_hooks.pre_remove.is_some());
+        assert!(plan_hooks.post_remove.is_some());
     }
 }

--- a/src/cli/commands/remove.rs
+++ b/src/cli/commands/remove.rs
@@ -135,9 +135,16 @@ pub fn execute_dry_run(
     let hooks = if no_hooks {
         None
     } else {
-        hooks_config.map(|h| RemoveDryRunHooks {
-            pre_remove: h.pre_remove.clone(),
-            post_remove: h.post_remove.clone(),
+        hooks_config.and_then(|h| {
+            let hooks = RemoveDryRunHooks {
+                pre_remove: h.pre_remove.clone(),
+                post_remove: h.post_remove.clone(),
+            };
+            if hooks.pre_remove.is_none() && hooks.post_remove.is_none() {
+                None
+            } else {
+                Some(hooks)
+            }
         })
     };
 
@@ -1325,5 +1332,36 @@ mod tests {
 
         assert!(plan.prune, "prune should be true");
         assert!(plan.hooks.is_none(), "no hooks configured");
+    }
+
+    #[test]
+    fn dry_run_empty_hooks_config_normalizes_to_none() {
+        let (repo_dir, _wt_root, _db_dir, db) = create_worktree_for_dry_run("empty-hooks");
+
+        // HooksConfig exists but both pre_remove and post_remove are None
+        let empty_hooks = crate::config::HooksConfig {
+            pre_create: None,
+            post_create: None,
+            pre_remove: None,
+            post_remove: None,
+            pre_sync: None,
+            post_sync: None,
+        };
+
+        let plan = execute_dry_run(
+            "empty-hooks",
+            repo_dir.path(),
+            Some(&db),
+            false,
+            Some(&empty_hooks),
+            false,
+        )
+        .expect("dry-run should succeed");
+
+        assert!(
+            plan.hooks.is_none(),
+            "empty hooks config should normalize to None, got: {:?}",
+            plan.hooks
+        );
     }
 }

--- a/src/cli/commands/remove.rs
+++ b/src/cli/commands/remove.rs
@@ -59,6 +59,55 @@ pub struct RemoveDryRunPlan {
     pub hooks: Option<RemoveDryRunHooks>,
 }
 
+impl fmt::Display for RemoveDryRunPlan {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "Dry run — no changes will be made\n")?;
+        writeln!(f, "  Worktree:  {}", self.name)?;
+        writeln!(f, "  Branch:    {}", self.branch)?;
+        writeln!(f, "  Path:      {}", self.path)?;
+        writeln!(
+            f,
+            "  Prune:     {}",
+            if self.prune { "yes" } else { "no" }
+        )?;
+
+        match &self.hooks {
+            Some(hooks) if hooks.pre_remove.is_some() || hooks.post_remove.is_some() => {
+                writeln!(f, "  Hooks:")?;
+                if let Some(h) = &hooks.pre_remove {
+                    writeln!(f, "    pre_remove:")?;
+                    format_hook_def(f, h)?;
+                }
+                if let Some(h) = &hooks.post_remove {
+                    writeln!(f, "    post_remove:")?;
+                    format_hook_def(f, h)?;
+                }
+            }
+            _ => {
+                writeln!(f, "  Hooks:     (none)")?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+fn format_hook_def(f: &mut fmt::Formatter<'_>, hook: &crate::config::HookDef) -> fmt::Result {
+    if let Some(copy) = &hook.copy {
+        writeln!(f, "      copy: {}", copy.join(", "))?;
+    }
+    if let Some(run) = &hook.run {
+        writeln!(f, "      run:  {}", run.join(", "))?;
+    }
+    if let Some(shell) = &hook.shell {
+        writeln!(f, "      shell: {shell}")?;
+    }
+    if let Some(timeout) = &hook.timeout_secs {
+        writeln!(f, "      timeout: {timeout}s")?;
+    }
+    Ok(())
+}
+
 /// Hook definitions included in a remove dry-run plan.
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct RemoveDryRunHooks {
@@ -1206,6 +1255,58 @@ mod tests {
         assert!(plan.dry_run);
         assert_eq!(plan.name, "no-hooks-dry");
         assert!(plan.hooks.is_none(), "hooks should be None when --no-hooks");
+    }
+
+    #[test]
+    fn dry_run_display_shows_human_readable_plan() {
+        let (repo_dir, _wt_root, _db_dir, db) = create_worktree_for_dry_run("display-test");
+
+        let hooks = sample_hooks_config();
+
+        let plan = execute_dry_run(
+            "display-test",
+            repo_dir.path(),
+            Some(&db),
+            true,
+            Some(&hooks),
+            false,
+        )
+        .expect("dry-run should succeed");
+
+        let output = format!("{plan}");
+        assert!(output.contains("Dry run"), "should contain 'Dry run' header");
+        assert!(output.contains("display-test"), "should contain worktree name");
+        assert!(output.contains("pre_remove"), "should show pre_remove hook");
+        assert!(output.contains("post_remove"), "should show post_remove hook");
+        assert!(output.contains("Prune:"), "should mention prune status");
+    }
+
+    #[test]
+    fn dry_run_json_serialization_includes_all_fields() {
+        let (repo_dir, _wt_root, _db_dir, db) = create_worktree_for_dry_run("json-test");
+
+        let hooks = sample_hooks_config();
+
+        let plan = execute_dry_run(
+            "json-test",
+            repo_dir.path(),
+            Some(&db),
+            false,
+            Some(&hooks),
+            false,
+        )
+        .expect("dry-run should succeed");
+
+        let json_str = serde_json::to_string_pretty(&plan).expect("should serialize");
+        let parsed: serde_json::Value = serde_json::from_str(&json_str).unwrap();
+
+        assert_eq!(parsed["dry_run"], true);
+        assert_eq!(parsed["name"], "json-test");
+        assert_eq!(parsed["branch"], "json-test");
+        assert_eq!(parsed["prune"], false);
+        assert!(parsed["hooks"].is_object(), "hooks should be an object");
+        assert!(parsed["hooks"]["pre_remove"].is_object());
+        assert!(parsed["hooks"]["post_remove"].is_object());
     }
 
     #[test]

--- a/src/cli/commands/remove.rs
+++ b/src/cli/commands/remove.rs
@@ -1133,17 +1133,22 @@ mod tests {
 
     // ── Dry-run tests ──────────────────────────────────────────────────
 
-    #[test]
-    fn dry_run_returns_plan_with_worktree_details_and_hooks() {
+    fn create_worktree_for_dry_run(
+        branch: &str,
+    ) -> (
+        tempfile::TempDir,
+        tempfile::TempDir,
+        tempfile::TempDir,
+        Database,
+    ) {
         let repo_dir = tempfile::tempdir().unwrap();
         let _repo = init_repo_with_commit(repo_dir.path());
         let wt_root = tempfile::tempdir().unwrap();
         let db_dir = tempfile::tempdir().unwrap();
         let db = Database::open(&db_dir.path().join("test.db")).unwrap();
 
-        // Create a worktree first
         crate::cli::commands::create::execute(
-            "dry-run-test",
+            branch,
             None,
             repo_dir.path(),
             wt_root.path(),
@@ -1151,6 +1156,13 @@ mod tests {
             &db,
         )
         .expect("create should succeed");
+
+        (repo_dir, wt_root, db_dir, db)
+    }
+
+    #[test]
+    fn dry_run_returns_plan_with_worktree_details_and_hooks() {
+        let (repo_dir, _wt_root, _db_dir, db) = create_worktree_for_dry_run("dry-run-test");
 
         let hooks = sample_hooks_config();
 
@@ -1173,5 +1185,44 @@ mod tests {
         let plan_hooks = plan.hooks.unwrap();
         assert!(plan_hooks.pre_remove.is_some());
         assert!(plan_hooks.post_remove.is_some());
+    }
+
+    #[test]
+    fn dry_run_with_no_hooks_excludes_hooks() {
+        let (repo_dir, _wt_root, _db_dir, db) = create_worktree_for_dry_run("no-hooks-dry");
+
+        let hooks = sample_hooks_config();
+
+        let plan = execute_dry_run(
+            "no-hooks-dry",
+            repo_dir.path(),
+            Some(&db),
+            false,
+            Some(&hooks),
+            true, // no_hooks = true
+        )
+        .expect("dry-run should succeed");
+
+        assert!(plan.dry_run);
+        assert_eq!(plan.name, "no-hooks-dry");
+        assert!(plan.hooks.is_none(), "hooks should be None when --no-hooks");
+    }
+
+    #[test]
+    fn dry_run_with_prune_shows_prune_status() {
+        let (repo_dir, _wt_root, _db_dir, db) = create_worktree_for_dry_run("prune-dry");
+
+        let plan = execute_dry_run(
+            "prune-dry",
+            repo_dir.path(),
+            Some(&db),
+            true, // prune
+            None,
+            false,
+        )
+        .expect("dry-run should succeed");
+
+        assert!(plan.prune, "prune should be true");
+        assert!(plan.hooks.is_none(), "no hooks configured");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -427,7 +427,7 @@ fn run_remove(
     };
 
     if dry_run {
-        let db_path = paths::data_dir()?.join("trench.db");
+        let db_path = paths::data_dir_path()?.join("trench.db");
         let db = if db_path.exists() {
             Some(state::Database::open(&db_path)?)
         } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -228,7 +228,7 @@ fn main() -> anyhow::Result<()> {
             force,
             prune,
             no_hooks,
-        }) => run_remove(&branch, force, prune, no_hooks),
+        }) => run_remove(&branch, force, prune, no_hooks, dry_run, json),
         Some(Commands::Switch { branch, print_path }) => run_switch(&branch, print_path),
         Some(Commands::Tag { branch, tags }) => run_tag(&branch, &tags),
         Some(Commands::Open { branch }) => run_open(&branch),
@@ -405,14 +405,19 @@ fn run_create(
     }
 }
 
-fn run_remove(identifier: &str, force: bool, prune: bool, no_hooks: bool) -> anyhow::Result<()> {
+fn run_remove(
+    identifier: &str,
+    force: bool,
+    prune: bool,
+    no_hooks: bool,
+    dry_run: bool,
+    json: bool,
+) -> anyhow::Result<()> {
     let cwd = std::env::current_dir().context("failed to determine current directory")?;
-    let db_path = paths::data_dir()?.join("trench.db");
-    let db = state::Database::open(&db_path)?;
 
     let repo_info = git::discover_repo(&cwd)?;
 
-    // Skip config I/O when --no-hooks is set (escape hatch)
+    // Load hooks config (skip config I/O when --no-hooks is set)
     let hooks_config = if no_hooks {
         None
     } else {
@@ -420,6 +425,34 @@ fn run_remove(identifier: &str, force: bool, prune: bool, no_hooks: bool) -> any
         let global_config = config::load_global_config()?;
         config::resolve_config(None, project_config.as_ref(), &global_config).hooks
     };
+
+    if dry_run {
+        let db_path = paths::data_dir()?.join("trench.db");
+        let db = if db_path.exists() {
+            Some(state::Database::open(&db_path)?)
+        } else {
+            None
+        };
+
+        let plan = cli::commands::remove::execute_dry_run(
+            identifier,
+            &cwd,
+            db.as_ref(),
+            prune,
+            hooks_config.as_ref(),
+            no_hooks,
+        )?;
+
+        if json {
+            println!("{}", serde_json::to_string_pretty(&plan)?);
+        } else {
+            print!("{plan}");
+        }
+        return Ok(());
+    }
+
+    let db_path = paths::data_dir()?.join("trench.db");
+    let db = state::Database::open(&db_path)?;
 
     // If not forced, resolve the worktree (adopting if unmanaged) for the prompt
     let resolved = if !force {

--- a/tests/exit_codes.rs
+++ b/tests/exit_codes.rs
@@ -279,6 +279,11 @@ fn dry_run_remove_does_not_delete_worktree() {
         .current_dir(tmp.path())
         .output()
         .expect("failed to run trench list");
+    assert!(
+        list_output.status.success(),
+        "trench list --json should succeed, stderr: {}",
+        String::from_utf8_lossy(&list_output.stderr)
+    );
     let list_json: serde_json::Value =
         serde_json::from_slice(&list_output.stdout).expect("list should output valid JSON");
     let wt_path = list_json[0]["path"]

--- a/tests/exit_codes.rs
+++ b/tests/exit_codes.rs
@@ -319,3 +319,74 @@ fn dry_run_remove_does_not_delete_worktree() {
         "stdout should mention the worktree name"
     );
 }
+
+#[test]
+fn dry_run_remove_with_json_outputs_valid_json() {
+    let tmp = tempfile::tempdir().unwrap();
+    init_git_repo(tmp.path());
+
+    create_worktree(tmp.path(), "json-dry-integ");
+
+    // Run remove with --dry-run --json
+    let output = Command::new(trench_bin())
+        .args(["remove", "json-dry-integ", "--force", "--dry-run", "--json"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("failed to run trench remove --dry-run --json");
+
+    assert!(
+        output.status.success(),
+        "dry-run --json should exit 0, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // Parse JSON output
+    let json: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("stdout should be valid JSON");
+
+    assert_eq!(json["dry_run"], true);
+    assert_eq!(json["name"], "json-dry-integ");
+    assert_eq!(json["branch"], "json-dry-integ");
+    assert_eq!(json["prune"], false);
+    assert!(json["path"].is_string(), "path should be a string");
+
+    // Verify worktree still exists
+    let wt_path = json["path"].as_str().unwrap();
+    assert!(
+        Path::new(wt_path).exists(),
+        "worktree should still exist after dry-run --json"
+    );
+}
+
+#[test]
+fn dry_run_remove_with_prune_shows_prune_true() {
+    let tmp = tempfile::tempdir().unwrap();
+    init_git_repo(tmp.path());
+
+    create_worktree(tmp.path(), "prune-dry-integ");
+
+    let output = Command::new(trench_bin())
+        .args([
+            "remove",
+            "prune-dry-integ",
+            "--force",
+            "--prune",
+            "--dry-run",
+            "--json",
+        ])
+        .current_dir(tmp.path())
+        .output()
+        .expect("failed to run trench remove --dry-run --prune --json");
+
+    assert!(
+        output.status.success(),
+        "dry-run --prune --json should exit 0, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("stdout should be valid JSON");
+
+    assert_eq!(json["dry_run"], true);
+    assert_eq!(json["prune"], true, "prune should be true in JSON output");
+}

--- a/tests/exit_codes.rs
+++ b/tests/exit_codes.rs
@@ -11,7 +11,7 @@
 //!   7: Hook timeout
 //!   8: Missing required flag
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 fn trench_bin() -> PathBuf {
@@ -246,5 +246,76 @@ fn exit_code_1_sync_branch_with_all_flag() {
         Some(1),
         "sync with both --all and <BRANCH> should exit 1, stderr: {}",
         String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+// ── Dry-run tests ─────────────────────────────────────────────────────
+
+/// Helper: create a worktree via trench so we can test dry-run removal.
+fn create_worktree(repo_dir: &Path, branch: &str) {
+    let output = Command::new(trench_bin())
+        .args(["create", branch])
+        .current_dir(repo_dir)
+        .output()
+        .expect("failed to run trench create");
+    assert!(
+        output.status.success(),
+        "trench create should succeed, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn dry_run_remove_does_not_delete_worktree() {
+    let tmp = tempfile::tempdir().unwrap();
+    init_git_repo(tmp.path());
+
+    // Create a worktree first
+    create_worktree(tmp.path(), "dry-run-integ");
+
+    // Get the worktree path from list
+    let list_output = Command::new(trench_bin())
+        .args(["list", "--json"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("failed to run trench list");
+    let list_json: serde_json::Value =
+        serde_json::from_slice(&list_output.stdout).expect("list should output valid JSON");
+    let wt_path = list_json[0]["path"]
+        .as_str()
+        .expect("should have worktree path");
+    assert!(
+        Path::new(wt_path).exists(),
+        "worktree should exist before dry-run"
+    );
+
+    // Run remove with --dry-run
+    let output = Command::new(trench_bin())
+        .args(["remove", "dry-run-integ", "--force", "--dry-run"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("failed to run trench remove --dry-run");
+
+    assert!(
+        output.status.success(),
+        "dry-run remove should exit 0, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // Verify worktree still exists (no side effects)
+    assert!(
+        Path::new(wt_path).exists(),
+        "worktree should still exist after dry-run"
+    );
+
+    // Verify stdout contains plan info
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Dry run"),
+        "stdout should contain dry-run plan, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("dry-run-integ"),
+        "stdout should mention the worktree name"
     );
 }


### PR DESCRIPTION
Closes #47

## Summary
Add `--dry-run` support to `trench remove`, showing a preview of what would be removed (worktree name, path, hooks, prune status) without performing any destructive operations. Works with `--json` for machine-readable output and `--no-hooks` to exclude hooks from the plan. The `--no-hooks` flag for actual removal was already implemented in a prior PR.

## User Stories Addressed
- US-8: Preview removal before executing (dry-run shows worktree details, hooks list, prune status)

## Automated Testing
- Total tests added: 8 (5 unit + 3 integration)
- Tests passing: 8
- Tests failing: 0
- `cargo clippy`: pass (0 errors, only pre-existing warnings)
- `cargo test`: pass (599 total: 588 unit + 11 integration)

## UAT Checklist
- [ ] `trench remove my-feature --dry-run` → shows human-readable plan without removing worktree
- [ ] `trench remove my-feature --dry-run --json` → outputs valid JSON with dry_run, name, branch, path, prune fields
- [ ] `trench remove my-feature --dry-run --prune` → plan shows `prune: true`
- [ ] `trench remove my-feature --dry-run --no-hooks` → plan shows no hooks section
- [ ] `trench remove my-feature --no-hooks --force` → removes worktree without running any hooks
- [ ] After `--dry-run`, worktree directory still exists on disk
- [ ] After `--dry-run`, `trench list` still shows the worktree

## Known Issues
None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Preview worktree removals with --dry-run, showing name, branch, path, prune status, and optional hook details.
  * Output dry-run plans as machine-readable JSON via --json.

* **Behavior**
  * Dry-run path avoids modifying repository state and respects --no-hooks to omit hook info.

* **Tests**
  * Added integration tests covering dry-run behavior, JSON output, prune flag, hook presence, and no-side-effects verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->