### PR TITLE
feat(cli): implement trench log --output for hook stdout/stderr replay

### DIFF
--- a/src/cli/commands/log.rs
+++ b/src/cli/commands/log.rs
@@ -1,26 +1,18 @@
 use anyhow::Result;
 use serde::Serialize;
 
-use crate::output::json::format_json;
+use crate::output::json::{format_json, format_json_value};
 use crate::output::table::Table;
 use crate::state::{Database, LogEntry};
 
 /// Extract duration_secs from a LogEntry's JSON payload, if present.
 fn extract_duration(entry: &LogEntry) -> Option<f64> {
-    entry
-        .payload
-        .as_deref()
-        .and_then(|p| serde_json::from_str::<serde_json::Value>(p).ok())
-        .and_then(|v| v.get("duration_secs")?.as_f64())
+    extract_duration_from_payload(&entry.payload)
 }
 
 /// Extract exit_code from a LogEntry's JSON payload, if present.
 fn extract_exit_code(entry: &LogEntry) -> Option<i64> {
-    entry
-        .payload
-        .as_deref()
-        .and_then(|p| serde_json::from_str::<serde_json::Value>(p).ok())
-        .and_then(|v| v.get("exit_code")?.as_i64())
+    extract_exit_code_from_payload(&entry.payload)
 }
 
 /// Format a Unix timestamp as a human-readable datetime string.
@@ -126,6 +118,43 @@ pub fn execute(
 }
 
 #[derive(Serialize)]
+struct HookOutputJson {
+    event_id: i64,
+    event_type: String,
+    timestamp: String,
+    duration_secs: Option<f64>,
+    exit_code: Option<i64>,
+    created_at: i64,
+    lines: Vec<HookOutputLineJson>,
+}
+
+#[derive(Serialize)]
+struct HookOutputLineJson {
+    stream: String,
+    line: String,
+    step: Option<String>,
+    line_number: i64,
+    timestamp: String,
+    created_at: i64,
+}
+
+/// Extract duration_secs from a JSON payload string.
+fn extract_duration_from_payload(payload: &Option<String>) -> Option<f64> {
+    payload
+        .as_deref()
+        .and_then(|p| serde_json::from_str::<serde_json::Value>(p).ok())
+        .and_then(|v| v.get("duration_secs")?.as_f64())
+}
+
+/// Extract exit_code from a JSON payload string.
+fn extract_exit_code_from_payload(payload: &Option<String>) -> Option<i64> {
+    payload
+        .as_deref()
+        .and_then(|p| serde_json::from_str::<serde_json::Value>(p).ok())
+        .and_then(|v| v.get("exit_code")?.as_i64())
+}
+
+#[derive(Serialize)]
 struct LogEntryJson {
     id: i64,
     timestamp: String,
@@ -192,8 +221,35 @@ pub fn execute_output_json(
     repo_id: i64,
     worktree: &str,
 ) -> Result<String> {
-    // Stub — will be implemented in cycle 6
-    execute_output(db, repo_id, worktree)
+    let event = db
+        .get_last_hook_event_for_worktree(repo_id, worktree)?
+        .ok_or_else(|| anyhow::anyhow!("No hook output found for worktree '{}'", worktree))?;
+
+    let lines = db.get_hook_output(event.id)?;
+
+    let json_lines: Vec<HookOutputLineJson> = lines
+        .iter()
+        .map(|l| HookOutputLineJson {
+            stream: l.stream.clone(),
+            line: l.line.clone(),
+            step: l.step.clone(),
+            line_number: l.line_number,
+            timestamp: format_timestamp(l.created_at),
+            created_at: l.created_at,
+        })
+        .collect();
+
+    let output = HookOutputJson {
+        event_id: event.id,
+        event_type: event.event_type.clone(),
+        timestamp: format_timestamp(event.created_at),
+        duration_secs: extract_duration_from_payload(&event.payload),
+        exit_code: extract_exit_code_from_payload(&event.payload),
+        created_at: event.created_at,
+        lines: json_lines,
+    };
+
+    format_json_value(&output)
 }
 
 pub fn execute_json(
@@ -243,6 +299,45 @@ mod tests {
 
         // Should contain event type header
         assert!(output.contains("hook:post_create"), "should show event type");
+    }
+
+    #[test]
+    fn execute_output_json_returns_structured_json() {
+        let db = Database::open_in_memory().unwrap();
+        let repo = db.insert_repo("r", "/r", None).unwrap();
+        let wt = db
+            .insert_worktree(repo.id, "feat", "feature/feat", "/wt/feat", None)
+            .unwrap();
+
+        let payload = serde_json::json!({"hook": "post_create", "exit_code": 0, "duration_secs": 1.5});
+        let event_id = db
+            .insert_event(repo.id, Some(wt.id), "hook:post_create", Some(&payload))
+            .unwrap();
+
+        db.insert_log(event_id, "stdout", "hello", 1, Some("run")).unwrap();
+        db.insert_log(event_id, "stderr", "warn", 2, Some("shell")).unwrap();
+
+        let output = execute_output_json(&db, repo.id, "feat").unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&output).expect("valid JSON");
+
+        // Top-level fields
+        assert_eq!(parsed["event_type"], "hook:post_create");
+        assert_eq!(parsed["exit_code"], 0);
+        assert_eq!(parsed["duration_secs"], 1.5);
+        assert!(parsed["timestamp"].is_string());
+
+        // Lines array
+        let lines = parsed["lines"].as_array().expect("lines should be array");
+        assert_eq!(lines.len(), 2);
+
+        assert_eq!(lines[0]["stream"], "stdout");
+        assert_eq!(lines[0]["line"], "hello");
+        assert_eq!(lines[0]["step"], "run");
+        assert_eq!(lines[0]["line_number"], 1);
+        assert!(lines[0]["timestamp"].is_string());
+
+        assert_eq!(lines[1]["stream"], "stderr");
+        assert_eq!(lines[1]["step"], "shell");
     }
 
     #[test]

--- a/src/cli/commands/log.rs
+++ b/src/cli/commands/log.rs
@@ -148,6 +148,54 @@ fn to_json_entry(entry: &LogEntry) -> LogEntryJson {
     }
 }
 
