### PR TITLE
feat(cli): implement trench log <branch> scoped + --tail N

### DIFF
--- a/src/cli/commands/log.rs
+++ b/src/cli/commands/log.rs
@@ -55,8 +55,14 @@ fn days_to_ymd(days: i64) -> (i64, i64, i64) {
     (y, m as i64, d as i64)
 }
 
-pub fn execute(db: &Database, repo_id: i64, use_color: bool) -> Result<String> {
-    let entries = db.list_all_events(repo_id)?;
+pub fn execute(
+    db: &Database,
+    repo_id: i64,
+    use_color: bool,
+    worktree: Option<&str>,
+    tail: Option<usize>,
+) -> Result<String> {
+    let entries = db.list_events_filtered(repo_id, worktree, tail)?;
 
     if entries.is_empty() {
         return Ok("No events.\n".to_string());
@@ -142,8 +148,13 @@ fn to_json_entry(entry: &LogEntry) -> LogEntryJson {
     }
 }
 
-pub fn execute_json(db: &Database, repo_id: i64) -> Result<String> {
-    let entries = db.list_all_events(repo_id)?;
+pub fn execute_json(
+    db: &Database,
+    repo_id: i64,
+    worktree: Option<&str>,
+    tail: Option<usize>,
+) -> Result<String> {
+    let entries = db.list_events_filtered(repo_id, worktree, tail)?;
     let json_entries: Vec<LogEntryJson> = entries.iter().map(to_json_entry).collect();
     format_json(&json_entries)
 }
@@ -157,7 +168,7 @@ mod tests {
         let db = Database::open_in_memory().unwrap();
         let repo = db.insert_repo("r", "/r", None).unwrap();
 
-        let output = execute(&db, repo.id, false).unwrap();
+        let output = execute(&db, repo.id, false, None, None).unwrap();
         assert_eq!(output, "No events.\n");
     }
 
@@ -177,7 +188,7 @@ mod tests {
         db.insert_event(repo.id, Some(wt.id), "created", None)
             .unwrap();
 
-        let output = execute(&db, repo.id, false).unwrap();
+        let output = execute(&db, repo.id, false, None, None).unwrap();
 
         // Should have headers
         assert!(output.contains("Timestamp"), "should show Timestamp header");
@@ -210,7 +221,7 @@ mod tests {
         db.insert_event(repo.id, Some(wt.id), "created", None)
             .unwrap();
 
-        let output = execute(&db, repo.id, false).unwrap();
+        let output = execute(&db, repo.id, false, None, None).unwrap();
         assert!(
             !output.contains("\x1b"),
             "no-color output must not contain ANSI escapes"
@@ -229,7 +240,7 @@ mod tests {
         db.insert_event(repo.id, Some(wt.id), "hook:post_create", Some(&payload))
             .unwrap();
 
-        let output = execute(&db, repo.id, true).unwrap();
+        let output = execute(&db, repo.id, true, None, None).unwrap();
         assert!(
             output.contains("\x1b[32m"),
             "success events should be green"
@@ -248,7 +259,7 @@ mod tests {
         db.insert_event(repo.id, Some(wt.id), "hook:pre_create", Some(&payload))
             .unwrap();
 
-        let output = execute(&db, repo.id, true).unwrap();
+        let output = execute(&db, repo.id, true, None, None).unwrap();
         assert!(output.contains("\x1b[31m"), "failure events should be red");
     }
 
@@ -266,7 +277,7 @@ mod tests {
         db.insert_event(repo.id, Some(wt.id), "created", None)
             .unwrap();
 
-        let output = execute_json(&db, repo.id).unwrap();
+        let output = execute_json(&db, repo.id, None, None).unwrap();
         let parsed: serde_json::Value = serde_json::from_str(&output).unwrap();
         let arr = parsed.as_array().expect("should be array");
 
@@ -292,8 +303,53 @@ mod tests {
         let db = Database::open_in_memory().unwrap();
         let repo = db.insert_repo("r", "/r", None).unwrap();
 
-        let output = execute_json(&db, repo.id).unwrap();
+        let output = execute_json(&db, repo.id, None, None).unwrap();
         assert_eq!(output, "[]");
+    }
+
+    #[test]
+    fn execute_with_tail_limits_output() {
+        let db = Database::open_in_memory().unwrap();
+        let repo = db.insert_repo("r", "/r", None).unwrap();
+        let wt = db
+            .insert_worktree(repo.id, "wt", "branch", "/wt", None)
+            .unwrap();
+        for _ in 0..5 {
+            db.insert_event(repo.id, Some(wt.id), "created", None)
+                .unwrap();
+        }
+
+        let output = execute(&db, repo.id, false, None, Some(2)).unwrap();
+        // Header + 2 data rows
+        let data_lines: Vec<&str> = output.lines().skip(1).filter(|l| !l.is_empty()).collect();
+        assert_eq!(data_lines.len(), 2, "should only show 2 events");
+    }
+
+    #[test]
+    fn execute_json_with_worktree_filter() {
+        let db = Database::open_in_memory().unwrap();
+        let repo = db.insert_repo("r", "/r", None).unwrap();
+        let wt_a = db
+            .insert_worktree(repo.id, "alpha", "feature/alpha", "/wt/a", None)
+            .unwrap();
+        let wt_b = db
+            .insert_worktree(repo.id, "beta", "feature/beta", "/wt/b", None)
+            .unwrap();
+
+        db.insert_event(repo.id, Some(wt_a.id), "created", None)
+            .unwrap();
+        db.insert_event(repo.id, Some(wt_a.id), "switched", None)
+            .unwrap();
+        db.insert_event(repo.id, Some(wt_b.id), "created", None)
+            .unwrap();
+
+        let output = execute_json(&db, repo.id, Some("alpha"), None).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&output).unwrap();
+        let arr = parsed.as_array().unwrap();
+        assert_eq!(arr.len(), 2, "should only show alpha's 2 events");
+        for entry in arr {
+            assert_eq!(entry["worktree"], "alpha");
+        }
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -666,7 +666,7 @@ fn run_log(
     };
 
     // If a branch filter is specified, verify the worktree exists
-    if let Some(ref b) = branch {
+    if let Some(b) = branch {
         if !db.worktree_exists_any(repo_id, b)? {
             eprintln!("error: worktree '{b}' not found");
             ExitCode::NotFound.exit();

--- a/src/main.rs
+++ b/src/main.rs
@@ -648,9 +648,9 @@ fn run_log(json: bool, use_color: bool) -> anyhow::Result<()> {
     };
 
     let output = if json {
-        cli::commands::log::execute_json(&db, repo_id)?
+        cli::commands::log::execute_json(&db, repo_id, None, None)?
     } else {
-        cli::commands::log::execute(&db, repo_id, use_color)?
+        cli::commands::log::execute(&db, repo_id, use_color, None, None)?
     };
     if output.ends_with('\n') {
         print!("{output}");

--- a/src/main.rs
+++ b/src/main.rs
@@ -139,7 +139,14 @@ enum Commands {
         no_hooks: bool,
     },
     /// View event log
-    Log,
+    Log {
+        /// Filter events to a specific worktree (by branch name or sanitized name)
+        branch: Option<String>,
+
+        /// Limit to the last N events
+        #[arg(long)]
+        tail: Option<usize>,
+    },
     /// Initialize .trench.toml in current directory
     Init {
         /// Overwrite existing .trench.toml
@@ -272,7 +279,9 @@ fn main() -> anyhow::Result<()> {
                 run_sync(&branch, strategy, json, dry_run, no_hooks)
             }
         }
-        Some(Commands::Log) => run_log(json, output_config.should_color()),
+        Some(Commands::Log { branch, tail }) => {
+            run_log(branch.as_deref(), tail, json, output_config.should_color())
+        }
         None => {
             anyhow::bail!("TUI requires an interactive terminal (stdin and stdout must be a TTY)");
         }
@@ -622,7 +631,12 @@ fn run_tag(identifier: &str, tags: &[String]) -> anyhow::Result<()> {
     Ok(())
 }
 
-fn run_log(json: bool, use_color: bool) -> anyhow::Result<()> {
+fn run_log(
+    branch: Option<&str>,
+    tail: Option<usize>,
+    json: bool,
+    use_color: bool,
+) -> anyhow::Result<()> {
     let cwd = std::env::current_dir().context("failed to determine current directory")?;
     let db_path = paths::data_dir()?.join("trench.db");
     let db = state::Database::open(&db_path)?;
@@ -637,6 +651,10 @@ fn run_log(json: bool, use_color: bool) -> anyhow::Result<()> {
     let repo_id = match repo {
         Some(r) => r.id,
         None => {
+            if let Some(b) = branch {
+                eprintln!("error: worktree '{b}' not found");
+                ExitCode::NotFound.exit();
+            }
             // No repo tracked yet — show empty state
             if json {
                 println!("[]");
@@ -647,10 +665,18 @@ fn run_log(json: bool, use_color: bool) -> anyhow::Result<()> {
         }
     };
 
+    // If a branch filter is specified, verify the worktree exists
+    if let Some(ref b) = branch {
+        if !db.worktree_exists_any(repo_id, b)? {
+            eprintln!("error: worktree '{b}' not found");
+            ExitCode::NotFound.exit();
+        }
+    }
+
     let output = if json {
-        cli::commands::log::execute_json(&db, repo_id, None, None)?
+        cli::commands::log::execute_json(&db, repo_id, branch, tail)?
     } else {
-        cli::commands::log::execute(&db, repo_id, use_color, None, None)?
+        cli::commands::log::execute(&db, repo_id, use_color, branch, tail)?
     };
     if output.ends_with('\n') {
         print!("{output}");

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -826,7 +826,7 @@ mod tests {
     }
 
     #[test]
-    fn list_all_events_returns_events_for_repo_most_recent_first() {
+    fn list_events_filtered_returns_events_for_repo_most_recent_first() {
         let db = Database::open_in_memory().unwrap();
         let repo = db.insert_repo("r", "/r", None).unwrap();
         let wt1 = db
@@ -848,7 +848,7 @@ mod tests {
             .insert_event(repo.id, Some(wt1.id), "hook:post_create", Some(&payload))
             .unwrap();
 
-        let entries = db.list_all_events(repo.id).unwrap();
+        let entries = db.list_events_filtered(repo.id, None, None).unwrap();
         assert_eq!(entries.len(), 3, "should return all 3 events");
 
         // Verify exact ordering: most recent (highest id) first,
@@ -861,21 +861,21 @@ mod tests {
     }
 
     #[test]
-    fn list_all_events_includes_events_without_worktree() {
+    fn list_events_filtered_includes_events_without_worktree() {
         let db = Database::open_in_memory().unwrap();
         let repo = db.insert_repo("r", "/r", None).unwrap();
 
         // Event with no worktree_id
         db.insert_event(repo.id, None, "init", None).unwrap();
 
-        let entries = db.list_all_events(repo.id).unwrap();
+        let entries = db.list_events_filtered(repo.id, None, None).unwrap();
         assert_eq!(entries.len(), 1);
         assert!(entries[0].worktree_name.is_none());
         assert_eq!(entries[0].event_type, "init");
     }
 
     #[test]
-    fn list_all_events_scoped_to_repo() {
+    fn list_events_filtered_scoped_to_repo() {
         let db = Database::open_in_memory().unwrap();
         let repo_a = db.insert_repo("a", "/a", None).unwrap();
         let repo_b = db.insert_repo("b", "/b", None).unwrap();
@@ -891,13 +891,13 @@ mod tests {
         db.insert_event(repo_b.id, Some(wt_b.id), "created", None)
             .unwrap();
 
-        let entries_a = db.list_all_events(repo_a.id).unwrap();
+        let entries_a = db.list_events_filtered(repo_a.id, None, None).unwrap();
         assert_eq!(entries_a.len(), 1, "should only return repo_a events");
         assert_eq!(entries_a[0].worktree_name.as_deref(), Some("wt-a"));
     }
 
     #[test]
-    fn list_all_events_returns_all_events_unbounded() {
+    fn list_events_filtered_returns_all_events_unbounded() {
         let db = Database::open_in_memory().unwrap();
         let repo = db.insert_repo("r", "/r", None).unwrap();
         let wt = db
@@ -909,12 +909,12 @@ mod tests {
                 .unwrap();
         }
 
-        let entries = db.list_all_events(repo.id).unwrap();
+        let entries = db.list_events_filtered(repo.id, None, None).unwrap();
         assert_eq!(entries.len(), 1500, "should return all events without a cap");
     }
 
     #[test]
-    fn list_all_events_does_not_leak_cross_repo_worktree_name() {
+    fn list_events_filtered_does_not_leak_cross_repo_worktree_name() {
         let db = Database::open_in_memory().unwrap();
         let repo_a = db.insert_repo("a", "/a", None).unwrap();
         let repo_b = db.insert_repo("b", "/b", None).unwrap();
@@ -941,7 +941,7 @@ mod tests {
         )
         .unwrap();
 
-        let entries = db.list_all_events(repo_a.id).unwrap();
+        let entries = db.list_events_filtered(repo_a.id, None, None).unwrap();
         assert_eq!(entries.len(), 1);
         // The worktree belongs to repo_b, so it should NOT resolve to a name
         // when querying repo_a's events.

--- a/src/state/queries.rs
+++ b/src/state/queries.rs
@@ -670,4 +670,71 @@ mod tests {
             .unwrap();
         assert_eq!(all.len(), 5, "no limit should return all 5 events");
     }
+
+    #[test]
+    fn list_events_filtered_by_worktree_name() {
+        let db = Database::open_in_memory().unwrap();
+        let repo = db.insert_repo("r", "/r", None).unwrap();
+        let wt_a = db
+            .insert_worktree(repo.id, "alpha", "feature/alpha", "/wt/a", None)
+            .unwrap();
+        let wt_b = db
+            .insert_worktree(repo.id, "beta", "feature/beta", "/wt/b", None)
+            .unwrap();
+
+        // 3 events for alpha, 2 for beta
+        for _ in 0..3 {
+            db.insert_event(repo.id, Some(wt_a.id), "created", None)
+                .unwrap();
+        }
+        for _ in 0..2 {
+            db.insert_event(repo.id, Some(wt_b.id), "created", None)
+                .unwrap();
+        }
+
+        // Filter by sanitized name
+        let alpha_events = db
+            .list_events_filtered(repo.id, Some("alpha"), None)
+            .unwrap();
+        assert_eq!(alpha_events.len(), 3);
+
+        // Filter by branch name
+        let beta_events = db
+            .list_events_filtered(repo.id, Some("feature/beta"), None)
+            .unwrap();
+        assert_eq!(beta_events.len(), 2);
+
+        // Combined: filter + limit
+        let limited = db
+            .list_events_filtered(repo.id, Some("alpha"), Some(2))
+            .unwrap();
+        assert_eq!(limited.len(), 2);
+    }
+
+    #[test]
+    fn worktree_exists_any_includes_removed() {
+        let db = Database::open_in_memory().unwrap();
+        let repo = db.insert_repo("r", "/r", None).unwrap();
+        let wt = db
+            .insert_worktree(repo.id, "gone", "feature/gone", "/wt/gone", None)
+            .unwrap();
+
+        assert!(db.worktree_exists_any(repo.id, "gone").unwrap());
+        assert!(db.worktree_exists_any(repo.id, "feature/gone").unwrap());
+        assert!(!db.worktree_exists_any(repo.id, "nonexistent").unwrap());
+
+        // Mark as removed — should still exist
+        db.update_worktree(
+            wt.id,
+            &crate::state::WorktreeUpdate {
+                removed_at: Some(Some(1000)),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert!(
+            db.worktree_exists_any(repo.id, "gone").unwrap(),
+            "removed worktree should still be found"
+        );
+    }
 }

--- a/src/state/queries.rs
+++ b/src/state/queries.rs
@@ -524,6 +524,92 @@ impl Database {
         Ok(entries)
     }
 
+    /// List events for a repo with optional worktree filter and limit.
+    ///
+    /// When `worktree_identifier` is `Some`, only events for the matching
+    /// worktree (by name or branch) are returned.
+    /// When `limit` is `Some`, at most that many events are returned.
+    /// Results are ordered most recent first.
+    pub fn list_events_filtered(
+        &self,
+        repo_id: i64,
+        worktree_identifier: Option<&str>,
+        limit: Option<usize>,
+    ) -> Result<Vec<LogEntry>> {
+        let mut sql = String::from(
+            "SELECT e.id, e.event_type, w.name, e.payload, e.created_at
+             FROM events e
+             LEFT JOIN worktrees w
+               ON e.worktree_id = w.id
+              AND e.repo_id = w.repo_id
+             WHERE e.repo_id = ?1",
+        );
+
+        if worktree_identifier.is_some() {
+            sql.push_str(" AND (w.name = ?2 OR w.branch = ?2)");
+        }
+
+        sql.push_str(" ORDER BY e.created_at DESC, e.id DESC");
+
+        if limit.is_some() {
+            if worktree_identifier.is_some() {
+                sql.push_str(" LIMIT ?3");
+            } else {
+                sql.push_str(" LIMIT ?2");
+            }
+        }
+
+        let mut stmt = self
+            .conn
+            .prepare(&sql)
+            .context("failed to prepare list_events_filtered query")?;
+
+        let params: Vec<Box<dyn rusqlite::types::ToSql>> = {
+            let mut p: Vec<Box<dyn rusqlite::types::ToSql>> = vec![Box::new(repo_id)];
+            if let Some(id) = worktree_identifier {
+                p.push(Box::new(id.to_string()));
+            }
+            if let Some(lim) = limit {
+                p.push(Box::new(lim as i64));
+            }
+            p
+        };
+        let param_refs: Vec<&dyn rusqlite::types::ToSql> =
+            params.iter().map(|p| p.as_ref()).collect();
+
+        let rows = stmt
+            .query_map(param_refs.as_slice(), |row| {
+                Ok(LogEntry {
+                    id: row.get(0)?,
+                    event_type: row.get(1)?,
+                    worktree_name: row.get(2)?,
+                    payload: row.get(3)?,
+                    created_at: row.get(4)?,
+                })
+            })
+            .context("failed to list filtered events")?;
+
+        let mut entries = Vec::new();
+        for row in rows {
+            entries.push(row.context("failed to read log entry row")?);
+        }
+        Ok(entries)
+    }
+
+    /// Check whether any worktree (active or removed) exists for the given
+    /// identifier (name or branch) in a repo.
+    pub fn worktree_exists_any(&self, repo_id: i64, identifier: &str) -> Result<bool> {
+        let exists: bool = self
+            .conn
+            .query_row(
+                "SELECT EXISTS(SELECT 1 FROM worktrees WHERE repo_id = ?1 AND (name = ?2 OR branch = ?2))",
+                rusqlite::params![repo_id, identifier],
+                |row| row.get(0),
+            )
+            .context("failed to check worktree existence")?;
+        Ok(exists)
+    }
+
     /// List events for a worktree, most recent first, up to `limit`.
     pub fn list_events(&self, worktree_id: i64, limit: usize) -> Result<Vec<Event>> {
         let mut stmt = self.conn.prepare(
@@ -550,5 +636,38 @@ impl Database {
             events.push(row.context("failed to read event row")?);
         }
         Ok(events)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::Database;
+
+    #[test]
+    fn list_events_filtered_with_limit_returns_n_most_recent() {
+        let db = Database::open_in_memory().unwrap();
+        let repo = db.insert_repo("r", "/r", None).unwrap();
+        let wt = db
+            .insert_worktree(repo.id, "feat", "feat", "/wt/feat", None)
+            .unwrap();
+
+        // Insert 5 events
+        for _ in 0..5 {
+            db.insert_event(repo.id, Some(wt.id), "created", None)
+                .unwrap();
+        }
+
+        // Limit to 3
+        let entries = db
+            .list_events_filtered(repo.id, None, Some(3))
+            .unwrap();
+        assert_eq!(entries.len(), 3, "should return exactly 3 events");
+
+        // No limit returns all
+        let all = db
+            .list_events_filtered(repo.id, None, None)
+            .unwrap();
+        assert_eq!(all.len(), 5, "no limit should return all 5 events");
     }
 }

--- a/src/state/queries.rs
+++ b/src/state/queries.rs
@@ -490,40 +490,6 @@ impl Database {
         Ok(count)
     }
 
-    /// List all events for a repo (across all worktrees), most recent first.
-    ///
-    /// Joins with the worktrees table to include the worktree name.
-    /// Events without a worktree_id will have `worktree_name = None`.
-    pub fn list_all_events(&self, repo_id: i64) -> Result<Vec<LogEntry>> {
-        let mut stmt = self.conn.prepare(
-            "SELECT e.id, e.event_type, w.name, e.payload, e.created_at
-             FROM events e
-             LEFT JOIN worktrees w
-               ON e.worktree_id = w.id
-              AND e.repo_id = w.repo_id
-             WHERE e.repo_id = ?1
-             ORDER BY e.created_at DESC, e.id DESC",
-        ).context("failed to prepare list_all_events query")?;
-
-        let rows = stmt
-            .query_map(rusqlite::params![repo_id], |row| {
-                Ok(LogEntry {
-                    id: row.get(0)?,
-                    event_type: row.get(1)?,
-                    worktree_name: row.get(2)?,
-                    payload: row.get(3)?,
-                    created_at: row.get(4)?,
-                })
-            })
-            .context("failed to list all events")?;
-
-        let mut entries = Vec::new();
-        for row in rows {
-            entries.push(row.context("failed to read log entry row")?);
-        }
-        Ok(entries)
-    }
-
     /// List events for a repo with optional worktree filter and limit.
     ///
     /// When `worktree_identifier` is `Some`, only events for the matching

--- a/src/state/queries.rs
+++ b/src/state/queries.rs
@@ -511,6 +511,10 @@ impl Database {
              WHERE e.repo_id = ?1",
         );
 
+        // Parameter layout:
+        //   ?1 = repo_id (always)
+        //   ?2 = worktree_identifier (if Some) or limit (if worktree is None)
+        //   ?3 = limit (only when worktree_identifier is also Some)
         if worktree_identifier.is_some() {
             sql.push_str(" AND (w.name = ?2 OR w.branch = ?2)");
         }

--- a/tests/log_command.rs
+++ b/tests/log_command.rs
@@ -257,16 +257,18 @@ fn log_scoped_to_worktree_filters_events() {
     init_git_repo(tmp.path());
 
     // Create two worktrees
-    Command::new(trench_bin())
+    let out = Command::new(trench_bin())
         .args(["create", "alpha-branch", "--no-hooks"])
         .current_dir(tmp.path())
         .output()
         .expect("create alpha");
-    Command::new(trench_bin())
+    assert!(out.status.success(), "trench create alpha failed: {}", String::from_utf8_lossy(&out.stderr));
+    let out = Command::new(trench_bin())
         .args(["create", "beta-branch", "--no-hooks"])
         .current_dir(tmp.path())
         .output()
         .expect("create beta");
+    assert!(out.status.success(), "trench create beta failed: {}", String::from_utf8_lossy(&out.stderr));
 
     // Log scoped to alpha — JSON output
     let output = Command::new(trench_bin())
@@ -301,16 +303,18 @@ fn log_tail_limits_output() {
     init_git_repo(tmp.path());
 
     // Create and remove to generate multiple events
-    Command::new(trench_bin())
+    let out = Command::new(trench_bin())
         .args(["create", "tail-test", "--no-hooks"])
         .current_dir(tmp.path())
         .output()
         .expect("create");
-    Command::new(trench_bin())
+    assert!(out.status.success(), "trench create failed: {}", String::from_utf8_lossy(&out.stderr));
+    let out = Command::new(trench_bin())
         .args(["remove", "tail-test", "--force", "--no-hooks"])
         .current_dir(tmp.path())
         .output()
         .expect("remove");
+    assert!(out.status.success(), "trench remove failed: {}", String::from_utf8_lossy(&out.stderr));
 
     // tail 1 — JSON
     let output = Command::new(trench_bin())
@@ -332,23 +336,26 @@ fn log_scoped_and_tail_combined() {
     init_git_repo(tmp.path());
 
     // Create two worktrees
-    Command::new(trench_bin())
+    let out = Command::new(trench_bin())
         .args(["create", "combo-a", "--no-hooks"])
         .current_dir(tmp.path())
         .output()
         .expect("create combo-a");
-    Command::new(trench_bin())
+    assert!(out.status.success(), "trench create combo-a failed: {}", String::from_utf8_lossy(&out.stderr));
+    let out = Command::new(trench_bin())
         .args(["create", "combo-b", "--no-hooks"])
         .current_dir(tmp.path())
         .output()
         .expect("create combo-b");
+    assert!(out.status.success(), "trench create combo-b failed: {}", String::from_utf8_lossy(&out.stderr));
 
     // Remove combo-a to generate more events for it
-    Command::new(trench_bin())
+    let out = Command::new(trench_bin())
         .args(["remove", "combo-a", "--force", "--no-hooks"])
         .current_dir(tmp.path())
         .output()
         .expect("remove combo-a");
+    assert!(out.status.success(), "trench remove combo-a failed: {}", String::from_utf8_lossy(&out.stderr));
 
     // combo-a should have at least 2 events (created + removed), tail to 1
     let output = Command::new(trench_bin())

--- a/tests/log_command.rs
+++ b/tests/log_command.rs
@@ -1,10 +1,15 @@
 //! Integration tests for `trench log` command.
 
 use std::path::PathBuf;
-use std::process::Command;
+use std::process::{Command, ExitStatus};
 
 fn trench_bin() -> PathBuf {
     PathBuf::from(env!("CARGO_BIN_EXE_trench"))
+}
+
+/// Helper to get the exit code from a status.
+fn exit_code(status: ExitStatus) -> i32 {
+    status.code().unwrap_or(-1)
 }
 
 /// Run a git command in `dir`, panicking with stderr on failure.
@@ -216,5 +221,154 @@ fn log_table_output_after_create() {
     assert!(
         stdout.contains("log-table-test"),
         "should show worktree name, got: {stdout}"
+    );
+}
+
+#[test]
+fn log_nonexistent_worktree_exits_2() {
+    let tmp = tempfile::tempdir().unwrap();
+    init_git_repo(tmp.path());
+
+    // Create at least one worktree so the repo is tracked
+    let create = Command::new(trench_bin())
+        .args(["create", "real-branch", "--no-hooks"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("failed to run trench create");
+    assert!(create.status.success());
+
+    let output = Command::new(trench_bin())
+        .args(["log", "nonexistent-branch"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("failed to run trench log");
+
+    assert_eq!(
+        exit_code(output.status),
+        2,
+        "should exit 2 for unknown worktree, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn log_scoped_to_worktree_filters_events() {
+    let tmp = tempfile::tempdir().unwrap();
+    init_git_repo(tmp.path());
+
+    // Create two worktrees
+    Command::new(trench_bin())
+        .args(["create", "alpha-branch", "--no-hooks"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("create alpha");
+    Command::new(trench_bin())
+        .args(["create", "beta-branch", "--no-hooks"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("create beta");
+
+    // Log scoped to alpha — JSON output
+    let output = Command::new(trench_bin())
+        .args(["log", "alpha-branch", "--json"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("failed to run trench log alpha-branch --json");
+
+    assert!(
+        output.status.success(),
+        "trench log alpha-branch --json should exit 0, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).expect("valid JSON");
+    let arr = parsed.as_array().expect("array");
+
+    // All events should be for alpha-branch
+    for event in arr {
+        assert_eq!(
+            event["worktree"].as_str().unwrap_or(""),
+            "alpha-branch",
+            "scoped log should only contain alpha events"
+        );
+    }
+}
+
+#[test]
+fn log_tail_limits_output() {
+    let tmp = tempfile::tempdir().unwrap();
+    init_git_repo(tmp.path());
+
+    // Create and remove to generate multiple events
+    Command::new(trench_bin())
+        .args(["create", "tail-test", "--no-hooks"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("create");
+    Command::new(trench_bin())
+        .args(["remove", "tail-test", "--force", "--no-hooks"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("remove");
+
+    // tail 1 — JSON
+    let output = Command::new(trench_bin())
+        .args(["log", "--tail", "1", "--json"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("trench log --tail 1 --json");
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).expect("valid JSON");
+    let arr = parsed.as_array().expect("array");
+    assert_eq!(arr.len(), 1, "tail 1 should return exactly 1 event");
+}
+
+#[test]
+fn log_scoped_and_tail_combined() {
+    let tmp = tempfile::tempdir().unwrap();
+    init_git_repo(tmp.path());
+
+    // Create two worktrees
+    Command::new(trench_bin())
+        .args(["create", "combo-a", "--no-hooks"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("create combo-a");
+    Command::new(trench_bin())
+        .args(["create", "combo-b", "--no-hooks"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("create combo-b");
+
+    // Remove combo-a to generate more events for it
+    Command::new(trench_bin())
+        .args(["remove", "combo-a", "--force", "--no-hooks"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("remove combo-a");
+
+    // combo-a should have at least 2 events (created + removed), tail to 1
+    let output = Command::new(trench_bin())
+        .args(["log", "combo-a", "--tail", "1", "--json"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("trench log combo-a --tail 1 --json");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).expect("valid JSON");
+    let arr = parsed.as_array().expect("array");
+    assert_eq!(arr.len(), 1, "combined filter should return 1 event");
+    assert_eq!(
+        arr[0]["worktree"].as_str().unwrap_or(""),
+        "combo-a",
+        "event should be for combo-a"
     );
 }


### PR DESCRIPTION
Closes #49

## Summary
Adds worktree-scoped filtering and `--tail N` limiting to `trench log`. Users can now run `trench log <branch>` to see only events for a specific worktree, `trench log --tail N` to limit output, or combine both. Returns exit code 2 when the specified worktree is not found.

## User Stories Addressed
- US-10: View hook execution logs and output from past runs (filtered log view)

## Automated Testing
- Total tests added: 8 (5 unit + 3 integration, plus updated existing tests)
- Tests passing: 629
- Tests failing: 0
- `cargo clippy`: pass
- `cargo test`: pass

## UAT Checklist
- [ ] `trench log` with no args still shows all events (backward compatible)
- [ ] `trench log my-worktree` shows only events for that worktree
- [ ] `trench log my-worktree --json` returns filtered JSON array
- [ ] `trench log --tail 3` shows only the 3 most recent events
- [ ] `trench log my-worktree --tail 2` combines both filters correctly
- [ ] `trench log nonexistent` prints error to stderr and exits with code 2
- [ ] `trench log --tail 1 --no-color` works with table output

## Known Issues
None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Log command now supports filtering events by worktree or branch using optional filter parameters.
  * Added support for limiting log output to a specified number of recent entries.
  * Enhanced error handling when referencing non-existent worktrees during filtering.

* **Bug Fixes**
  * Log command now returns appropriate feedback when no tracked repository exists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->