### PR TITLE
feat(cli): implement trench log — list all events, most recent first

### DIFF
--- a/src/cli/commands/log.rs
+++ b/src/cli/commands/log.rs
@@ -25,9 +25,6 @@ fn extract_exit_code(entry: &LogEntry) -> Option<i64> {
 
 /// Format a Unix timestamp as a human-readable datetime string.
 fn format_timestamp(ts: i64) -> String {
-    use std::time::{Duration, UNIX_EPOCH};
-    let dt = UNIX_EPOCH + Duration::from_secs(ts as u64);
-    // Format as "YYYY-MM-DD HH:MM:SS" using chrono-free approach
     let secs = ts;
     let days = secs / 86400;
     let time_of_day = secs % 86400;

--- a/src/cli/commands/log.rs
+++ b/src/cli/commands/log.rs
@@ -25,9 +25,8 @@ fn extract_exit_code(entry: &LogEntry) -> Option<i64> {
 
 /// Format a Unix timestamp as a human-readable datetime string.
 fn format_timestamp(ts: i64) -> String {
-    let secs = ts;
-    let days = secs / 86400;
-    let time_of_day = secs % 86400;
+    let days = ts.div_euclid(86400);
+    let time_of_day = ts.rem_euclid(86400);
     let hours = time_of_day / 3600;
     let minutes = (time_of_day % 3600) / 60;
     let seconds = time_of_day % 60;

--- a/src/cli/commands/log.rs
+++ b/src/cli/commands/log.rs
@@ -1,5 +1,7 @@
 use anyhow::Result;
+use serde::Serialize;
 
+use crate::output::json::format_json;
 use crate::output::table::Table;
 use crate::state::{Database, LogEntry};
 
@@ -121,6 +123,35 @@ pub fn execute(db: &Database, repo_id: i64, use_color: bool) -> Result<String> {
     Ok(out)
 }
 
+#[derive(Serialize)]
+struct LogEntryJson {
+    id: i64,
+    timestamp: String,
+    event_type: String,
+    worktree: Option<String>,
+    duration_secs: Option<f64>,
+    exit_code: Option<i64>,
+    created_at: i64,
+}
+
+fn to_json_entry(entry: &LogEntry) -> LogEntryJson {
+    LogEntryJson {
+        id: entry.id,
+        timestamp: format_timestamp(entry.created_at),
+        event_type: entry.event_type.clone(),
+        worktree: entry.worktree_name.clone(),
+        duration_secs: extract_duration(entry),
+        exit_code: extract_exit_code(entry),
+        created_at: entry.created_at,
+    }
+}
+
+pub fn execute_json(db: &Database, repo_id: i64) -> Result<String> {
+    let entries = db.list_all_events(repo_id, 1000)?;
+    let json_entries: Vec<LogEntryJson> = entries.iter().map(to_json_entry).collect();
+    format_json(&json_entries)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -223,6 +254,50 @@ mod tests {
 
         let output = execute(&db, repo.id, true).unwrap();
         assert!(output.contains("\x1b[31m"), "failure events should be red");
+    }
+
+    #[test]
+    fn execute_json_returns_json_array() {
+        let db = Database::open_in_memory().unwrap();
+        let repo = db.insert_repo("r", "/r", None).unwrap();
+        let wt = db
+            .insert_worktree(repo.id, "wt-alpha", "alpha", "/wt/alpha", None)
+            .unwrap();
+
+        let payload = serde_json::json!({"exit_code": 0, "duration_secs": 1.5});
+        db.insert_event(repo.id, Some(wt.id), "hook:post_create", Some(&payload))
+            .unwrap();
+        db.insert_event(repo.id, Some(wt.id), "created", None)
+            .unwrap();
+
+        let output = execute_json(&db, repo.id).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&output).unwrap();
+        let arr = parsed.as_array().expect("should be array");
+
+        assert_eq!(arr.len(), 2, "should have 2 events");
+
+        // Most recent first — "created" was inserted last
+        let first = &arr[0];
+        assert_eq!(first["event_type"], "created");
+        assert_eq!(first["worktree"], "wt-alpha");
+        assert!(first["duration_secs"].is_null());
+        assert!(first["exit_code"].is_null());
+
+        let second = &arr[1];
+        assert_eq!(second["event_type"], "hook:post_create");
+        assert_eq!(second["duration_secs"], 1.5);
+        assert_eq!(second["exit_code"], 0);
+        assert!(second["timestamp"].is_string());
+        assert!(second["created_at"].is_number());
+    }
+
+    #[test]
+    fn execute_json_returns_empty_array_when_no_events() {
+        let db = Database::open_in_memory().unwrap();
+        let repo = db.insert_repo("r", "/r", None).unwrap();
+
+        let output = execute_json(&db, repo.id).unwrap();
+        assert_eq!(output, "[]");
     }
 
     #[test]

--- a/src/cli/commands/log.rs
+++ b/src/cli/commands/log.rs
@@ -1,0 +1,272 @@
+use anyhow::Result;
+
+use crate::output::table::Table;
+use crate::state::{Database, LogEntry};
+
+/// Extract duration_secs from a LogEntry's JSON payload, if present.
+fn extract_duration(entry: &LogEntry) -> Option<f64> {
+    entry
+        .payload
+        .as_deref()
+        .and_then(|p| serde_json::from_str::<serde_json::Value>(p).ok())
+        .and_then(|v| v.get("duration_secs")?.as_f64())
+}
+
+/// Extract exit_code from a LogEntry's JSON payload, if present.
+fn extract_exit_code(entry: &LogEntry) -> Option<i64> {
+    entry
+        .payload
+        .as_deref()
+        .and_then(|p| serde_json::from_str::<serde_json::Value>(p).ok())
+        .and_then(|v| v.get("exit_code")?.as_i64())
+}
+
+/// Format a Unix timestamp as a human-readable datetime string.
+fn format_timestamp(ts: i64) -> String {
+    use std::time::{Duration, UNIX_EPOCH};
+    let dt = UNIX_EPOCH + Duration::from_secs(ts as u64);
+    // Format as "YYYY-MM-DD HH:MM:SS" using chrono-free approach
+    let secs = ts;
+    let days = secs / 86400;
+    let time_of_day = secs % 86400;
+    let hours = time_of_day / 3600;
+    let minutes = (time_of_day % 3600) / 60;
+    let seconds = time_of_day % 60;
+
+    // Compute year/month/day from days since epoch
+    let (year, month, day) = days_to_ymd(days);
+    format!(
+        "{:04}-{:02}-{:02} {:02}:{:02}:{:02}",
+        year, month, day, hours, minutes, seconds
+    )
+}
+
+/// Convert days since Unix epoch to (year, month, day).
+fn days_to_ymd(days: i64) -> (i64, i64, i64) {
+    // Algorithm from Howard Hinnant's civil_from_days
+    let z = days + 719468;
+    let era = if z >= 0 { z } else { z - 146096 } / 146097;
+    let doe = (z - era * 146097) as u64;
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
+    let y = yoe as i64 + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    let y = if m <= 2 { y + 1 } else { y };
+    (y, m as i64, d as i64)
+}
+
+pub fn execute(db: &Database, repo_id: i64, use_color: bool) -> Result<String> {
+    let entries = db.list_all_events(repo_id, 1000)?;
+
+    if entries.is_empty() {
+        return Ok("No events.\n".to_string());
+    }
+
+    let mut table = Table::new(vec!["Timestamp", "Type", "Worktree", "Duration", "Exit"]);
+
+    for entry in &entries {
+        let ts = format_timestamp(entry.created_at);
+        let wt_name = entry.worktree_name.as_deref().unwrap_or("-");
+        let duration = match extract_duration(entry) {
+            Some(d) => format!("{:.1}s", d),
+            None => "-".to_string(),
+        };
+        let exit = match extract_exit_code(entry) {
+            Some(code) => code.to_string(),
+            None => "-".to_string(),
+        };
+
+        table = table.row(vec![&ts, &entry.event_type, wt_name, &duration, &exit]);
+    }
+
+    let rendered = table.render();
+
+    if !use_color {
+        return Ok(rendered);
+    }
+
+    // Color-code rows: green for success (exit_code 0 or absent), red for failure
+    let lines: Vec<&str> = rendered.lines().collect();
+    let mut out = String::new();
+
+    // Header line (no color)
+    if let Some(header) = lines.first() {
+        out.push_str(header);
+        out.push('\n');
+    }
+
+    for (i, line) in lines.iter().skip(1).enumerate() {
+        if i < entries.len() {
+            let exit_code = extract_exit_code(&entries[i]);
+            match exit_code {
+                Some(code) if code != 0 => {
+                    out.push_str("\x1b[31m"); // red
+                    out.push_str(line);
+                    out.push_str("\x1b[0m");
+                }
+                _ => {
+                    out.push_str("\x1b[32m"); // green
+                    out.push_str(line);
+                    out.push_str("\x1b[0m");
+                }
+            }
+        } else {
+            out.push_str(line);
+        }
+        out.push('\n');
+    }
+
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn execute_shows_empty_state_message() {
+        let db = Database::open_in_memory().unwrap();
+        let repo = db.insert_repo("r", "/r", None).unwrap();
+
+        let output = execute(&db, repo.id, false).unwrap();
+        assert_eq!(output, "No events.\n");
+    }
+
+    #[test]
+    fn execute_renders_table_with_event_details() {
+        let db = Database::open_in_memory().unwrap();
+        let repo = db.insert_repo("r", "/r", None).unwrap();
+        let wt = db
+            .insert_worktree(repo.id, "feature-auth", "feature/auth", "/wt/auth", None)
+            .unwrap();
+
+        // Insert a hook event with payload
+        let payload = serde_json::json!({"exit_code": 0, "duration_secs": 2.3});
+        db.insert_event(repo.id, Some(wt.id), "hook:post_create", Some(&payload))
+            .unwrap();
+        // Insert a plain event without payload
+        db.insert_event(repo.id, Some(wt.id), "created", None)
+            .unwrap();
+
+        let output = execute(&db, repo.id, false).unwrap();
+
+        // Should have headers
+        assert!(output.contains("Timestamp"), "should show Timestamp header");
+        assert!(output.contains("Type"), "should show Type header");
+        assert!(output.contains("Worktree"), "should show Worktree header");
+        assert!(output.contains("Duration"), "should show Duration header");
+        assert!(output.contains("Exit"), "should show Exit header");
+
+        // Should show event details
+        assert!(
+            output.contains("hook:post_create"),
+            "should show hook event type"
+        );
+        assert!(output.contains("created"), "should show created event type");
+        assert!(
+            output.contains("feature-auth"),
+            "should show worktree name"
+        );
+        assert!(output.contains("2.3s"), "should show duration");
+        assert!(output.contains("0"), "should show exit code");
+    }
+
+    #[test]
+    fn execute_no_color_has_no_ansi() {
+        let db = Database::open_in_memory().unwrap();
+        let repo = db.insert_repo("r", "/r", None).unwrap();
+        let wt = db
+            .insert_worktree(repo.id, "wt", "branch", "/wt", None)
+            .unwrap();
+        db.insert_event(repo.id, Some(wt.id), "created", None)
+            .unwrap();
+
+        let output = execute(&db, repo.id, false).unwrap();
+        assert!(
+            !output.contains("\x1b"),
+            "no-color output must not contain ANSI escapes"
+        );
+    }
+
+    #[test]
+    fn execute_with_color_has_green_for_success() {
+        let db = Database::open_in_memory().unwrap();
+        let repo = db.insert_repo("r", "/r", None).unwrap();
+        let wt = db
+            .insert_worktree(repo.id, "wt", "branch", "/wt", None)
+            .unwrap();
+
+        let payload = serde_json::json!({"exit_code": 0, "duration_secs": 1.0});
+        db.insert_event(repo.id, Some(wt.id), "hook:post_create", Some(&payload))
+            .unwrap();
+
+        let output = execute(&db, repo.id, true).unwrap();
+        assert!(
+            output.contains("\x1b[32m"),
+            "success events should be green"
+        );
+    }
+
+    #[test]
+    fn execute_with_color_has_red_for_failure() {
+        let db = Database::open_in_memory().unwrap();
+        let repo = db.insert_repo("r", "/r", None).unwrap();
+        let wt = db
+            .insert_worktree(repo.id, "wt", "branch", "/wt", None)
+            .unwrap();
+
+        let payload = serde_json::json!({"exit_code": 1, "duration_secs": 0.5});
+        db.insert_event(repo.id, Some(wt.id), "hook:pre_create", Some(&payload))
+            .unwrap();
+
+        let output = execute(&db, repo.id, true).unwrap();
+        assert!(output.contains("\x1b[31m"), "failure events should be red");
+    }
+
+    #[test]
+    fn extract_duration_from_payload() {
+        let entry = LogEntry {
+            id: 1,
+            event_type: "hook:post_create".to_string(),
+            worktree_name: Some("wt".to_string()),
+            payload: Some(r#"{"duration_secs": 3.14, "exit_code": 0}"#.to_string()),
+            created_at: 1700000000,
+        };
+        assert_eq!(extract_duration(&entry), Some(3.14));
+    }
+
+    #[test]
+    fn extract_exit_code_from_payload() {
+        let entry = LogEntry {
+            id: 1,
+            event_type: "hook:post_create".to_string(),
+            worktree_name: Some("wt".to_string()),
+            payload: Some(r#"{"exit_code": 42}"#.to_string()),
+            created_at: 1700000000,
+        };
+        assert_eq!(extract_exit_code(&entry), Some(42));
+    }
+
+    #[test]
+    fn extract_returns_none_for_missing_payload() {
+        let entry = LogEntry {
+            id: 1,
+            event_type: "created".to_string(),
+            worktree_name: None,
+            payload: None,
+            created_at: 1700000000,
+        };
+        assert_eq!(extract_duration(&entry), None);
+        assert_eq!(extract_exit_code(&entry), None);
+    }
+
+    #[test]
+    fn format_timestamp_produces_valid_datetime() {
+        // 2023-11-14 22:13:20 UTC
+        let ts = 1700000000;
+        let result = format_timestamp(ts);
+        assert_eq!(result, "2023-11-14 22:13:20");
+    }
+}

--- a/src/cli/commands/log.rs
+++ b/src/cli/commands/log.rs
@@ -57,7 +57,7 @@ fn days_to_ymd(days: i64) -> (i64, i64, i64) {
 }
 
 pub fn execute(db: &Database, repo_id: i64, use_color: bool) -> Result<String> {
-    let entries = db.list_all_events(repo_id, 1000)?;
+    let entries = db.list_all_events(repo_id)?;
 
     if entries.is_empty() {
         return Ok("No events.\n".to_string());
@@ -144,7 +144,7 @@ fn to_json_entry(entry: &LogEntry) -> LogEntryJson {
 }
 
 pub fn execute_json(db: &Database, repo_id: i64) -> Result<String> {
-    let entries = db.list_all_events(repo_id, 1000)?;
+    let entries = db.list_all_events(repo_id)?;
     let json_entries: Vec<LogEntryJson> = entries.iter().map(to_json_entry).collect();
     format_json(&json_entries)
 }

--- a/src/cli/commands/mod.rs
+++ b/src/cli/commands/mod.rs
@@ -2,6 +2,7 @@ pub mod completions;
 pub mod create;
 pub mod init;
 pub mod list;
+pub mod log;
 pub mod open;
 pub mod remove;
 pub mod shell_init;

--- a/src/main.rs
+++ b/src/main.rs
@@ -272,10 +272,7 @@ fn main() -> anyhow::Result<()> {
                 run_sync(&branch, strategy, json, dry_run, no_hooks)
             }
         }
-        Some(Commands::Log) => {
-            // Log command not yet implemented
-            Ok(())
-        }
+        Some(Commands::Log) => run_log(json, output_config.should_color()),
         None => {
             anyhow::bail!("TUI requires an interactive terminal (stdin and stdout must be a TTY)");
         }
@@ -622,6 +619,44 @@ fn run_tag(identifier: &str, tags: &[String]) -> anyhow::Result<()> {
 
     let output = cli::commands::tag::execute(identifier, tags, &cwd, &db)?;
     print!("{output}");
+    Ok(())
+}
+
+fn run_log(json: bool, use_color: bool) -> anyhow::Result<()> {
+    let cwd = std::env::current_dir().context("failed to determine current directory")?;
+    let db_path = paths::data_dir()?.join("trench.db");
+    let db = state::Database::open(&db_path)?;
+
+    let repo_info = git::discover_repo(&cwd)?;
+    let repo_path_str = repo_info
+        .path
+        .to_str()
+        .ok_or_else(|| anyhow::anyhow!("repo path is not valid UTF-8"))?;
+
+    let repo = db.get_repo_by_path(repo_path_str)?;
+    let repo_id = match repo {
+        Some(r) => r.id,
+        None => {
+            // No repo tracked yet — show empty state
+            if json {
+                println!("[]");
+            } else {
+                println!("No events.");
+            }
+            return Ok(());
+        }
+    };
+
+    let output = if json {
+        cli::commands::log::execute_json(&db, repo_id)?
+    } else {
+        cli::commands::log::execute(&db, repo_id, use_color)?
+    };
+    if output.ends_with('\n') {
+        print!("{output}");
+    } else {
+        println!("{output}");
+    }
     Ok(())
 }
 

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -837,35 +837,27 @@ mod tests {
             .unwrap();
 
         // Insert events (they get auto-timestamped with now())
-        db.insert_event(repo.id, Some(wt1.id), "created", None)
+        let first_id = db
+            .insert_event(repo.id, Some(wt1.id), "created", None)
             .unwrap();
-        db.insert_event(repo.id, Some(wt2.id), "created", None)
+        let second_id = db
+            .insert_event(repo.id, Some(wt2.id), "created", None)
             .unwrap();
         let payload = serde_json::json!({"exit_code": 0, "duration_secs": 1.5});
-        db.insert_event(repo.id, Some(wt1.id), "hook:post_create", Some(&payload))
+        let third_id = db
+            .insert_event(repo.id, Some(wt1.id), "hook:post_create", Some(&payload))
             .unwrap();
 
         let entries = db.list_all_events(repo.id).unwrap();
         assert_eq!(entries.len(), 3, "should return all 3 events");
 
-        // Most recent first (last inserted = most recent due to same-second timestamps)
-        // All should have worktree names
-        assert!(
-            entries.iter().any(|e| e.worktree_name.as_deref() == Some("wt-alpha")),
-            "should include wt-alpha events"
+        // Verify exact ordering: most recent (highest id) first,
+        // which also validates the id DESC tiebreaker for same-second timestamps.
+        assert_eq!(
+            entries.iter().map(|e| e.id).collect::<Vec<_>>(),
+            vec![third_id, second_id, first_id],
+            "events should be ordered by created_at DESC, then id DESC"
         );
-        assert!(
-            entries.iter().any(|e| e.worktree_name.as_deref() == Some("wt-beta")),
-            "should include wt-beta events"
-        );
-
-        // Verify ordering: created_at should be descending
-        for w in entries.windows(2) {
-            assert!(
-                w[0].created_at >= w[1].created_at,
-                "events should be ordered most recent first"
-            );
-        }
     }
 
     #[test]

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -922,6 +922,45 @@ mod tests {
     }
 
     #[test]
+    fn list_all_events_does_not_leak_cross_repo_worktree_name() {
+        let db = Database::open_in_memory().unwrap();
+        let repo_a = db.insert_repo("a", "/a", None).unwrap();
+        let repo_b = db.insert_repo("b", "/b", None).unwrap();
+        let _wt_a = db
+            .insert_worktree(repo_a.id, "wt-a", "branch-a", "/wt/a", None)
+            .unwrap();
+        let wt_b = db
+            .insert_worktree(repo_b.id, "wt-b", "branch-b", "/wt/b", None)
+            .unwrap();
+
+        // Bypass the trigger to insert a cross-repo event:
+        // event belongs to repo_a but references repo_b's worktree_id.
+        let conn = db.conn_for_test();
+        conn.execute(
+            "DROP TRIGGER events_check_worktree_repo_consistency",
+            [],
+        )
+        .unwrap();
+        let created_at = unix_epoch_secs() as i64;
+        conn.execute(
+            "INSERT INTO events (repo_id, worktree_id, event_type, payload, created_at)
+             VALUES (?1, ?2, ?3, NULL, ?4)",
+            rusqlite::params![repo_a.id, wt_b.id, "created", created_at],
+        )
+        .unwrap();
+
+        let entries = db.list_all_events(repo_a.id, 100).unwrap();
+        assert_eq!(entries.len(), 1);
+        // The worktree belongs to repo_b, so it should NOT resolve to a name
+        // when querying repo_a's events.
+        assert!(
+            entries[0].worktree_name.is_none(),
+            "cross-repo worktree name should not leak; got {:?}",
+            entries[0].worktree_name
+        );
+    }
+
+    #[test]
     fn get_repo_by_path_returns_existing_repo() {
         let db = Database::open_in_memory().unwrap();
         let repo = db.insert_repo("my-project", "/home/user/my-project", Some("main")).unwrap();

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -845,7 +845,7 @@ mod tests {
         db.insert_event(repo.id, Some(wt1.id), "hook:post_create", Some(&payload))
             .unwrap();
 
-        let entries = db.list_all_events(repo.id, 100).unwrap();
+        let entries = db.list_all_events(repo.id).unwrap();
         assert_eq!(entries.len(), 3, "should return all 3 events");
 
         // Most recent first (last inserted = most recent due to same-second timestamps)
@@ -876,27 +876,10 @@ mod tests {
         // Event with no worktree_id
         db.insert_event(repo.id, None, "init", None).unwrap();
 
-        let entries = db.list_all_events(repo.id, 100).unwrap();
+        let entries = db.list_all_events(repo.id).unwrap();
         assert_eq!(entries.len(), 1);
         assert!(entries[0].worktree_name.is_none());
         assert_eq!(entries[0].event_type, "init");
-    }
-
-    #[test]
-    fn list_all_events_respects_limit() {
-        let db = Database::open_in_memory().unwrap();
-        let repo = db.insert_repo("r", "/r", None).unwrap();
-        let wt = db
-            .insert_worktree(repo.id, "wt", "branch", "/wt", None)
-            .unwrap();
-
-        for _ in 0..5 {
-            db.insert_event(repo.id, Some(wt.id), "created", None)
-                .unwrap();
-        }
-
-        let entries = db.list_all_events(repo.id, 3).unwrap();
-        assert_eq!(entries.len(), 3, "should respect limit");
     }
 
     #[test]
@@ -916,9 +899,26 @@ mod tests {
         db.insert_event(repo_b.id, Some(wt_b.id), "created", None)
             .unwrap();
 
-        let entries_a = db.list_all_events(repo_a.id, 100).unwrap();
+        let entries_a = db.list_all_events(repo_a.id).unwrap();
         assert_eq!(entries_a.len(), 1, "should only return repo_a events");
         assert_eq!(entries_a[0].worktree_name.as_deref(), Some("wt-a"));
+    }
+
+    #[test]
+    fn list_all_events_returns_all_events_unbounded() {
+        let db = Database::open_in_memory().unwrap();
+        let repo = db.insert_repo("r", "/r", None).unwrap();
+        let wt = db
+            .insert_worktree(repo.id, "wt", "branch", "/wt", None)
+            .unwrap();
+
+        for _ in 0..1500 {
+            db.insert_event(repo.id, Some(wt.id), "created", None)
+                .unwrap();
+        }
+
+        let entries = db.list_all_events(repo.id).unwrap();
+        assert_eq!(entries.len(), 1500, "should return all events without a cap");
     }
 
     #[test]
@@ -949,7 +949,7 @@ mod tests {
         )
         .unwrap();
 
-        let entries = db.list_all_events(repo_a.id, 100).unwrap();
+        let entries = db.list_all_events(repo_a.id).unwrap();
         assert_eq!(entries.len(), 1);
         // The worktree belongs to repo_b, so it should NOT resolve to a name
         // when querying repo_a's events.

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -69,6 +69,16 @@ pub struct Event {
     pub created_at: i64,
 }
 
+/// An event record enriched with worktree name, for log display.
+#[derive(Debug, Clone)]
+pub struct LogEntry {
+    pub id: i64,
+    pub event_type: String,
+    pub worktree_name: Option<String>,
+    pub payload: Option<String>,
+    pub created_at: i64,
+}
+
 /// Core database handle wrapping a SQLite connection with migrations applied.
 #[derive(Debug)]
 pub struct Database {
@@ -813,6 +823,102 @@ mod tests {
 
         let logs = db.get_logs(event_id).unwrap();
         assert!(logs.is_empty());
+    }
+
+    #[test]
+    fn list_all_events_returns_events_for_repo_most_recent_first() {
+        let db = Database::open_in_memory().unwrap();
+        let repo = db.insert_repo("r", "/r", None).unwrap();
+        let wt1 = db
+            .insert_worktree(repo.id, "wt-alpha", "alpha", "/wt/alpha", None)
+            .unwrap();
+        let wt2 = db
+            .insert_worktree(repo.id, "wt-beta", "beta", "/wt/beta", None)
+            .unwrap();
+
+        // Insert events (they get auto-timestamped with now())
+        db.insert_event(repo.id, Some(wt1.id), "created", None)
+            .unwrap();
+        db.insert_event(repo.id, Some(wt2.id), "created", None)
+            .unwrap();
+        let payload = serde_json::json!({"exit_code": 0, "duration_secs": 1.5});
+        db.insert_event(repo.id, Some(wt1.id), "hook:post_create", Some(&payload))
+            .unwrap();
+
+        let entries = db.list_all_events(repo.id, 100).unwrap();
+        assert_eq!(entries.len(), 3, "should return all 3 events");
+
+        // Most recent first (last inserted = most recent due to same-second timestamps)
+        // All should have worktree names
+        assert!(
+            entries.iter().any(|e| e.worktree_name.as_deref() == Some("wt-alpha")),
+            "should include wt-alpha events"
+        );
+        assert!(
+            entries.iter().any(|e| e.worktree_name.as_deref() == Some("wt-beta")),
+            "should include wt-beta events"
+        );
+
+        // Verify ordering: created_at should be descending
+        for w in entries.windows(2) {
+            assert!(
+                w[0].created_at >= w[1].created_at,
+                "events should be ordered most recent first"
+            );
+        }
+    }
+
+    #[test]
+    fn list_all_events_includes_events_without_worktree() {
+        let db = Database::open_in_memory().unwrap();
+        let repo = db.insert_repo("r", "/r", None).unwrap();
+
+        // Event with no worktree_id
+        db.insert_event(repo.id, None, "init", None).unwrap();
+
+        let entries = db.list_all_events(repo.id, 100).unwrap();
+        assert_eq!(entries.len(), 1);
+        assert!(entries[0].worktree_name.is_none());
+        assert_eq!(entries[0].event_type, "init");
+    }
+
+    #[test]
+    fn list_all_events_respects_limit() {
+        let db = Database::open_in_memory().unwrap();
+        let repo = db.insert_repo("r", "/r", None).unwrap();
+        let wt = db
+            .insert_worktree(repo.id, "wt", "branch", "/wt", None)
+            .unwrap();
+
+        for _ in 0..5 {
+            db.insert_event(repo.id, Some(wt.id), "created", None)
+                .unwrap();
+        }
+
+        let entries = db.list_all_events(repo.id, 3).unwrap();
+        assert_eq!(entries.len(), 3, "should respect limit");
+    }
+
+    #[test]
+    fn list_all_events_scoped_to_repo() {
+        let db = Database::open_in_memory().unwrap();
+        let repo_a = db.insert_repo("a", "/a", None).unwrap();
+        let repo_b = db.insert_repo("b", "/b", None).unwrap();
+        let wt_a = db
+            .insert_worktree(repo_a.id, "wt-a", "branch-a", "/wt/a", None)
+            .unwrap();
+        let wt_b = db
+            .insert_worktree(repo_b.id, "wt-b", "branch-b", "/wt/b", None)
+            .unwrap();
+
+        db.insert_event(repo_a.id, Some(wt_a.id), "created", None)
+            .unwrap();
+        db.insert_event(repo_b.id, Some(wt_b.id), "created", None)
+            .unwrap();
+
+        let entries_a = db.list_all_events(repo_a.id, 100).unwrap();
+        assert_eq!(entries_a.len(), 1, "should only return repo_a events");
+        assert_eq!(entries_a[0].worktree_name.as_deref(), Some("wt-a"));
     }
 
     #[test]

--- a/src/state/queries.rs
+++ b/src/state/queries.rs
@@ -1,7 +1,7 @@
 use anyhow::{bail, Context, Result};
 use rusqlite::OptionalExtension;
 
-use super::{unix_epoch_secs, Database, Event, Repo, Worktree, WorktreeUpdate};
+use super::{unix_epoch_secs, Database, Event, LogEntry, Repo, Worktree, WorktreeUpdate};
 
 fn now() -> i64 {
     unix_epoch_secs() as i64
@@ -488,6 +488,39 @@ impl Database {
             .query_row(sql, param_refs.as_slice(), |row| row.get(0))
             .context("failed to count events")?;
         Ok(count)
+    }
+
+    /// List all events for a repo (across all worktrees), most recent first, up to `limit`.
+    ///
+    /// Joins with the worktrees table to include the worktree name.
+    /// Events without a worktree_id will have `worktree_name = None`.
+    pub fn list_all_events(&self, repo_id: i64, limit: usize) -> Result<Vec<LogEntry>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT e.id, e.event_type, w.name, e.payload, e.created_at
+             FROM events e
+             LEFT JOIN worktrees w ON e.worktree_id = w.id
+             WHERE e.repo_id = ?1
+             ORDER BY e.created_at DESC, e.id DESC
+             LIMIT ?2",
+        ).context("failed to prepare list_all_events query")?;
+
+        let rows = stmt
+            .query_map(rusqlite::params![repo_id, limit as i64], |row| {
+                Ok(LogEntry {
+                    id: row.get(0)?,
+                    event_type: row.get(1)?,
+                    worktree_name: row.get(2)?,
+                    payload: row.get(3)?,
+                    created_at: row.get(4)?,
+                })
+            })
+            .context("failed to list all events")?;
+
+        let mut entries = Vec::new();
+        for row in rows {
+            entries.push(row.context("failed to read log entry row")?);
+        }
+        Ok(entries)
     }
 
     /// List events for a worktree, most recent first, up to `limit`.

--- a/src/state/queries.rs
+++ b/src/state/queries.rs
@@ -490,11 +490,11 @@ impl Database {
         Ok(count)
     }
 
-    /// List all events for a repo (across all worktrees), most recent first, up to `limit`.
+    /// List all events for a repo (across all worktrees), most recent first.
     ///
     /// Joins with the worktrees table to include the worktree name.
     /// Events without a worktree_id will have `worktree_name = None`.
-    pub fn list_all_events(&self, repo_id: i64, limit: usize) -> Result<Vec<LogEntry>> {
+    pub fn list_all_events(&self, repo_id: i64) -> Result<Vec<LogEntry>> {
         let mut stmt = self.conn.prepare(
             "SELECT e.id, e.event_type, w.name, e.payload, e.created_at
              FROM events e
@@ -502,12 +502,11 @@ impl Database {
                ON e.worktree_id = w.id
               AND e.repo_id = w.repo_id
              WHERE e.repo_id = ?1
-             ORDER BY e.created_at DESC, e.id DESC
-             LIMIT ?2",
+             ORDER BY e.created_at DESC, e.id DESC",
         ).context("failed to prepare list_all_events query")?;
 
         let rows = stmt
-            .query_map(rusqlite::params![repo_id, limit as i64], |row| {
+            .query_map(rusqlite::params![repo_id], |row| {
                 Ok(LogEntry {
                     id: row.get(0)?,
                     event_type: row.get(1)?,

--- a/src/state/queries.rs
+++ b/src/state/queries.rs
@@ -498,7 +498,9 @@ impl Database {
         let mut stmt = self.conn.prepare(
             "SELECT e.id, e.event_type, w.name, e.payload, e.created_at
              FROM events e
-             LEFT JOIN worktrees w ON e.worktree_id = w.id
+             LEFT JOIN worktrees w
+               ON e.worktree_id = w.id
+              AND e.repo_id = w.repo_id
              WHERE e.repo_id = ?1
              ORDER BY e.created_at DESC, e.id DESC
              LIMIT ?2",

--- a/tests/log_command.rs
+++ b/tests/log_command.rs
@@ -1,0 +1,225 @@
+//! Integration tests for `trench log` command.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn trench_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_trench"))
+}
+
+/// Initialize a temporary git repo with an initial commit.
+fn init_git_repo(dir: &std::path::Path) {
+    Command::new("git")
+        .args(["init", "-b", "main"])
+        .current_dir(dir)
+        .output()
+        .expect("git init failed");
+    Command::new("git")
+        .args(["config", "user.email", "test@test.com"])
+        .current_dir(dir)
+        .output()
+        .expect("git config email failed");
+    Command::new("git")
+        .args(["config", "user.name", "Test"])
+        .current_dir(dir)
+        .output()
+        .expect("git config name failed");
+    std::fs::write(dir.join("README.md"), "# test\n").unwrap();
+    Command::new("git")
+        .args(["add", "."])
+        .current_dir(dir)
+        .output()
+        .expect("git add failed");
+    Command::new("git")
+        .args(["commit", "-m", "init"])
+        .current_dir(dir)
+        .output()
+        .expect("git commit failed");
+}
+
+#[test]
+fn log_empty_state_shows_no_events() {
+    let tmp = tempfile::tempdir().unwrap();
+    init_git_repo(tmp.path());
+
+    let output = Command::new(trench_bin())
+        .args(["log"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("failed to run trench log");
+
+    assert!(
+        output.status.success(),
+        "trench log should exit 0, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("No events"),
+        "should show empty state message, got: {stdout}"
+    );
+}
+
+#[test]
+fn log_json_empty_state_shows_empty_array() {
+    let tmp = tempfile::tempdir().unwrap();
+    init_git_repo(tmp.path());
+
+    let output = Command::new(trench_bin())
+        .args(["log", "--json"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("failed to run trench log --json");
+
+    assert!(
+        output.status.success(),
+        "trench log --json should exit 0, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert_eq!(stdout.trim(), "[]", "should output empty JSON array");
+}
+
+#[test]
+fn log_shows_events_after_create_and_remove() {
+    let tmp = tempfile::tempdir().unwrap();
+    init_git_repo(tmp.path());
+
+    // Create a worktree
+    let create_output = Command::new(trench_bin())
+        .args(["create", "log-test-feature"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("failed to run trench create");
+    assert!(
+        create_output.status.success(),
+        "trench create should succeed, stderr: {}",
+        String::from_utf8_lossy(&create_output.stderr)
+    );
+
+    // Remove the worktree
+    let remove_output = Command::new(trench_bin())
+        .args(["remove", "log-test-feature", "--force"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("failed to run trench remove");
+    assert!(
+        remove_output.status.success(),
+        "trench remove should succeed, stderr: {}",
+        String::from_utf8_lossy(&remove_output.stderr)
+    );
+
+    // Run trench log --json to get structured output
+    let log_output = Command::new(trench_bin())
+        .args(["log", "--json"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("failed to run trench log --json");
+    assert!(
+        log_output.status.success(),
+        "trench log --json should exit 0, stderr: {}",
+        String::from_utf8_lossy(&log_output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&log_output.stdout);
+    let parsed: serde_json::Value =
+        serde_json::from_str(&stdout).expect("should be valid JSON");
+    let arr = parsed.as_array().expect("should be a JSON array");
+
+    // Should have at least a "created" and "removed" event
+    assert!(
+        arr.len() >= 2,
+        "should have at least 2 events (created + removed), got {}",
+        arr.len()
+    );
+
+    let event_types: Vec<&str> = arr
+        .iter()
+        .filter_map(|e| e["event_type"].as_str())
+        .collect();
+
+    assert!(
+        event_types.contains(&"created"),
+        "should contain 'created' event, got: {:?}",
+        event_types
+    );
+    assert!(
+        event_types.contains(&"removed"),
+        "should contain 'removed' event, got: {:?}",
+        event_types
+    );
+
+    // Most recent first — "removed" should be before "created"
+    let removed_idx = event_types.iter().position(|&t| t == "removed").unwrap();
+    let created_idx = event_types.iter().position(|&t| t == "created").unwrap();
+    assert!(
+        removed_idx < created_idx,
+        "removed should be before created (most recent first)"
+    );
+
+    // Each event should have a worktree name
+    for event in arr {
+        assert!(
+            event["worktree"].is_string(),
+            "each event should have a worktree name, got: {}",
+            event
+        );
+        assert!(
+            event["timestamp"].is_string(),
+            "each event should have a timestamp"
+        );
+        assert!(
+            event["created_at"].is_number(),
+            "each event should have created_at"
+        );
+    }
+}
+
+#[test]
+fn log_table_output_after_create() {
+    let tmp = tempfile::tempdir().unwrap();
+    init_git_repo(tmp.path());
+
+    // Create a worktree
+    let create_output = Command::new(trench_bin())
+        .args(["create", "log-table-test"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("failed to run trench create");
+    assert!(
+        create_output.status.success(),
+        "trench create should succeed, stderr: {}",
+        String::from_utf8_lossy(&create_output.stderr)
+    );
+
+    // Run trench log (table output, with --no-color to avoid ANSI)
+    let log_output = Command::new(trench_bin())
+        .args(["log", "--no-color"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("failed to run trench log");
+    assert!(
+        log_output.status.success(),
+        "trench log should exit 0, stderr: {}",
+        String::from_utf8_lossy(&log_output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&log_output.stdout);
+
+    // Should have table headers
+    assert!(stdout.contains("Timestamp"), "should have Timestamp header");
+    assert!(stdout.contains("Type"), "should have Type header");
+    assert!(stdout.contains("Worktree"), "should have Worktree header");
+
+    // Should show the created event
+    assert!(
+        stdout.contains("created"),
+        "should show created event, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("log-table-test"),
+        "should show worktree name, got: {stdout}"
+    );
+}

--- a/tests/log_command.rs
+++ b/tests/log_command.rs
@@ -159,11 +159,11 @@ fn log_shows_events_after_create_and_remove() {
         "removed should be before created (most recent first)"
     );
 
-    // Each event should have a worktree name
+    // Each event should have a worktree (string or null for repo-level events)
     for event in arr {
         assert!(
-            event["worktree"].is_string(),
-            "each event should have a worktree name, got: {}",
+            event["worktree"].is_string() || event["worktree"].is_null(),
+            "worktree should be string or null, got: {}",
             event
         );
         assert!(

--- a/tests/log_command.rs
+++ b/tests/log_command.rs
@@ -89,7 +89,7 @@ fn log_shows_events_after_create_and_remove() {
 
     // Create a worktree
     let create_output = Command::new(trench_bin())
-        .args(["create", "log-test-feature"])
+        .args(["create", "log-test-feature", "--no-hooks"])
         .current_dir(tmp.path())
         .output()
         .expect("failed to run trench create");
@@ -101,7 +101,7 @@ fn log_shows_events_after_create_and_remove() {
 
     // Remove the worktree
     let remove_output = Command::new(trench_bin())
-        .args(["remove", "log-test-feature", "--force"])
+        .args(["remove", "log-test-feature", "--force", "--no-hooks"])
         .current_dir(tmp.path())
         .output()
         .expect("failed to run trench remove");
@@ -184,7 +184,7 @@ fn log_table_output_after_create() {
 
     // Create a worktree
     let create_output = Command::new(trench_bin())
-        .args(["create", "log-table-test"])
+        .args(["create", "log-table-test", "--no-hooks"])
         .current_dir(tmp.path())
         .output()
         .expect("failed to run trench create");

--- a/tests/log_command.rs
+++ b/tests/log_command.rs
@@ -7,34 +7,29 @@ fn trench_bin() -> PathBuf {
     PathBuf::from(env!("CARGO_BIN_EXE_trench"))
 }
 
+/// Run a git command in `dir`, panicking with stderr on failure.
+fn git(dir: &std::path::Path, args: &[&str]) {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .unwrap_or_else(|e| panic!("failed to run git {}: {e}", args[0]));
+    assert!(
+        output.status.success(),
+        "git {} failed: {}",
+        args[0],
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
 /// Initialize a temporary git repo with an initial commit.
 fn init_git_repo(dir: &std::path::Path) {
-    Command::new("git")
-        .args(["init", "-b", "main"])
-        .current_dir(dir)
-        .output()
-        .expect("git init failed");
-    Command::new("git")
-        .args(["config", "user.email", "test@test.com"])
-        .current_dir(dir)
-        .output()
-        .expect("git config email failed");
-    Command::new("git")
-        .args(["config", "user.name", "Test"])
-        .current_dir(dir)
-        .output()
-        .expect("git config name failed");
+    git(dir, &["init", "-b", "main"]);
+    git(dir, &["config", "user.email", "test@test.com"]);
+    git(dir, &["config", "user.name", "Test"]);
     std::fs::write(dir.join("README.md"), "# test\n").unwrap();
-    Command::new("git")
-        .args(["add", "."])
-        .current_dir(dir)
-        .output()
-        .expect("git add failed");
-    Command::new("git")
-        .args(["commit", "-m", "init"])
-        .current_dir(dir)
-        .output()
-        .expect("git commit failed");
+    git(dir, &["add", "."]);
+    git(dir, &["commit", "-m", "init"]);
 }
 
 #[test]


### PR DESCRIPTION
Closes #48

## Summary
Implements `trench log` command that queries all events from the events table (across all worktrees for the current repo), sorted by timestamp DESC. Displays timestamp, event type, worktree name, duration, and exit code in a color-coded table (green for success, red for failure). Supports `--json` output as a JSON array with structured fields.

## User Stories Addressed
- US-10: View hook execution logs and output from past runs

## Automated Testing
- Total tests added: 19
- Tests passing: 19
- Tests failing: 0
- `cargo clippy`: pass (no errors; pre-existing warnings only)
- `cargo test`: pass (619 total: 604 unit + 11 existing integration + 4 new integration)

## UAT Checklist
- [ ] `trench log` in a repo with no prior trench activity → shows "No events."
- [ ] `trench create my-feature` then `trench log` → shows "created" event with worktree name
- [ ] `trench create my-feature` then `trench remove my-feature --force` then `trench log` → shows both "removed" and "created" events, most recent first
- [ ] `trench log --json` → outputs valid JSON array with id, timestamp, event_type, worktree, duration_secs, exit_code, created_at fields
- [ ] `trench log --no-color` → no ANSI escape codes in output
- [ ] `trench log` with hooks configured (e.g. post_create with `run = ["echo hello"]`) → hook events show duration and exit code
- [ ] `trench log` in a repo outside any git directory → exits with error code 5

## Known Issues
None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a working log command that shows recent repository events.
  * Table view with Timestamp, Type, Worktree, Duration, Exit and optional ANSI color (green=success, red=failure).
  * JSON output option returning an array of log events.
  * Prints "No events." or an empty JSON array when no events exist.

* **Tests**
  * Integration tests for table/JSON output, ordering, color behavior, and empty-state cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->