+/// Display stdout/stderr from the last hook execution for a worktree.
+///
+/// Shows output labeled by step (run/shell) with timestamps.
+/// Returns an error if no hook events exist for the worktree.
+pub fn execute_output(
+    db: &Database,
+    repo_id: i64,
+    worktree: &str,
+) -> Result<String> {
+    let event = db
+        .get_last_hook_event_for_worktree(repo_id, worktree)?
+        .ok_or_else(|| anyhow::anyhow!("No hook output found for worktree '{}'", worktree))?;
+
+    let lines = db.get_hook_output(event.id)?;
+
+    if lines.is_empty() {
+        let mut out = String::new();
+        out.push_str(&format!("=== {} ({})\n", event.event_type, format_timestamp(event.created_at)));
+        out.push_str("(no output captured)\n");
+        return Ok(out);
+    }
+
+    let mut out = String::new();
+    out.push_str(&format!("=== {} ({})\n", event.event_type, format_timestamp(event.created_at)));
+
+    for line in &lines {
+        let step_label = line.step.as_deref().unwrap_or("unknown");
+        let ts = format_timestamp(line.created_at);
+        let stream_marker = if line.stream == "stderr" { "!" } else { " " };
+        out.push_str(&format!(
+            "[{}]{} {} {}\n",
+            step_label, stream_marker, ts, line.line
+        ));
+    }
+
+    Ok(out)
+}
+
+/// JSON output for hook stdout/stderr replay.
+pub fn execute_output_json(
+    db: &Database,
+    repo_id: i64,
+    worktree: &str,
+) -> Result<String> {
+    // Stub — will be implemented in cycle 6
+    execute_output(db, repo_id, worktree)
+}
+
 pub fn execute_json(
     db: &Database,
     repo_id: i64,
@@ -162,6 +210,57 @@ pub fn execute_json(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn execute_output_shows_hook_output_with_step_labels() {
+        let db = Database::open_in_memory().unwrap();
+        let repo = db.insert_repo("r", "/r", None).unwrap();
+        let wt = db
+            .insert_worktree(repo.id, "feat", "feature/feat", "/wt/feat", None)
+            .unwrap();
+
+        // Insert a hook event
+        let payload = serde_json::json!({"hook": "post_create", "exit_code": 0, "duration_secs": 1.5});
+        let event_id = db
+            .insert_event(repo.id, Some(wt.id), "hook:post_create", Some(&payload))
+            .unwrap();
+
+        // Insert log lines with step labels
+        db.insert_log(event_id, "stdout", "Installing deps...", 1, Some("run")).unwrap();
+        db.insert_log(event_id, "stderr", "warning: peer dep", 2, Some("run")).unwrap();
+        db.insert_log(event_id, "stdout", "Migration done", 3, Some("shell")).unwrap();
+
+        let output = execute_output(&db, repo.id, "feat").unwrap();
+
+        // Should contain step labels
+        assert!(output.contains("[run]"), "should show [run] step label");
+        assert!(output.contains("[shell]"), "should show [shell] step label");
+
+        // Should contain actual output lines
+        assert!(output.contains("Installing deps..."), "should show stdout line");
+        assert!(output.contains("warning: peer dep"), "should show stderr line");
+        assert!(output.contains("Migration done"), "should show shell output");
+
+        // Should contain event type header
+        assert!(output.contains("hook:post_create"), "should show event type");
+    }
+
+    #[test]
+    fn execute_output_returns_error_when_no_hook_events() {
+        let db = Database::open_in_memory().unwrap();
+        let repo = db.insert_repo("r", "/r", None).unwrap();
+        let _wt = db
+            .insert_worktree(repo.id, "feat", "feature/feat", "/wt/feat", None)
+            .unwrap();
+
+        // Only a non-hook event
+        db.insert_event(repo.id, Some(_wt.id), "created", None).unwrap();
+
+        let result = execute_output(&db, repo.id, "feat");
+        assert!(result.is_err(), "should error when no hook output exists");
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("No hook output"), "error message: {err}");
+    }
 
     #[test]
     fn execute_shows_empty_state_message() {

--- a/src/hooks/runner.rs
+++ b/src/hooks/runner.rs
@@ -46,7 +46,7 @@ pub async fn execute_hook(
     let env_vars = build_env(env_ctx, event);
     let timeout_secs = config.timeout_secs.unwrap_or(120);
 
-    let mut all_output: Vec<(String, String)> = Vec::new(); // (stream, line)
+    let mut all_output: Vec<(String, String, String)> = Vec::new(); // (step, stream, line)
 
     // Step 1: Copy (not subject to timeout)
     if let Some(ref patterns) = config.copy {
@@ -68,7 +68,7 @@ pub async fn execute_hook(
         {
             Ok(Ok(run_result)) => {
                 for cmd_output in &run_result.executed {
-                    collect_output(&mut all_output, &cmd_output.stdout, &cmd_output.stderr);
+                    collect_output(&mut all_output, "run", &cmd_output.stdout, &cmd_output.stderr);
                 }
             }
             Ok(Err(e)) => {
@@ -97,7 +97,7 @@ pub async fn execute_hook(
             .await
         {
             Ok(Ok(shell_output)) => {
-                collect_output(&mut all_output, &shell_output.stdout, &shell_output.stderr);
+                collect_output(&mut all_output, "shell", &shell_output.stdout, &shell_output.stderr);
             }
             Ok(Err(e)) => {
                 let exit_code = extract_shell_error_output(&e, &mut all_output);
@@ -131,11 +131,11 @@ pub async fn execute_hook(
 /// Extract partial output from a RunStepError and return the exit code.
 fn extract_run_error_output(
     err: &anyhow::Error,
-    all_output: &mut Vec<(String, String)>,
+    all_output: &mut Vec<(String, String, String)>,
 ) -> i32 {
     if let Some(run_err) = err.downcast_ref::<RunStepError>() {
         for cmd_output in &run_err.results.executed {
-            collect_output(all_output, &cmd_output.stdout, &cmd_output.stderr);
+            collect_output(all_output, "run", &cmd_output.stdout, &cmd_output.stderr);
         }
         run_err.exit_code
     } else {
@@ -146,22 +146,22 @@ fn extract_run_error_output(
 /// Extract output from a ShellStepError and return the exit code.
 fn extract_shell_error_output(
     err: &anyhow::Error,
-    all_output: &mut Vec<(String, String)>,
+    all_output: &mut Vec<(String, String, String)>,
 ) -> i32 {
     if let Some(shell_err) = err.downcast_ref::<ShellStepError>() {
-        collect_output(all_output, &shell_err.output.stdout, &shell_err.output.stderr);
+        collect_output(all_output, "shell", &shell_err.output.stdout, &shell_err.output.stderr);
         shell_err.exit_code
     } else {
         1
     }
 }
 
-fn collect_output(all_output: &mut Vec<(String, String)>, stdout: &str, stderr: &str) {
+fn collect_output(all_output: &mut Vec<(String, String, String)>, step: &str, stdout: &str, stderr: &str) {
     for line in stdout.lines() {
-        all_output.push(("stdout".to_string(), line.to_string()));
+        all_output.push((step.to_string(), "stdout".to_string(), line.to_string()));
     }
     for line in stderr.lines() {
-        all_output.push(("stderr".to_string(), line.to_string()));
+        all_output.push((step.to_string(), "stderr".to_string(), line.to_string()));
     }
 }
 
@@ -172,7 +172,7 @@ fn record_execution(
     event: &HookEvent,
     exit_code: i32,
     duration_secs: f64,
-    output: &[(String, String)],
+    output: &[(String, String, String)],
 ) -> Result<i64> {
     let payload = serde_json::json!({
         "hook": event.as_str(),
@@ -187,8 +187,8 @@ fn record_execution(
         Some(&payload),
     )?;
 
-    for (i, (stream, line)) in output.iter().enumerate() {
-        db.insert_log(event_id, stream, line, (i + 1) as i64, None)?;
+    for (i, (step, stream, line)) in output.iter().enumerate() {
+        db.insert_log(event_id, stream, line, (i + 1) as i64, Some(step))?;
     }
 
     Ok(event_id)
@@ -599,5 +599,51 @@ mod tests {
         let streams: Vec<&str> = logs.iter().map(|(s, _, _)| s.as_str()).collect();
         assert!(streams.contains(&"stdout"));
         assert!(streams.contains(&"stderr"));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn hook_output_logs_include_step_labels() {
+        let source = TempDir::new().unwrap();
+        let work = TempDir::new().unwrap();
+        let (db, repo_id, wt_id) = setup_db();
+
+        let config = HookDef {
+            copy: None,
+            run: Some(vec!["echo from_run".to_string()]),
+            shell: Some("echo from_shell".to_string()),
+            timeout_secs: Some(30),
+        };
+
+        let env_ctx = test_env_ctx(source.path(), work.path());
+
+        let result = execute_hook(
+            &HookEvent::PostCreate,
+            &config,
+            &env_ctx,
+            source.path(),
+            work.path(),
+            &db,
+            repo_id,
+            Some(wt_id),
+        )
+        .await
+        .unwrap();
+
+        // Verify step labels are stored via raw query
+        let conn = db.conn_for_test();
+        let mut stmt = conn.prepare(
+            "SELECT line, step FROM logs WHERE event_id = ?1 ORDER BY line_number"
+        ).unwrap();
+        let rows: Vec<(String, Option<String>)> = stmt
+            .query_map(rusqlite::params![result.event_id], |row| {
+                Ok((row.get(0)?, row.get(1)?))
+            })
+            .unwrap()
+            .map(|r| r.unwrap())
+            .collect();
+
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0], ("from_run".to_string(), Some("run".to_string())));
+        assert_eq!(rows[1], ("from_shell".to_string(), Some("shell".to_string())));
     }
 }

--- a/src/hooks/runner.rs
+++ b/src/hooks/runner.rs
@@ -188,7 +188,7 @@ fn record_execution(
     )?;
 
     for (i, (stream, line)) in output.iter().enumerate() {
-        db.insert_log(event_id, stream, line, (i + 1) as i64)?;
+        db.insert_log(event_id, stream, line, (i + 1) as i64, None)?;
     }
 
     Ok(event_id)

--- a/src/main.rs
+++ b/src/main.rs
@@ -146,6 +146,10 @@ enum Commands {
         /// Limit to the last N events
         #[arg(long)]
         tail: Option<usize>,
+
+        /// Show stdout/stderr from the last hook execution for the worktree
+        #[arg(long)]
+        output: bool,
     },
     /// Initialize .trench.toml in current directory
     Init {
@@ -279,8 +283,8 @@ fn main() -> anyhow::Result<()> {
                 run_sync(&branch, strategy, json, dry_run, no_hooks)
             }
         }
-        Some(Commands::Log { branch, tail }) => {
-            run_log(branch.as_deref(), tail, json, output_config.should_color())
+        Some(Commands::Log { branch, tail, output }) => {
+            run_log(branch.as_deref(), tail, output, json, output_config.should_color())
         }
         None => {
             anyhow::bail!("TUI requires an interactive terminal (stdin and stdout must be a TTY)");
@@ -634,6 +638,7 @@ fn run_tag(identifier: &str, tags: &[String]) -> anyhow::Result<()> {
 fn run_log(
     branch: Option<&str>,
     tail: Option<usize>,
+    show_output: bool,
     json: bool,
     use_color: bool,
 ) -> anyhow::Result<()> {
@@ -671,6 +676,37 @@ fn run_log(
             eprintln!("error: worktree '{b}' not found");
             ExitCode::NotFound.exit();
         }
+    }
+
+    // --output mode: show hook stdout/stderr for a specific worktree
+    if show_output {
+        let b = match branch {
+            Some(b) => b,
+            None => {
+                eprintln!("error: --output requires a worktree argument");
+                eprintln!("usage: trench log <branch> --output");
+                ExitCode::MissingRequiredFlag.exit();
+            }
+        };
+        let result = if json {
+            cli::commands::log::execute_output_json(&db, repo_id, b)
+        } else {
+            cli::commands::log::execute_output(&db, repo_id, b)
+        };
+        match result {
+            Ok(out) => {
+                if out.ends_with('\n') {
+                    print!("{out}");
+                } else {
+                    println!("{out}");
+                }
+            }
+            Err(e) => {
+                eprintln!("error: {e}");
+                ExitCode::NotFound.exit();
+            }
+        }
+        return Ok(());
     }
 
     let output = if json {

--- a/src/main.rs
+++ b/src/main.rs
@@ -642,6 +642,13 @@ fn run_log(
     json: bool,
     use_color: bool,
 ) -> anyhow::Result<()> {
+    // --output requires a worktree argument
+    if show_output && branch.is_none() {
+        eprintln!("error: --output requires a worktree argument");
+        eprintln!("usage: trench log <branch> --output");
+        ExitCode::MissingRequiredFlag.exit();
+    }
+
     let cwd = std::env::current_dir().context("failed to determine current directory")?;
     let db_path = paths::data_dir()?.join("trench.db");
     let db = state::Database::open(&db_path)?;
@@ -680,14 +687,8 @@ fn run_log(
 
     // --output mode: show hook stdout/stderr for a specific worktree
     if show_output {
-        let b = match branch {
-            Some(b) => b,
-            None => {
-                eprintln!("error: --output requires a worktree argument");
-                eprintln!("usage: trench log <branch> --output");
-                ExitCode::MissingRequiredFlag.exit();
-            }
-        };
+        // branch is guaranteed Some by the check at function entry
+        let b = branch.unwrap();
         let result = if json {
             cli::commands::log::execute_output_json(&db, repo_id, b)
         } else {

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -135,6 +135,7 @@ impl Database {
         Migrations::new(vec![
             M::up(include_str!("sql/001_initial_schema.sql")),
             M::up(include_str!("sql/002_add_removed_at.sql")),
+            M::up(include_str!("sql/003_add_step_to_logs.sql")),
         ])
     }
 
@@ -798,15 +799,44 @@ mod tests {
             .insert_event(repo.id, Some(wt.id), "hook:post_create", None)
             .unwrap();
 
-        db.insert_log(event_id, "stdout", "hello world", 1).unwrap();
-        db.insert_log(event_id, "stderr", "warning: something", 2).unwrap();
-        db.insert_log(event_id, "stdout", "done", 3).unwrap();
+        db.insert_log(event_id, "stdout", "hello world", 1, Some("run")).unwrap();
+        db.insert_log(event_id, "stderr", "warning: something", 2, Some("run")).unwrap();
+        db.insert_log(event_id, "stdout", "done", 3, Some("shell")).unwrap();
 
         let logs = db.get_logs(event_id).unwrap();
         assert_eq!(logs.len(), 3);
         assert_eq!(logs[0], ("stdout".to_string(), "hello world".to_string(), 1));
         assert_eq!(logs[1], ("stderr".to_string(), "warning: something".to_string(), 2));
         assert_eq!(logs[2], ("stdout".to_string(), "done".to_string(), 3));
+    }
+
+    #[test]
+    fn insert_log_stores_step_label() {
+        let db = Database::open_in_memory().unwrap();
+        let repo = db.insert_repo("r", "/r", None).unwrap();
+        let wt = db
+            .insert_worktree(repo.id, "wt", "branch", "/wt", None)
+            .unwrap();
+
+        let event_id = db
+            .insert_event(repo.id, Some(wt.id), "hook:post_create", None)
+            .unwrap();
+
+        db.insert_log(event_id, "stdout", "line1", 1, Some("run")).unwrap();
+        db.insert_log(event_id, "stderr", "line2", 2, Some("shell")).unwrap();
+        db.insert_log(event_id, "stdout", "line3", 3, None).unwrap();
+
+        // Verify step is stored via raw query
+        let mut stmt = db.conn_for_test().prepare(
+            "SELECT step FROM logs WHERE event_id = ?1 ORDER BY line_number"
+        ).unwrap();
+        let steps: Vec<Option<String>> = stmt
+            .query_map(rusqlite::params![event_id], |row| row.get(0))
+            .unwrap()
+            .map(|r| r.unwrap())
+            .collect();
+
+        assert_eq!(steps, vec![Some("run".to_string()), Some("shell".to_string()), None]);
     }
 
     #[test]

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -79,6 +79,16 @@ pub struct LogEntry {
     pub created_at: i64,
 }
 
+/// A single line of hook output with metadata for replay display.
+#[derive(Debug, Clone)]
+pub struct HookOutputLine {
+    pub stream: String,
+    pub line: String,
+    pub step: Option<String>,
+    pub line_number: i64,
+    pub created_at: i64,
+}
+
 /// Core database handle wrapping a SQLite connection with migrations applied.
 #[derive(Debug)]
 pub struct Database {
@@ -808,6 +818,37 @@ mod tests {
         assert_eq!(logs[0], ("stdout".to_string(), "hello world".to_string(), 1));
         assert_eq!(logs[1], ("stderr".to_string(), "warning: something".to_string(), 2));
         assert_eq!(logs[2], ("stdout".to_string(), "done".to_string(), 3));
+    }
+
+    #[test]
+    fn get_hook_output_returns_lines_with_step_and_timestamp() {
+        let db = Database::open_in_memory().unwrap();
+        let repo = db.insert_repo("r", "/r", None).unwrap();
+        let wt = db
+            .insert_worktree(repo.id, "wt", "branch", "/wt", None)
+            .unwrap();
+
+        let event_id = db
+            .insert_event(repo.id, Some(wt.id), "hook:post_create", None)
+            .unwrap();
+
+        db.insert_log(event_id, "stdout", "hello", 1, Some("run")).unwrap();
+        db.insert_log(event_id, "stderr", "warn", 2, Some("run")).unwrap();
+        db.insert_log(event_id, "stdout", "done", 3, Some("shell")).unwrap();
+
+        let lines = db.get_hook_output(event_id).unwrap();
+        assert_eq!(lines.len(), 3);
+
+        assert_eq!(lines[0].stream, "stdout");
+        assert_eq!(lines[0].line, "hello");
+        assert_eq!(lines[0].step, Some("run".to_string()));
+        assert_eq!(lines[0].line_number, 1);
+        assert!(lines[0].created_at > 0);
+
+        assert_eq!(lines[1].stream, "stderr");
+        assert_eq!(lines[1].step, Some("run".to_string()));
+
+        assert_eq!(lines[2].step, Some("shell".to_string()));
     }
 
     #[test]

--- a/src/state/queries.rs
+++ b/src/state/queries.rs
@@ -581,6 +581,41 @@ impl Database {
         Ok(exists)
     }
 
+    /// Find the most recent hook event for a worktree (by name or branch).
+    ///
+    /// Returns the last event whose `event_type` starts with `hook:` for the
+    /// matching worktree, or `None` if no hook events exist.
+    pub fn get_last_hook_event_for_worktree(
+        &self,
+        repo_id: i64,
+        identifier: &str,
+    ) -> Result<Option<Event>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT e.id, e.event_type, e.payload, e.created_at
+             FROM events e
+             JOIN worktrees w ON e.worktree_id = w.id AND e.repo_id = w.repo_id
+             WHERE e.repo_id = ?1
+               AND (w.name = ?2 OR w.branch = ?2)
+               AND e.event_type LIKE 'hook:%'
+             ORDER BY e.created_at DESC, e.id DESC
+             LIMIT 1",
+        ).context("failed to prepare get_last_hook_event_for_worktree query")?;
+
+        let event = stmt
+            .query_row(rusqlite::params![repo_id, identifier], |row| {
+                Ok(Event {
+                    id: row.get(0)?,
+                    event_type: row.get(1)?,
+                    payload: row.get(2)?,
+                    created_at: row.get(3)?,
+                })
+            })
+            .optional()
+            .context("failed to get last hook event")?;
+
+        Ok(event)
+    }
+
     /// List events for a worktree, most recent first, up to `limit`.
     pub fn list_events(&self, worktree_id: i64, limit: usize) -> Result<Vec<Event>> {
         let mut stmt = self.conn.prepare(
@@ -614,6 +649,59 @@ impl Database {
 mod tests {
     use super::*;
     use crate::state::Database;
+
+    #[test]
+    fn get_last_hook_event_returns_most_recent_hook() {
+        let db = Database::open_in_memory().unwrap();
+        let repo = db.insert_repo("r", "/r", None).unwrap();
+        let wt = db
+            .insert_worktree(repo.id, "feat", "feature/feat", "/wt/feat", None)
+            .unwrap();
+
+        // Insert a non-hook event, then two hook events
+        db.insert_event(repo.id, Some(wt.id), "created", None).unwrap();
+        let payload1 = serde_json::json!({"hook": "post_create", "exit_code": 0, "duration_secs": 1.0});
+        db.insert_event(repo.id, Some(wt.id), "hook:post_create", Some(&payload1)).unwrap();
+        let payload2 = serde_json::json!({"hook": "pre_sync", "exit_code": 0, "duration_secs": 0.5});
+        let last_id = db.insert_event(repo.id, Some(wt.id), "hook:pre_sync", Some(&payload2)).unwrap();
+
+        let event = db.get_last_hook_event_for_worktree(repo.id, "feat").unwrap();
+        assert!(event.is_some(), "should find a hook event");
+        let event = event.unwrap();
+        assert_eq!(event.id, last_id);
+        assert_eq!(event.event_type, "hook:pre_sync");
+    }
+
+    #[test]
+    fn get_last_hook_event_returns_none_when_no_hooks() {
+        let db = Database::open_in_memory().unwrap();
+        let repo = db.insert_repo("r", "/r", None).unwrap();
+        let wt = db
+            .insert_worktree(repo.id, "feat", "feature/feat", "/wt/feat", None)
+            .unwrap();
+
+        // Only non-hook events
+        db.insert_event(repo.id, Some(wt.id), "created", None).unwrap();
+
+        let event = db.get_last_hook_event_for_worktree(repo.id, "feat").unwrap();
+        assert!(event.is_none(), "should return None when no hook events");
+    }
+
+    #[test]
+    fn get_last_hook_event_matches_by_branch_name() {
+        let db = Database::open_in_memory().unwrap();
+        let repo = db.insert_repo("r", "/r", None).unwrap();
+        let wt = db
+            .insert_worktree(repo.id, "feat", "feature/feat", "/wt/feat", None)
+            .unwrap();
+
+        let payload = serde_json::json!({"hook": "post_create", "exit_code": 0, "duration_secs": 1.0});
+        db.insert_event(repo.id, Some(wt.id), "hook:post_create", Some(&payload)).unwrap();
+
+        // Match by branch name (not sanitized name)
+        let event = db.get_last_hook_event_for_worktree(repo.id, "feature/feat").unwrap();
+        assert!(event.is_some(), "should match by branch name");
+    }
 
     #[test]
     fn list_events_filtered_with_limit_returns_n_most_recent() {

--- a/src/state/queries.rs
+++ b/src/state/queries.rs
@@ -443,6 +443,35 @@ impl Database {
         Ok(())
     }
 
+    /// Retrieve hook output lines for an event with full metadata (step, timestamps).
+    pub fn get_hook_output(&self, event_id: i64) -> Result<Vec<super::HookOutputLine>> {
+        let mut stmt = self
+            .conn
+            .prepare(
+                "SELECT stream, line, step, line_number, created_at FROM logs
+                 WHERE event_id = ?1 ORDER BY line_number",
+            )
+            .context("failed to prepare get_hook_output query")?;
+
+        let rows = stmt
+            .query_map(rusqlite::params![event_id], |row| {
+                Ok(super::HookOutputLine {
+                    stream: row.get(0)?,
+                    line: row.get(1)?,
+                    step: row.get(2)?,
+                    line_number: row.get(3)?,
+                    created_at: row.get(4)?,
+                })
+            })
+            .context("failed to get hook output")?;
+
+        let mut lines = Vec::new();
+        for row in rows {
+            lines.push(row.context("failed to read hook output line")?);
+        }
+        Ok(lines)
+    }
+
     /// Retrieve log lines for an event, ordered by line number.
     pub fn get_logs(&self, event_id: i64) -> Result<Vec<(String, String, i64)>> {
         let mut stmt = self

--- a/src/state/queries.rs
+++ b/src/state/queries.rs
@@ -430,13 +430,14 @@ impl Database {
         stream: &str,
         line: &str,
         line_number: i64,
+        step: Option<&str>,
     ) -> Result<()> {
         let created_at = now();
         self.conn
             .execute(
-                "INSERT INTO logs (event_id, stream, line, line_number, created_at)
-                 VALUES (?1, ?2, ?3, ?4, ?5)",
-                rusqlite::params![event_id, stream, line, line_number, created_at],
+                "INSERT INTO logs (event_id, stream, line, line_number, step, created_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+                rusqlite::params![event_id, stream, line, line_number, step, created_at],
             )
             .context("failed to insert log line")?;
         Ok(())

--- a/src/state/sql/003_add_step_to_logs.sql
+++ b/src/state/sql/003_add_step_to_logs.sql
@@ -1,0 +1,1 @@
+ALTER TABLE logs ADD COLUMN step TEXT;

--- a/tests/log_command.rs
+++ b/tests/log_command.rs
@@ -379,3 +379,183 @@ fn log_scoped_and_tail_combined() {
         "event should be for combo-a"
     );
 }
+
+#[test]
+fn log_output_replays_hook_stdout_stderr() {
+    let tmp = tempfile::tempdir().unwrap();
+    init_git_repo(tmp.path());
+
+    // Write .trench.toml with post_create hooks that produce output
+    std::fs::write(
+        tmp.path().join(".trench.toml"),
+        r#"
+[hooks.post_create]
+run = ["echo hook_run_output"]
+shell = "echo hook_shell_output >&2"
+timeout_secs = 30
+"#,
+    )
+    .unwrap();
+
+    // Create a worktree — triggers post_create hook
+    let create = Command::new(trench_bin())
+        .args(["create", "output-test"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("create");
+    assert!(
+        create.status.success(),
+        "trench create should succeed, stderr: {}",
+        String::from_utf8_lossy(&create.stderr)
+    );
+
+    // Replay hook output via --output (table mode)
+    let output = Command::new(trench_bin())
+        .args(["log", "output-test", "--output", "--no-color"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("trench log --output");
+
+    assert!(
+        output.status.success(),
+        "trench log --output should exit 0, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    // Should contain actual hook output
+    assert!(
+        stdout.contains("hook_run_output"),
+        "should contain run output, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("hook_shell_output"),
+        "should contain shell output, got: {stdout}"
+    );
+
+    // Should contain step labels
+    assert!(
+        stdout.contains("[run]"),
+        "should contain [run] step label, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("[shell]"),
+        "should contain [shell] step label, got: {stdout}"
+    );
+
+    // Should contain event type header
+    assert!(
+        stdout.contains("hook:post_create"),
+        "should contain event type, got: {stdout}"
+    );
+}
+
+#[test]
+fn log_output_json_returns_structured_output() {
+    let tmp = tempfile::tempdir().unwrap();
+    init_git_repo(tmp.path());
+
+    // Write .trench.toml with hooks that produce output
+    std::fs::write(
+        tmp.path().join(".trench.toml"),
+        r#"
+[hooks.post_create]
+run = ["echo json_test_output"]
+timeout_secs = 30
+"#,
+    )
+    .unwrap();
+
+    // Create a worktree
+    let create = Command::new(trench_bin())
+        .args(["create", "json-output-test"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("create");
+    assert!(
+        create.status.success(),
+        "trench create should succeed, stderr: {}",
+        String::from_utf8_lossy(&create.stderr)
+    );
+
+    // Replay hook output via --output --json
+    let output = Command::new(trench_bin())
+        .args(["log", "json-output-test", "--output", "--json"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("trench log --output --json");
+
+    assert!(
+        output.status.success(),
+        "trench log --output --json should exit 0, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).expect("valid JSON");
+
+    assert_eq!(parsed["event_type"], "hook:post_create");
+    assert_eq!(parsed["exit_code"], 0);
+    assert!(parsed["duration_secs"].is_number());
+    assert!(parsed["timestamp"].is_string());
+
+    let lines = parsed["lines"].as_array().expect("lines array");
+    assert!(!lines.is_empty(), "should have at least one output line");
+
+    // Find the line containing our output
+    let has_output = lines.iter().any(|l| l["line"].as_str() == Some("json_test_output"));
+    assert!(has_output, "should contain our hook output, got: {parsed}");
+
+    // Check step label
+    let run_line = lines.iter().find(|l| l["line"].as_str() == Some("json_test_output")).unwrap();
+    assert_eq!(run_line["step"], "run");
+    assert_eq!(run_line["stream"], "stdout");
+}
+
+#[test]
+fn log_output_without_branch_exits_8() {
+    let tmp = tempfile::tempdir().unwrap();
+    init_git_repo(tmp.path());
+
+    let output = Command::new(trench_bin())
+        .args(["log", "--output"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("trench log --output");
+
+    assert_eq!(
+        exit_code(output.status),
+        8,
+        "should exit 8 when --output used without branch, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn log_output_no_hooks_exits_2() {
+    let tmp = tempfile::tempdir().unwrap();
+    init_git_repo(tmp.path());
+
+    // Create a worktree without hooks
+    let create = Command::new(trench_bin())
+        .args(["create", "no-hooks-test", "--no-hooks"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("create");
+    assert!(create.status.success());
+
+    // Try to replay output — should fail since no hook events
+    let output = Command::new(trench_bin())
+        .args(["log", "no-hooks-test", "--output"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("trench log --output");
+
+    assert_eq!(
+        exit_code(output.status),
+        2,
+        "should exit 2 when no hook output, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}


### PR DESCRIPTION
Closes #50

## Summary
Implements the `--output` flag for `trench log` that replays captured hook stdout/stderr from the last hook execution for a given worktree. Output is labeled by step (run/shell) with timestamps per line, and supports both human-readable table format and structured JSON via `--json`. Includes a schema migration to track which hook step produced each output line.

## User Stories Addressed
- US-10: View hook execution logs and output from past runs

## Automated Testing
- Total tests added: 13
- Tests passing: 13
- Tests failing: 0
- `cargo clippy`: pass (warnings only — all pre-existing)
- `cargo test`: pass (642 total: 619 unit + 11 exit_codes + 12 log_command)

## UAT Checklist
- [ ] Create a worktree with hooks configured in `.trench.toml` (e.g., `[hooks.post_create] run = ["echo hello"]`) → hook runs and output is captured
- [ ] `trench log my-feature --output` → displays hook stdout/stderr with `[run]`/`[shell]` step labels and timestamps
- [ ] `trench log my-feature --output --json` → returns structured JSON with event metadata and lines array
- [ ] `trench log --output` (no branch) → exits with code 8 and helpful usage message
- [ ] `trench log my-feature --output` on a worktree with no hook history → exits with code 2 and error message
- [ ] `trench log my-feature --output` after a failed hook → shows partial output captured before failure
- [ ] Existing `trench log` behavior (without `--output`) is unchanged — table/JSON event listing works as before

## Known Issues
None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--output` flag to the log command, allowing you to replay and view hook execution output for a specific worktree
  * Hook output displays with step labels and timestamps for each line
  * Hook output supports both plain text and JSON format options for structured consumption

<!-- end of auto-generated comment: release notes by coderabbit.ai -->