### PR TITLE
feat(tui): implement hook log live streaming during execution

### DIFF
--- a/src/cli/commands/create.rs
+++ b/src/cli/commands/create.rs
@@ -178,6 +178,7 @@ pub async fn execute_with_hooks(
     db: &Database,
     hooks_config: Option<&HooksConfig>,
     no_hooks: bool,
+    hook_tx: Option<&std::sync::mpsc::Sender<crate::tui::screens::hook_log::HookOutputMessage>>,
 ) -> Result<CreateWithHooksResult> {
     let has_hooks = hooks_config
         .map(|h| h.pre_create.is_some() || h.post_create.is_some())
@@ -234,7 +235,7 @@ pub async fn execute_with_hooks(
             db,
             repo.id,
             None,
-            None,
+            hook_tx,
         )
         .await
         .map_err(CreateError::PreCreateHookFailed)?;
@@ -258,7 +259,7 @@ pub async fn execute_with_hooks(
             db,
             repo.id,
             worktree_id,
-            None,
+            hook_tx,
         )
         .await
         {
@@ -1095,6 +1096,7 @@ mod tests {
             &db,
             None, // no hooks configured
             false, // no_hooks flag = false
+            None,
         )
         .await
         .expect("should succeed");
@@ -1129,6 +1131,7 @@ mod tests {
             &db,
             Some(&hooks),
             true, // no_hooks = true → skip
+            None,
         )
         .await
         .expect("should succeed");
@@ -1171,6 +1174,7 @@ mod tests {
             &db,
             Some(&hooks),
             false,
+            None,
         )
         .await
         .expect("should succeed");
@@ -1208,6 +1212,7 @@ mod tests {
             &db,
             Some(&hooks),
             false,
+            None,
         )
         .await
         .expect_err("should fail when pre_create hook fails");
@@ -1261,6 +1266,7 @@ mod tests {
             &db,
             Some(&hooks),
             false,
+            None,
         )
         .await
         .expect("should succeed");
@@ -1308,6 +1314,7 @@ mod tests {
             &db,
             Some(&hooks),
             false,
+            None,
         )
         .await
         .expect("should succeed (worktree stays despite hook failure)");
@@ -1363,6 +1370,7 @@ mod tests {
             &db,
             Some(&hooks),
             false,
+            None,
         )
         .await
         .expect("should succeed");
@@ -1430,6 +1438,7 @@ mod tests {
             &db,
             Some(&hooks),
             false,
+            None,
         )
         .await
         .expect_err("should fail when pre_create hook fails");

--- a/src/cli/commands/create.rs
+++ b/src/cli/commands/create.rs
@@ -234,6 +234,7 @@ pub async fn execute_with_hooks(
             db,
             repo.id,
             None,
+            None,
         )
         .await
         .map_err(CreateError::PreCreateHookFailed)?;
@@ -257,6 +258,7 @@ pub async fn execute_with_hooks(
             db,
             repo.id,
             worktree_id,
+            None,
         )
         .await
         {

--- a/src/cli/commands/remove.rs
+++ b/src/cli/commands/remove.rs
@@ -241,6 +241,7 @@ pub async fn execute_resolved_with_hooks(
     prune: bool,
     hooks_config: Option<&HooksConfig>,
     no_hooks: bool,
+    hook_tx: Option<&std::sync::mpsc::Sender<crate::tui::screens::hook_log::HookOutputMessage>>,
 ) -> Result<RemoveWithHooksResult> {
     let has_hooks = hooks_config
         .map(|h| h.pre_remove.is_some() || h.post_remove.is_some())
@@ -285,7 +286,7 @@ pub async fn execute_resolved_with_hooks(
                 db,
                 repo.id,
                 Some(wt.id),
-                None,
+                hook_tx,
             )
             .await
             .map_err(RemoveError::PreRemoveHookFailed)?;
@@ -317,7 +318,7 @@ pub async fn execute_resolved_with_hooks(
             db,
             repo.id,
             Some(wt.id),
-            None,
+            hook_tx,
         )
         .await
         {
@@ -816,6 +817,7 @@ mod tests {
             false,
             None,  // no hooks
             false, // no_hooks flag irrelevant
+            None,
         )
         .await
         .expect("remove should succeed");
@@ -859,6 +861,7 @@ mod tests {
             false,
             Some(&hooks),
             true, // no_hooks = true
+            None,
         )
         .await
         .expect("remove should succeed");
@@ -915,6 +918,7 @@ mod tests {
             false,
             Some(&hooks),
             false,
+            None,
         )
         .await
         .expect("remove should succeed");
@@ -982,6 +986,7 @@ mod tests {
             false,
             Some(&hooks),
             false,
+            None,
         )
         .await
         .expect_err("should fail when pre_remove hook fails");
@@ -1048,6 +1053,7 @@ mod tests {
             false,
             Some(&hooks),
             false,
+            None,
         )
         .await
         .expect("remove should succeed");
@@ -1112,6 +1118,7 @@ mod tests {
             false,
             Some(&hooks),
             false,
+            None,
         )
         .await
         .expect("remove should succeed even when worktree dir is gone");
@@ -1170,6 +1177,7 @@ mod tests {
             false,
             Some(&hooks),
             false,
+            None,
         )
         .await
         .expect("remove should succeed even if post_remove fails");

--- a/src/cli/commands/remove.rs
+++ b/src/cli/commands/remove.rs
@@ -285,6 +285,7 @@ pub async fn execute_resolved_with_hooks(
                 db,
                 repo.id,
                 Some(wt.id),
+                None,
             )
             .await
             .map_err(RemoveError::PreRemoveHookFailed)?;
@@ -316,6 +317,7 @@ pub async fn execute_resolved_with_hooks(
             db,
             repo.id,
             Some(wt.id),
+            None,
         )
         .await
         {

--- a/src/cli/commands/sync.rs
+++ b/src/cli/commands/sync.rs
@@ -434,6 +434,7 @@ pub async fn execute_with_hooks(
     strategy: Strategy,
     hooks_config: Option<&HooksConfig>,
     no_hooks: bool,
+    hook_tx: Option<&std::sync::mpsc::Sender<crate::tui::screens::hook_log::HookOutputMessage>>,
 ) -> Result<SyncWithHooksResult> {
     let has_hooks = hooks_config
         .map(|h| h.pre_sync.is_some() || h.post_sync.is_some())
@@ -486,7 +487,7 @@ pub async fn execute_with_hooks(
             db,
             repo.id,
             Some(wt.id),
-            None,
+            hook_tx,
         )
         .await
         .map_err(SyncError::PreSyncHookFailed)?;
@@ -506,7 +507,7 @@ pub async fn execute_with_hooks(
             db,
             repo.id,
             Some(wt.id),
-            None,
+            hook_tx,
         )
         .await
         {
@@ -1243,6 +1244,7 @@ mod tests {
             Strategy::Rebase,
             None,  // no hooks config
             false, // no_hooks flag
+            None,
         )
         .await
         .expect("sync should succeed");
@@ -1265,6 +1267,7 @@ mod tests {
             Strategy::Rebase,
             Some(&hooks),
             true, // no_hooks = true
+            None,
         )
         .await
         .expect("sync should succeed");
@@ -1314,6 +1317,7 @@ mod tests {
             Strategy::Rebase,
             Some(&hooks),
             false,
+            None,
         )
         .await
         .expect("sync should succeed");
@@ -1371,6 +1375,7 @@ mod tests {
             Strategy::Rebase,
             Some(&hooks),
             false,
+            None,
         )
         .await
         .expect_err("should fail when pre_sync hook fails");
@@ -1427,6 +1432,7 @@ mod tests {
             Strategy::Rebase,
             Some(&hooks),
             false,
+            None,
         )
         .await
         .expect("sync should succeed");
@@ -1478,6 +1484,7 @@ mod tests {
             Strategy::Rebase,
             Some(&hooks),
             false,
+            None,
         )
         .await
         .expect("sync should succeed even if post_sync fails");
@@ -1555,6 +1562,7 @@ mod tests {
             Strategy::Rebase,
             Some(&hooks),
             false,
+            None,
         )
         .await
         .expect("sync should succeed");

--- a/src/cli/commands/sync.rs
+++ b/src/cli/commands/sync.rs
@@ -486,6 +486,7 @@ pub async fn execute_with_hooks(
             db,
             repo.id,
             Some(wt.id),
+            None,
         )
         .await
         .map_err(SyncError::PreSyncHookFailed)?;
@@ -505,6 +506,7 @@ pub async fn execute_with_hooks(
             db,
             repo.id,
             Some(wt.id),
+            None,
         )
         .await
         {

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -3,6 +3,7 @@ pub mod run;
 pub mod runner;
 pub mod shell;
 pub mod stream;
+pub mod types;
 
 use std::collections::HashMap;
 use std::fmt;
@@ -121,7 +122,10 @@ mod tests {
         let env = build_env(&ctx, &HookEvent::PostCreate);
 
         assert_eq!(env.len(), 7);
-        assert_eq!(env["TRENCH_WORKTREE_PATH"], "/home/user/.worktrees/myrepo/feat-auth");
+        assert_eq!(
+            env["TRENCH_WORKTREE_PATH"],
+            "/home/user/.worktrees/myrepo/feat-auth"
+        );
         assert_eq!(env["TRENCH_WORKTREE_NAME"], "feat-auth");
         assert_eq!(env["TRENCH_BRANCH"], "feature/auth");
         assert_eq!(env["TRENCH_REPO_NAME"], "myrepo");
@@ -212,7 +216,10 @@ timeout_secs = 60
         );
         assert_eq!(
             post_create.run,
-            Some(vec!["bun install".to_string(), "bunx prisma generate".to_string()])
+            Some(vec![
+                "bun install".to_string(),
+                "bunx prisma generate".to_string()
+            ])
         );
         assert!(post_create.shell.is_none());
         assert_eq!(post_create.timeout_secs, Some(300));
@@ -221,7 +228,10 @@ timeout_secs = 60
         let pre_remove = get_hook_config(&hooks, &HookEvent::PreRemove).unwrap();
         assert!(pre_remove.copy.is_none());
         assert!(pre_remove.run.is_none());
-        assert_eq!(pre_remove.shell, Some("pkill -f 'next dev' || true".to_string()));
+        assert_eq!(
+            pre_remove.shell,
+            Some("pkill -f 'next dev' || true".to_string())
+        );
         assert_eq!(pre_remove.timeout_secs, Some(60));
 
         // unconfigured hooks return None

--- a/src/hooks/runner.rs
+++ b/src/hooks/runner.rs
@@ -1,4 +1,5 @@
 use std::path::Path;
+use std::sync::mpsc::Sender;
 use std::time::Instant;
 
 use anyhow::{Context, Result};
@@ -8,6 +9,7 @@ use super::run::{execute_run_step, RunStepError};
 use super::shell::{execute_shell_step, ShellStepError};
 use super::{build_env, HookConfig, HookEnvContext, HookEvent};
 use crate::state::Database;
+use crate::tui::screens::hook_log::HookOutputMessage;
 
 /// Timeout error returned when run + shell steps exceed `timeout_secs`.
 #[derive(Debug, thiserror::Error)]
@@ -32,6 +34,14 @@ pub struct HookResult {
 /// - Any step failure stops remaining steps.
 /// - All output is captured and logged to the database.
 /// - Returns `HookTimeoutError` (exit code 7) on timeout.
+/// Helper to send a message through the optional sender, ignoring errors.
+fn send_msg(tx: Option<&Sender<HookOutputMessage>>, msg: HookOutputMessage) {
+    if let Some(tx) = tx {
+        let _ = tx.send(msg);
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
 pub async fn execute_hook(
     event: &HookEvent,
     config: &HookConfig,
@@ -41,6 +51,7 @@ pub async fn execute_hook(
     db: &Database,
     repo_id: i64,
     worktree_id: Option<i64>,
+    tx: Option<&Sender<HookOutputMessage>>,
 ) -> Result<HookResult> {
     let start = Instant::now();
     let env_vars = build_env(env_ctx, event);
@@ -50,41 +61,73 @@ pub async fn execute_hook(
 
     // Step 1: Copy (not subject to timeout)
     if let Some(ref patterns) = config.copy {
+        let step_start = Instant::now();
+        send_msg(tx, HookOutputMessage::StepStarted { step: "copy".into() });
         if let Err(e) = execute_copy_step(source_dir, work_dir, patterns) {
+            let step_dur = step_start.elapsed();
+            send_msg(tx, HookOutputMessage::StepCompleted {
+                step: "copy".into(), success: false, duration: step_dur,
+            });
             let duration = start.elapsed();
             record_execution(
                 db, repo_id, worktree_id, event, 1, duration.as_secs_f64(), &all_output,
             )?;
+            send_msg(tx, HookOutputMessage::HookCompleted {
+                success: false, duration, error: Some(e.to_string()),
+            });
             return Err(e.context("copy step failed"));
         }
+        let step_dur = step_start.elapsed();
+        send_msg(tx, HookOutputMessage::StepCompleted {
+            step: "copy".into(), success: true, duration: step_dur,
+        });
     }
 
     // Step 2: Run (subject to timeout)
     let run_deadline = Instant::now() + std::time::Duration::from_secs(timeout_secs);
     if let Some(ref commands) = config.run {
+        let step_start = Instant::now();
+        send_msg(tx, HookOutputMessage::StepStarted { step: "run".into() });
         let remaining = run_deadline.saturating_duration_since(Instant::now());
         match tokio::time::timeout(remaining, execute_run_step(commands, work_dir, &env_vars))
             .await
         {
             Ok(Ok(run_result)) => {
                 for cmd_output in &run_result.executed {
-                    collect_output(&mut all_output, "run", &cmd_output.stdout, &cmd_output.stderr);
+                    collect_output_with_sender(&mut all_output, "run", &cmd_output.stdout, &cmd_output.stderr, tx);
                 }
+                let step_dur = step_start.elapsed();
+                send_msg(tx, HookOutputMessage::StepCompleted {
+                    step: "run".into(), success: true, duration: step_dur,
+                });
             }
             Ok(Err(e)) => {
-                // Collect partial output from the error if it's a RunStepError
                 let exit_code = extract_run_error_output(&e, &mut all_output);
+                let step_dur = step_start.elapsed();
+                send_msg(tx, HookOutputMessage::StepCompleted {
+                    step: "run".into(), success: false, duration: step_dur,
+                });
                 let duration = start.elapsed();
                 record_execution(
                     db, repo_id, worktree_id, event, exit_code, duration.as_secs_f64(), &all_output,
                 )?;
+                send_msg(tx, HookOutputMessage::HookCompleted {
+                    success: false, duration, error: Some(e.to_string()),
+                });
                 return Err(e);
             }
             Err(_) => {
+                let step_dur = step_start.elapsed();
+                send_msg(tx, HookOutputMessage::StepCompleted {
+                    step: "run".into(), success: false, duration: step_dur,
+                });
                 let duration = start.elapsed();
                 record_execution(
                     db, repo_id, worktree_id, event, 7, duration.as_secs_f64(), &all_output,
                 )?;
+                send_msg(tx, HookOutputMessage::HookCompleted {
+                    success: false, duration, error: Some(format!("hook timed out after {timeout_secs}s")),
+                });
                 return Err(HookTimeoutError { timeout_secs }.into());
             }
         }
@@ -92,26 +135,46 @@ pub async fn execute_hook(
 
     // Step 3: Shell (remaining timeout budget)
     if let Some(ref script) = config.shell {
+        let step_start = Instant::now();
+        send_msg(tx, HookOutputMessage::StepStarted { step: "shell".into() });
         let remaining = run_deadline.saturating_duration_since(Instant::now());
         match tokio::time::timeout(remaining, execute_shell_step(script, work_dir, &env_vars))
             .await
         {
             Ok(Ok(shell_output)) => {
-                collect_output(&mut all_output, "shell", &shell_output.stdout, &shell_output.stderr);
+                collect_output_with_sender(&mut all_output, "shell", &shell_output.stdout, &shell_output.stderr, tx);
+                let step_dur = step_start.elapsed();
+                send_msg(tx, HookOutputMessage::StepCompleted {
+                    step: "shell".into(), success: true, duration: step_dur,
+                });
             }
             Ok(Err(e)) => {
                 let exit_code = extract_shell_error_output(&e, &mut all_output);
+                let step_dur = step_start.elapsed();
+                send_msg(tx, HookOutputMessage::StepCompleted {
+                    step: "shell".into(), success: false, duration: step_dur,
+                });
                 let duration = start.elapsed();
                 record_execution(
                     db, repo_id, worktree_id, event, exit_code, duration.as_secs_f64(), &all_output,
                 )?;
+                send_msg(tx, HookOutputMessage::HookCompleted {
+                    success: false, duration, error: Some(e.to_string()),
+                });
                 return Err(e);
             }
             Err(_) => {
+                let step_dur = step_start.elapsed();
+                send_msg(tx, HookOutputMessage::StepCompleted {
+                    step: "shell".into(), success: false, duration: step_dur,
+                });
                 let duration = start.elapsed();
                 record_execution(
                     db, repo_id, worktree_id, event, 7, duration.as_secs_f64(), &all_output,
                 )?;
+                send_msg(tx, HookOutputMessage::HookCompleted {
+                    success: false, duration, error: Some(format!("hook timed out after {timeout_secs}s")),
+                });
                 return Err(HookTimeoutError { timeout_secs }.into());
             }
         }
@@ -121,6 +184,10 @@ pub async fn execute_hook(
     let event_id = record_execution(
         db, repo_id, worktree_id, event, 0, duration.as_secs_f64(), &all_output,
     )?;
+
+    send_msg(tx, HookOutputMessage::HookCompleted {
+        success: true, duration, error: None,
+    });
 
     Ok(HookResult {
         event_id,
@@ -157,11 +224,31 @@ fn extract_shell_error_output(
 }
 
 fn collect_output(all_output: &mut Vec<(String, String, String)>, step: &str, stdout: &str, stderr: &str) {
+    collect_output_with_sender(all_output, step, stdout, stderr, None);
+}
+
+fn collect_output_with_sender(
+    all_output: &mut Vec<(String, String, String)>,
+    step: &str,
+    stdout: &str,
+    stderr: &str,
+    tx: Option<&Sender<HookOutputMessage>>,
+) {
     for line in stdout.lines() {
         all_output.push((step.to_string(), "stdout".to_string(), line.to_string()));
+        send_msg(tx, HookOutputMessage::OutputLine {
+            step: step.to_string(),
+            stream: "stdout".to_string(),
+            line: line.to_string(),
+        });
     }
     for line in stderr.lines() {
         all_output.push((step.to_string(), "stderr".to_string(), line.to_string()));
+        send_msg(tx, HookOutputMessage::OutputLine {
+            step: step.to_string(),
+            stream: "stderr".to_string(),
+            line: line.to_string(),
+        });
     }
 }
 
@@ -247,6 +334,7 @@ mod tests {
             &db,
             repo_id,
             Some(wt_id),
+            None,
         )
         .await
         .expect("hook should succeed");
@@ -303,6 +391,7 @@ mod tests {
             &db,
             repo_id,
             Some(wt_id),
+            None,
         )
         .await
         .expect("hook should succeed");
@@ -339,6 +428,7 @@ mod tests {
             &db,
             repo_id,
             Some(wt_id),
+            None,
         )
         .await
         .expect("hook should succeed");
@@ -374,6 +464,7 @@ mod tests {
             &db,
             repo_id,
             Some(wt_id),
+            None,
         )
         .await
         .expect_err("hook should fail");
@@ -424,6 +515,7 @@ mod tests {
             &db,
             repo_id,
             Some(wt_id),
+            None,
         )
         .await
         .expect_err("hook should fail");
@@ -464,6 +556,7 @@ mod tests {
             &db,
             repo_id,
             Some(wt_id),
+            None,
         )
         .await
         .expect_err("hook should timeout");
@@ -507,6 +600,7 @@ mod tests {
             &db,
             repo_id,
             Some(wt_id),
+            None,
         )
         .await
         .expect_err("hook should timeout on shell step");
@@ -540,6 +634,7 @@ mod tests {
             &db,
             repo_id,
             Some(wt_id),
+            None,
         )
         .await
         .unwrap();
@@ -582,6 +677,7 @@ mod tests {
             &db,
             repo_id,
             Some(wt_id),
+            None,
         )
         .await
         .unwrap();
@@ -625,6 +721,7 @@ mod tests {
             &db,
             repo_id,
             Some(wt_id),
+            None,
         )
         .await
         .unwrap();
@@ -645,5 +742,90 @@ mod tests {
         assert_eq!(rows.len(), 2);
         assert_eq!(rows[0], ("from_run".to_string(), Some("run".to_string())));
         assert_eq!(rows[1], ("from_shell".to_string(), Some("shell".to_string())));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn execute_hook_sends_messages_through_sender() {
+        use crate::tui::screens::hook_log::HookOutputMessage;
+
+        let source = TempDir::new().unwrap();
+        let work = TempDir::new().unwrap();
+        let (db, repo_id, wt_id) = setup_db();
+
+        let config = HookDef {
+            copy: None,
+            run: Some(vec!["echo hello".to_string()]),
+            shell: None,
+            timeout_secs: Some(30),
+        };
+
+        let env_ctx = test_env_ctx(source.path(), work.path());
+        let (tx, rx) = std::sync::mpsc::channel();
+
+        let _result = execute_hook(
+            &HookEvent::PostCreate,
+            &config,
+            &env_ctx,
+            source.path(),
+            work.path(),
+            &db,
+            repo_id,
+            Some(wt_id),
+            Some(&tx),
+        )
+        .await
+        .expect("hook should succeed");
+
+        // Collect all messages
+        let mut messages = Vec::new();
+        while let Ok(msg) = rx.try_recv() {
+            messages.push(msg);
+        }
+
+        // Should have: StepStarted(run), OutputLine(hello), StepCompleted(run), HookCompleted
+        assert!(messages.len() >= 3, "expected at least 3 messages, got: {}", messages.len());
+
+        // First should be StepStarted
+        assert!(matches!(&messages[0], HookOutputMessage::StepStarted { step } if step == "run"));
+
+        // Should contain an output line with "hello"
+        let has_hello = messages.iter().any(|m| {
+            matches!(m, HookOutputMessage::OutputLine { line, .. } if line == "hello")
+        });
+        assert!(has_hello, "should have output line with 'hello'");
+
+        // Last should be HookCompleted
+        assert!(matches!(messages.last().unwrap(), HookOutputMessage::HookCompleted { success: true, .. }));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn execute_hook_without_sender_still_works() {
+        let source = TempDir::new().unwrap();
+        let work = TempDir::new().unwrap();
+        let (db, repo_id, wt_id) = setup_db();
+
+        let config = HookDef {
+            copy: None,
+            run: Some(vec!["echo test".to_string()]),
+            shell: None,
+            timeout_secs: Some(30),
+        };
+
+        let env_ctx = test_env_ctx(source.path(), work.path());
+
+        // Pass None for sender — should work exactly like before
+        let result = execute_hook(
+            &HookEvent::PostCreate,
+            &config,
+            &env_ctx,
+            source.path(),
+            work.path(),
+            &db,
+            repo_id,
+            Some(wt_id),
+            None,
+        )
+        .await;
+        assert!(result.is_ok());
     }
 }

--- a/src/hooks/runner.rs
+++ b/src/hooks/runner.rs
@@ -7,9 +7,9 @@ use anyhow::{Context, Result};
 use super::copy::execute_copy_step;
 use super::run::{execute_run_step, RunStepError};
 use super::shell::{execute_shell_step, ShellStepError};
+use super::types::HookOutputMessage;
 use super::{build_env, HookConfig, HookEnvContext, HookEvent};
 use crate::state::Database;
-use crate::tui::screens::hook_log::HookOutputMessage;
 
 /// Timeout error returned when run + shell steps exceed `timeout_secs`.
 #[derive(Debug, thiserror::Error)]
@@ -62,25 +62,51 @@ pub async fn execute_hook(
     // Step 1: Copy (not subject to timeout)
     if let Some(ref patterns) = config.copy {
         let step_start = Instant::now();
-        send_msg(tx, HookOutputMessage::StepStarted { step: "copy".into() });
+        send_msg(
+            tx,
+            HookOutputMessage::StepStarted {
+                step: "copy".into(),
+            },
+        );
         if let Err(e) = execute_copy_step(source_dir, work_dir, patterns) {
             let step_dur = step_start.elapsed();
-            send_msg(tx, HookOutputMessage::StepCompleted {
-                step: "copy".into(), success: false, duration: step_dur,
-            });
+            send_msg(
+                tx,
+                HookOutputMessage::StepCompleted {
+                    step: "copy".into(),
+                    success: false,
+                    duration: step_dur,
+                },
+            );
             let duration = start.elapsed();
             record_execution(
-                db, repo_id, worktree_id, event, 1, duration.as_secs_f64(), &all_output,
+                db,
+                repo_id,
+                worktree_id,
+                event,
+                1,
+                duration.as_secs_f64(),
+                &all_output,
             )?;
-            send_msg(tx, HookOutputMessage::HookCompleted {
-                success: false, duration, error: Some(e.to_string()),
-            });
+            send_msg(
+                tx,
+                HookOutputMessage::HookCompleted {
+                    success: false,
+                    duration,
+                    error: Some(e.to_string()),
+                },
+            );
             return Err(e.context("copy step failed"));
         }
         let step_dur = step_start.elapsed();
-        send_msg(tx, HookOutputMessage::StepCompleted {
-            step: "copy".into(), success: true, duration: step_dur,
-        });
+        send_msg(
+            tx,
+            HookOutputMessage::StepCompleted {
+                step: "copy".into(),
+                success: true,
+                duration: step_dur,
+            },
+        );
     }
 
     // Step 2: Run (subject to timeout)
@@ -89,45 +115,87 @@ pub async fn execute_hook(
         let step_start = Instant::now();
         send_msg(tx, HookOutputMessage::StepStarted { step: "run".into() });
         let remaining = run_deadline.saturating_duration_since(Instant::now());
-        match tokio::time::timeout(remaining, execute_run_step(commands, work_dir, &env_vars))
-            .await
+        match tokio::time::timeout(remaining, execute_run_step(commands, work_dir, &env_vars)).await
         {
             Ok(Ok(run_result)) => {
                 for cmd_output in &run_result.executed {
-                    collect_output_with_sender(&mut all_output, "run", &cmd_output.stdout, &cmd_output.stderr, tx);
+                    collect_output_with_sender(
+                        &mut all_output,
+                        "run",
+                        &cmd_output.stdout,
+                        &cmd_output.stderr,
+                        tx,
+                    );
                 }
                 let step_dur = step_start.elapsed();
-                send_msg(tx, HookOutputMessage::StepCompleted {
-                    step: "run".into(), success: true, duration: step_dur,
-                });
+                send_msg(
+                    tx,
+                    HookOutputMessage::StepCompleted {
+                        step: "run".into(),
+                        success: true,
+                        duration: step_dur,
+                    },
+                );
             }
             Ok(Err(e)) => {
                 let exit_code = extract_run_error_output(&e, &mut all_output);
                 let step_dur = step_start.elapsed();
-                send_msg(tx, HookOutputMessage::StepCompleted {
-                    step: "run".into(), success: false, duration: step_dur,
-                });
+                send_msg(
+                    tx,
+                    HookOutputMessage::StepCompleted {
+                        step: "run".into(),
+                        success: false,
+                        duration: step_dur,
+                    },
+                );
                 let duration = start.elapsed();
                 record_execution(
-                    db, repo_id, worktree_id, event, exit_code, duration.as_secs_f64(), &all_output,
+                    db,
+                    repo_id,
+                    worktree_id,
+                    event,
+                    exit_code,
+                    duration.as_secs_f64(),
+                    &all_output,
                 )?;
-                send_msg(tx, HookOutputMessage::HookCompleted {
-                    success: false, duration, error: Some(e.to_string()),
-                });
+                send_msg(
+                    tx,
+                    HookOutputMessage::HookCompleted {
+                        success: false,
+                        duration,
+                        error: Some(e.to_string()),
+                    },
+                );
                 return Err(e);
             }
             Err(_) => {
                 let step_dur = step_start.elapsed();
-                send_msg(tx, HookOutputMessage::StepCompleted {
-                    step: "run".into(), success: false, duration: step_dur,
-                });
+                send_msg(
+                    tx,
+                    HookOutputMessage::StepCompleted {
+                        step: "run".into(),
+                        success: false,
+                        duration: step_dur,
+                    },
+                );
                 let duration = start.elapsed();
                 record_execution(
-                    db, repo_id, worktree_id, event, 7, duration.as_secs_f64(), &all_output,
+                    db,
+                    repo_id,
+                    worktree_id,
+                    event,
+                    7,
+                    duration.as_secs_f64(),
+                    &all_output,
                 )?;
-                send_msg(tx, HookOutputMessage::HookCompleted {
-                    success: false, duration, error: Some(format!("hook timed out after {timeout_secs}s")),
-                });
+                send_msg(
+                    tx,
+                    HookOutputMessage::HookCompleted {
+                        success: false,
+                        duration,
+                        error: Some(format!("hook timed out after {timeout_secs}s")),
+                    },
+                );
                 return Err(HookTimeoutError { timeout_secs }.into());
             }
         }
@@ -136,45 +204,92 @@ pub async fn execute_hook(
     // Step 3: Shell (remaining timeout budget)
     if let Some(ref script) = config.shell {
         let step_start = Instant::now();
-        send_msg(tx, HookOutputMessage::StepStarted { step: "shell".into() });
+        send_msg(
+            tx,
+            HookOutputMessage::StepStarted {
+                step: "shell".into(),
+            },
+        );
         let remaining = run_deadline.saturating_duration_since(Instant::now());
-        match tokio::time::timeout(remaining, execute_shell_step(script, work_dir, &env_vars))
-            .await
+        match tokio::time::timeout(remaining, execute_shell_step(script, work_dir, &env_vars)).await
         {
             Ok(Ok(shell_output)) => {
-                collect_output_with_sender(&mut all_output, "shell", &shell_output.stdout, &shell_output.stderr, tx);
+                collect_output_with_sender(
+                    &mut all_output,
+                    "shell",
+                    &shell_output.stdout,
+                    &shell_output.stderr,
+                    tx,
+                );
                 let step_dur = step_start.elapsed();
-                send_msg(tx, HookOutputMessage::StepCompleted {
-                    step: "shell".into(), success: true, duration: step_dur,
-                });
+                send_msg(
+                    tx,
+                    HookOutputMessage::StepCompleted {
+                        step: "shell".into(),
+                        success: true,
+                        duration: step_dur,
+                    },
+                );
             }
             Ok(Err(e)) => {
                 let exit_code = extract_shell_error_output(&e, &mut all_output);
                 let step_dur = step_start.elapsed();
-                send_msg(tx, HookOutputMessage::StepCompleted {
-                    step: "shell".into(), success: false, duration: step_dur,
-                });
+                send_msg(
+                    tx,
+                    HookOutputMessage::StepCompleted {
+                        step: "shell".into(),
+                        success: false,
+                        duration: step_dur,
+                    },
+                );
                 let duration = start.elapsed();
                 record_execution(
-                    db, repo_id, worktree_id, event, exit_code, duration.as_secs_f64(), &all_output,
+                    db,
+                    repo_id,
+                    worktree_id,
+                    event,
+                    exit_code,
+                    duration.as_secs_f64(),
+                    &all_output,
                 )?;
-                send_msg(tx, HookOutputMessage::HookCompleted {
-                    success: false, duration, error: Some(e.to_string()),
-                });
+                send_msg(
+                    tx,
+                    HookOutputMessage::HookCompleted {
+                        success: false,
+                        duration,
+                        error: Some(e.to_string()),
+                    },
+                );
                 return Err(e);
             }
             Err(_) => {
                 let step_dur = step_start.elapsed();
-                send_msg(tx, HookOutputMessage::StepCompleted {
-                    step: "shell".into(), success: false, duration: step_dur,
-                });
+                send_msg(
+                    tx,
+                    HookOutputMessage::StepCompleted {
+                        step: "shell".into(),
+                        success: false,
+                        duration: step_dur,
+                    },
+                );
                 let duration = start.elapsed();
                 record_execution(
-                    db, repo_id, worktree_id, event, 7, duration.as_secs_f64(), &all_output,
+                    db,
+                    repo_id,
+                    worktree_id,
+                    event,
+                    7,
+                    duration.as_secs_f64(),
+                    &all_output,
                 )?;
-                send_msg(tx, HookOutputMessage::HookCompleted {
-                    success: false, duration, error: Some(format!("hook timed out after {timeout_secs}s")),
-                });
+                send_msg(
+                    tx,
+                    HookOutputMessage::HookCompleted {
+                        success: false,
+                        duration,
+                        error: Some(format!("hook timed out after {timeout_secs}s")),
+                    },
+                );
                 return Err(HookTimeoutError { timeout_secs }.into());
             }
         }
@@ -182,12 +297,23 @@ pub async fn execute_hook(
 
     let duration = start.elapsed();
     let event_id = record_execution(
-        db, repo_id, worktree_id, event, 0, duration.as_secs_f64(), &all_output,
+        db,
+        repo_id,
+        worktree_id,
+        event,
+        0,
+        duration.as_secs_f64(),
+        &all_output,
     )?;
 
-    send_msg(tx, HookOutputMessage::HookCompleted {
-        success: true, duration, error: None,
-    });
+    send_msg(
+        tx,
+        HookOutputMessage::HookCompleted {
+            success: true,
+            duration,
+            error: None,
+        },
+    );
 
     Ok(HookResult {
         event_id,
@@ -216,14 +342,24 @@ fn extract_shell_error_output(
     all_output: &mut Vec<(String, String, String)>,
 ) -> i32 {
     if let Some(shell_err) = err.downcast_ref::<ShellStepError>() {
-        collect_output(all_output, "shell", &shell_err.output.stdout, &shell_err.output.stderr);
+        collect_output(
+            all_output,
+            "shell",
+            &shell_err.output.stdout,
+            &shell_err.output.stderr,
+        );
         shell_err.exit_code
     } else {
         1
     }
 }
 
-fn collect_output(all_output: &mut Vec<(String, String, String)>, step: &str, stdout: &str, stderr: &str) {
+fn collect_output(
+    all_output: &mut Vec<(String, String, String)>,
+    step: &str,
+    stdout: &str,
+    stderr: &str,
+) {
     collect_output_with_sender(all_output, step, stdout, stderr, None);
 }
 
@@ -236,19 +372,25 @@ fn collect_output_with_sender(
 ) {
     for line in stdout.lines() {
         all_output.push((step.to_string(), "stdout".to_string(), line.to_string()));
-        send_msg(tx, HookOutputMessage::OutputLine {
-            step: step.to_string(),
-            stream: "stdout".to_string(),
-            line: line.to_string(),
-        });
+        send_msg(
+            tx,
+            HookOutputMessage::OutputLine {
+                step: step.to_string(),
+                stream: "stdout".to_string(),
+                line: line.to_string(),
+            },
+        );
     }
     for line in stderr.lines() {
         all_output.push((step.to_string(), "stderr".to_string(), line.to_string()));
-        send_msg(tx, HookOutputMessage::OutputLine {
-            step: step.to_string(),
-            stream: "stderr".to_string(),
-            line: line.to_string(),
-        });
+        send_msg(
+            tx,
+            HookOutputMessage::OutputLine {
+                step: step.to_string(),
+                stream: "stderr".to_string(),
+                line: line.to_string(),
+            },
+        );
     }
 }
 
@@ -445,10 +587,7 @@ mod tests {
 
         let config = HookDef {
             copy: None,
-            run: Some(vec![
-                "echo before_fail".to_string(),
-                "exit 42".to_string(),
-            ]),
+            run: Some(vec!["echo before_fail".to_string(), "exit 42".to_string()]),
             shell: Some("echo should_not_run".to_string()),
             timeout_secs: Some(30),
         };
@@ -471,7 +610,10 @@ mod tests {
 
         // Error message should mention the failed command
         let msg = err.to_string();
-        assert!(msg.contains("exit 42") || msg.contains("42"), "error: {msg}");
+        assert!(
+            msg.contains("exit 42") || msg.contains("42"),
+            "error: {msg}"
+        );
 
         // Event should be recorded with non-zero exit code
         let events = db.list_events(wt_id, 10).unwrap();
@@ -484,7 +626,10 @@ mod tests {
         let event_id = events[0].id;
         let logs = db.get_logs(event_id).unwrap();
         let lines: Vec<&str> = logs.iter().map(|(_, l, _)| l.as_str()).collect();
-        assert!(lines.contains(&"before_fail"), "should have run output before failure");
+        assert!(
+            lines.contains(&"before_fail"),
+            "should have run output before failure"
+        );
         assert!(
             !lines.iter().any(|l| l.contains("should_not_run")),
             "shell should not have run after run failure"
@@ -562,7 +707,8 @@ mod tests {
         .expect_err("hook should timeout");
 
         // Should be a HookTimeoutError
-        let timeout_err = err.downcast_ref::<HookTimeoutError>()
+        let timeout_err = err
+            .downcast_ref::<HookTimeoutError>()
             .expect("error should be HookTimeoutError");
         assert_eq!(timeout_err.timeout_secs, 1);
 
@@ -605,7 +751,8 @@ mod tests {
         .await
         .expect_err("hook should timeout on shell step");
 
-        let timeout_err = err.downcast_ref::<HookTimeoutError>()
+        let timeout_err = err
+            .downcast_ref::<HookTimeoutError>()
             .expect("error should be HookTimeoutError");
         assert_eq!(timeout_err.timeout_secs, 2);
     }
@@ -728,9 +875,9 @@ mod tests {
 
         // Verify step labels are stored via raw query
         let conn = db.conn_for_test();
-        let mut stmt = conn.prepare(
-            "SELECT line, step FROM logs WHERE event_id = ?1 ORDER BY line_number"
-        ).unwrap();
+        let mut stmt = conn
+            .prepare("SELECT line, step FROM logs WHERE event_id = ?1 ORDER BY line_number")
+            .unwrap();
         let rows: Vec<(String, Option<String>)> = stmt
             .query_map(rusqlite::params![result.event_id], |row| {
                 Ok((row.get(0)?, row.get(1)?))
@@ -741,13 +888,14 @@ mod tests {
 
         assert_eq!(rows.len(), 2);
         assert_eq!(rows[0], ("from_run".to_string(), Some("run".to_string())));
-        assert_eq!(rows[1], ("from_shell".to_string(), Some("shell".to_string())));
+        assert_eq!(
+            rows[1],
+            ("from_shell".to_string(), Some("shell".to_string()))
+        );
     }
 
     #[tokio::test(flavor = "current_thread")]
     async fn execute_hook_sends_messages_through_sender() {
-        use crate::tui::screens::hook_log::HookOutputMessage;
-
         let source = TempDir::new().unwrap();
         let work = TempDir::new().unwrap();
         let (db, repo_id, wt_id) = setup_db();
@@ -783,19 +931,26 @@ mod tests {
         }
 
         // Should have: StepStarted(run), OutputLine(hello), StepCompleted(run), HookCompleted
-        assert!(messages.len() >= 3, "expected at least 3 messages, got: {}", messages.len());
+        assert!(
+            messages.len() >= 3,
+            "expected at least 3 messages, got: {}",
+            messages.len()
+        );
 
         // First should be StepStarted
         assert!(matches!(&messages[0], HookOutputMessage::StepStarted { step } if step == "run"));
 
         // Should contain an output line with "hello"
-        let has_hello = messages.iter().any(|m| {
-            matches!(m, HookOutputMessage::OutputLine { line, .. } if line == "hello")
-        });
+        let has_hello = messages
+            .iter()
+            .any(|m| matches!(m, HookOutputMessage::OutputLine { line, .. } if line == "hello"));
         assert!(has_hello, "should have output line with 'hello'");
 
         // Last should be HookCompleted
-        assert!(matches!(messages.last().unwrap(), HookOutputMessage::HookCompleted { success: true, .. }));
+        assert!(matches!(
+            messages.last().unwrap(),
+            HookOutputMessage::HookCompleted { success: true, .. }
+        ));
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/src/hooks/runner.rs
+++ b/src/hooks/runner.rs
@@ -130,7 +130,7 @@ pub async fn execute_hook(
                 );
             }
             Ok(Err(e)) => {
-                let exit_code = extract_run_error_output(&e, &mut all_output);
+                let exit_code = extract_run_error_output(&e, &mut all_output, tx);
                 let step_dur = step_start.elapsed();
                 send_msg(
                     tx,
@@ -208,7 +208,7 @@ pub async fn execute_hook(
                 );
             }
             Ok(Err(e)) => {
-                let exit_code = extract_shell_error_output(&e, &mut all_output);
+                let exit_code = extract_shell_error_output(&e, &mut all_output, tx);
                 let step_dur = step_start.elapsed();
                 send_msg(
                     tx,
@@ -276,10 +276,17 @@ pub async fn execute_hook(
 fn extract_run_error_output(
     err: &anyhow::Error,
     all_output: &mut Vec<(String, String, String)>,
+    tx: Option<&Sender<HookOutputMessage>>,
 ) -> i32 {
     if let Some(run_err) = err.downcast_ref::<RunStepError>() {
         for cmd_output in &run_err.results.executed {
-            collect_output(all_output, "run", &cmd_output.stdout, &cmd_output.stderr);
+            collect_output_with_sender(
+                all_output,
+                "run",
+                &cmd_output.stdout,
+                &cmd_output.stderr,
+                tx,
+            );
         }
         run_err.exit_code
     } else {
@@ -291,27 +298,20 @@ fn extract_run_error_output(
 fn extract_shell_error_output(
     err: &anyhow::Error,
     all_output: &mut Vec<(String, String, String)>,
+    tx: Option<&Sender<HookOutputMessage>>,
 ) -> i32 {
     if let Some(shell_err) = err.downcast_ref::<ShellStepError>() {
-        collect_output(
+        collect_output_with_sender(
             all_output,
             "shell",
             &shell_err.output.stdout,
             &shell_err.output.stderr,
+            tx,
         );
         shell_err.exit_code
     } else {
         1
     }
-}
-
-fn collect_output(
-    all_output: &mut Vec<(String, String, String)>,
-    step: &str,
-    stdout: &str,
-    stderr: &str,
-) {
-    collect_output_with_sender(all_output, step, stdout, stderr, None);
 }
 
 fn collect_output_with_sender(
@@ -942,5 +942,47 @@ mod tests {
         )
         .await;
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn extract_run_error_output_forwards_to_sender() {
+        use crate::hooks::run::{CommandOutput, RunResult, RunStepError};
+
+        let run_err = RunStepError {
+            command: "failing-cmd".to_string(),
+            exit_code: 1,
+            results: RunResult {
+                executed: vec![CommandOutput {
+                    command: "failing-cmd".to_string(),
+                    stdout: "some output".to_string(),
+                    stderr: "some error".to_string(),
+                    exit_code: 1,
+                }],
+            },
+        };
+        let err: anyhow::Error = run_err.into();
+
+        let (tx, rx) = std::sync::mpsc::channel();
+        let mut all_output = Vec::new();
+        let _code = extract_run_error_output(&err, &mut all_output, Some(&tx));
+
+        let mut messages = Vec::new();
+        while let Ok(msg) = rx.try_recv() {
+            messages.push(msg);
+        }
+
+        // Should have OutputLine messages for the error output
+        assert!(
+            !messages.is_empty(),
+            "extract_run_error_output should forward output to sender"
+        );
+        let has_stdout = messages
+            .iter()
+            .any(|m| matches!(m, HookOutputMessage::OutputLine { stream, line, .. } if stream == "stdout" && line == "some output"));
+        assert!(has_stdout, "should forward stdout to sender");
+        let has_stderr = messages
+            .iter()
+            .any(|m| matches!(m, HookOutputMessage::OutputLine { stream, line, .. } if stream == "stderr" && line == "some error"));
+        assert!(has_stderr, "should forward stderr to sender");
     }
 }

--- a/src/hooks/runner.rs
+++ b/src/hooks/runner.rs
@@ -88,14 +88,6 @@ pub async fn execute_hook(
                 duration.as_secs_f64(),
                 &all_output,
             )?;
-            send_msg(
-                tx,
-                HookOutputMessage::HookCompleted {
-                    success: false,
-                    duration,
-                    error: Some(e.to_string()),
-                },
-            );
             return Err(e.context("copy step failed"));
         }
         let step_dur = step_start.elapsed();
@@ -158,14 +150,6 @@ pub async fn execute_hook(
                     duration.as_secs_f64(),
                     &all_output,
                 )?;
-                send_msg(
-                    tx,
-                    HookOutputMessage::HookCompleted {
-                        success: false,
-                        duration,
-                        error: Some(e.to_string()),
-                    },
-                );
                 return Err(e);
             }
             Err(_) => {
@@ -188,14 +172,6 @@ pub async fn execute_hook(
                     duration.as_secs_f64(),
                     &all_output,
                 )?;
-                send_msg(
-                    tx,
-                    HookOutputMessage::HookCompleted {
-                        success: false,
-                        duration,
-                        error: Some(format!("hook timed out after {timeout_secs}s")),
-                    },
-                );
                 return Err(HookTimeoutError { timeout_secs }.into());
             }
         }
@@ -252,14 +228,6 @@ pub async fn execute_hook(
                     duration.as_secs_f64(),
                     &all_output,
                 )?;
-                send_msg(
-                    tx,
-                    HookOutputMessage::HookCompleted {
-                        success: false,
-                        duration,
-                        error: Some(e.to_string()),
-                    },
-                );
                 return Err(e);
             }
             Err(_) => {
@@ -282,14 +250,6 @@ pub async fn execute_hook(
                     duration.as_secs_f64(),
                     &all_output,
                 )?;
-                send_msg(
-                    tx,
-                    HookOutputMessage::HookCompleted {
-                        success: false,
-                        duration,
-                        error: Some(format!("hook timed out after {timeout_secs}s")),
-                    },
-                );
                 return Err(HookTimeoutError { timeout_secs }.into());
             }
         }
@@ -305,15 +265,6 @@ pub async fn execute_hook(
         duration.as_secs_f64(),
         &all_output,
     )?;
-
-    send_msg(
-        tx,
-        HookOutputMessage::HookCompleted {
-            success: true,
-            duration,
-            error: None,
-        },
-    );
 
     Ok(HookResult {
         event_id,
@@ -946,10 +897,19 @@ mod tests {
             .any(|m| matches!(m, HookOutputMessage::OutputLine { line, .. } if line == "hello"));
         assert!(has_hello, "should have output line with 'hello'");
 
-        // Last should be HookCompleted
+        // execute_hook must NOT send HookCompleted — that's the orchestration's job
+        let has_hook_completed = messages
+            .iter()
+            .any(|m| matches!(m, HookOutputMessage::HookCompleted { .. }));
+        assert!(
+            !has_hook_completed,
+            "execute_hook should not send HookCompleted (reserved for orchestration)"
+        );
+
+        // Last should be StepCompleted
         assert!(matches!(
             messages.last().unwrap(),
-            HookOutputMessage::HookCompleted { success: true, .. }
+            HookOutputMessage::StepCompleted { success: true, .. }
         ));
     }
 

--- a/src/hooks/types.rs
+++ b/src/hooks/types.rs
@@ -1,0 +1,48 @@
+use std::time::Duration;
+
+/// A message sent from the hook runner for live streaming of hook execution.
+///
+/// This type lives in the hooks module (not TUI) so that the hook runner
+/// does not depend on UI-layer types.
+#[derive(Debug, Clone)]
+pub enum HookOutputMessage {
+    /// A new hook step (copy/run/shell) has started.
+    StepStarted { step: String },
+    /// A line of output from the current step.
+    OutputLine {
+        step: String,
+        stream: String,
+        line: String,
+    },
+    /// A step completed (success or failure).
+    StepCompleted {
+        step: String,
+        success: bool,
+        duration: Duration,
+    },
+    /// The entire hook execution completed.
+    HookCompleted {
+        success: bool,
+        duration: Duration,
+        error: Option<String>,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hook_output_message_is_debug_and_clone() {
+        let msg = HookOutputMessage::StepStarted {
+            step: "run".to_string(),
+        };
+        let debug = format!("{msg:?}");
+        assert!(debug.contains("StepStarted"));
+        let cloned = msg.clone();
+        match cloned {
+            HookOutputMessage::StepStarted { step } => assert_eq!(step, "run"),
+            _ => panic!("expected StepStarted"),
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -359,6 +359,7 @@ fn run_create(
         &db,
         resolved.hooks.as_ref(),
         no_hooks,
+        None,
     )) {
         Ok(outcome) => {
             // Report post_create hook failure to stderr
@@ -512,6 +513,7 @@ fn run_remove(
         prune,
         hooks_config.as_ref(),
         no_hooks,
+        None,
     )) {
         Ok(outcome) => {
             // Report post_remove hook failure as warning (FR-24: WarnOnly)
@@ -917,6 +919,7 @@ fn run_sync(
         sync_strategy,
         hooks_config.as_ref(),
         no_hooks,
+        None,
     )) {
         Ok(outcome) => {
             // Report post_sync hook failure to stderr (FR-24: Report)
@@ -1072,6 +1075,7 @@ fn run_sync_all(
                 sync_strategy,
                 hooks_config.as_ref(),
                 no_hooks,
+                None,
             )) {
                 Ok(outcome) => {
                     if let Some(ref hook_err) = outcome.post_sync_error {

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -17,6 +17,7 @@ pub enum Screen {
     Help,
     SyncPicker,
     DeleteConfirm,
+    HookLog,
 }
 
 type PanicHook = dyn Fn(&std::panic::PanicHookInfo<'_>) + Send + Sync;
@@ -87,6 +88,7 @@ pub struct App {
     pub create_state: Option<screens::create::CreateState>,
     pub sync_picker_state: Option<screens::sync_picker::SyncPickerState>,
     pub delete_confirm_state: Option<screens::delete_confirm::DeleteConfirmState>,
+    pub hook_log_state: Option<screens::hook_log::HookLogState>,
     pub editor_request: Option<String>,
 }
 
@@ -100,6 +102,7 @@ impl App {
             create_state: None,
             sync_picker_state: None,
             delete_confirm_state: None,
+            hook_log_state: None,
             editor_request: None,
         }
     }
@@ -165,6 +168,15 @@ impl App {
                     frame.render_widget(placeholder, frame.area());
                 }
             }
+            Screen::HookLog => {
+                if let Some(ref hook_log) = self.hook_log_state {
+                    screens::hook_log::render(hook_log, frame, frame.area());
+                } else {
+                    let placeholder =
+                        Paragraph::new("trench TUI — press q to quit").alignment(Alignment::Center);
+                    frame.render_widget(placeholder, frame.area());
+                }
+            }
         }
     }
 
@@ -191,6 +203,11 @@ impl App {
                 screens::list::render(&self.list_state, frame, frame.area());
                 if let Some(ref confirm) = self.delete_confirm_state {
                     screens::delete_confirm::render(confirm, frame, frame.area());
+                }
+            }
+            Some(Screen::HookLog) => {
+                if let Some(ref hook_log) = self.hook_log_state {
+                    screens::hook_log::render(hook_log, frame, frame.area());
                 }
             }
             _ => screens::list::render(&self.list_state, frame, frame.area()),
@@ -240,6 +257,7 @@ impl App {
             Screen::DeleteConfirm => self.delete_confirm_state = None,
             Screen::SyncPicker => self.sync_picker_state = None,
             Screen::Create => self.create_state = None,
+            Screen::HookLog => self.hook_log_state = None,
             _ => {}
         }
     }
@@ -274,6 +292,7 @@ impl App {
             Screen::SyncPicker => self.handle_sync_picker_key(key),
             Screen::DeleteConfirm => self.handle_delete_confirm_key(key),
             Screen::Create => self.handle_create_key(key),
+            Screen::HookLog => {} // Esc/q handled globally; no screen-specific keys
             Screen::Help => {}
         }
     }
@@ -704,9 +723,8 @@ mod tests {
     }
 
     #[test]
-    fn screen_enum_has_six_variants() {
-        // Verify all six screen variants exist and are distinct
-        let screens = [Screen::List, Screen::Detail, Screen::Create, Screen::Help, Screen::SyncPicker, Screen::DeleteConfirm];
+    fn screen_enum_has_seven_variants() {
+        let screens = [Screen::List, Screen::Detail, Screen::Create, Screen::Help, Screen::SyncPicker, Screen::DeleteConfirm, Screen::HookLog];
         for (i, a) in screens.iter().enumerate() {
             for (j, b) in screens.iter().enumerate() {
                 if i == j {
@@ -716,6 +734,19 @@ mod tests {
                 }
             }
         }
+    }
+
+    #[test]
+    fn hook_log_screen_can_be_pushed_and_popped() {
+        let mut app = App::new();
+        app.hook_log_state = Some(screens::hook_log::HookLogState::new("post_create"));
+        app.push_screen(Screen::HookLog);
+        assert_eq!(app.active_screen(), Screen::HookLog);
+        assert_eq!(app.nav_stack_depth(), 2);
+
+        // Esc pops back
+        app.handle_key_event(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
+        assert_eq!(app.active_screen(), Screen::List);
     }
 
     #[test]

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -277,8 +277,15 @@ impl App {
     pub fn process_hook_messages(&mut self) {
         let Some(ref rx) = self.hook_rx else { return };
         let Some(ref mut state) = self.hook_log_state else { return };
+        let mut received = false;
         while let Ok(msg) = rx.try_recv() {
             state.process_message(msg);
+            received = true;
+        }
+        // Auto-scroll to latest output when new messages arrive
+        if received {
+            // Use a reasonable default visible height; actual height is set during render
+            state.auto_scroll(20);
         }
     }
 
@@ -295,7 +302,10 @@ impl App {
             Screen::DeleteConfirm => self.delete_confirm_state = None,
             Screen::SyncPicker => self.sync_picker_state = None,
             Screen::Create => self.create_state = None,
-            Screen::HookLog => self.hook_log_state = None,
+            Screen::HookLog => {
+                self.hook_log_state = None;
+                self.hook_rx = None;
+            }
             _ => {}
         }
     }
@@ -2070,5 +2080,30 @@ mod tests {
         assert!(app.hook_log_state.is_some());
         assert_eq!(app.hook_log_state.as_ref().unwrap().title, "post_create");
         assert!(app.hook_rx.is_some());
+    }
+
+    #[test]
+    fn esc_on_hook_log_returns_to_list_and_clears_state() {
+        let mut app = App::new();
+        let (_tx, rx) = std::sync::mpsc::channel();
+        app.start_hook_log("post_create", rx);
+        assert_eq!(app.active_screen(), Screen::HookLog);
+
+        app.handle_key_event(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
+        assert_eq!(app.active_screen(), Screen::List);
+        assert!(app.hook_log_state.is_none());
+        assert!(app.hook_rx.is_none());
+    }
+
+    #[test]
+    fn q_on_hook_log_returns_to_list() {
+        let mut app = App::new();
+        let (_tx, rx) = std::sync::mpsc::channel();
+        app.start_hook_log("post_create", rx);
+        assert_eq!(app.active_screen(), Screen::HookLog);
+
+        app.handle_key_event(KeyEvent::new(KeyCode::Char('q'), KeyModifiers::NONE));
+        assert_eq!(app.active_screen(), Screen::List);
+        assert!(app.hook_log_state.is_none());
     }
 }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -36,11 +36,18 @@ pub fn run() -> Result<()> {
 
     let result = (|| -> Result<()> {
         while app.is_running() {
+            // Process any pending hook output messages
+            app.process_hook_messages();
+
             terminal.draw(|frame| app.ui(frame))?;
 
-            if let Event::Key(key) = event::read()? {
-                if key.kind == KeyEventKind::Press {
-                    app.handle_key_event(key);
+            // Non-blocking poll: wait up to 50ms for key events, allowing
+            // hook messages to be processed between frames for live streaming.
+            if event::poll(std::time::Duration::from_millis(50))? {
+                if let Event::Key(key) = event::read()? {
+                    if key.kind == KeyEventKind::Press {
+                        app.handle_key_event(key);
+                    }
                 }
             }
 
@@ -89,6 +96,7 @@ pub struct App {
     pub sync_picker_state: Option<screens::sync_picker::SyncPickerState>,
     pub delete_confirm_state: Option<screens::delete_confirm::DeleteConfirmState>,
     pub hook_log_state: Option<screens::hook_log::HookLogState>,
+    pub hook_rx: Option<std::sync::mpsc::Receiver<screens::hook_log::HookOutputMessage>>,
     pub editor_request: Option<String>,
 }
 
@@ -103,6 +111,7 @@ impl App {
             sync_picker_state: None,
             delete_confirm_state: None,
             hook_log_state: None,
+            hook_rx: None,
             editor_request: None,
         }
     }
@@ -241,6 +250,15 @@ impl App {
             if self.list_state.rows.len() > prev_selected {
                 self.list_state.selected = prev_selected;
             }
+        }
+    }
+
+    /// Drain pending messages from the hook output channel and update state.
+    pub fn process_hook_messages(&mut self) {
+        let Some(ref rx) = self.hook_rx else { return };
+        let Some(ref mut state) = self.hook_log_state else { return };
+        while let Ok(msg) = rx.try_recv() {
+            state.process_message(msg);
         }
     }
 
@@ -1836,5 +1854,46 @@ mod tests {
             app.create_state.as_ref().unwrap().error.is_some(),
             "empty input after backspace should revalidate and show error"
         );
+    }
+
+    #[test]
+    fn process_hook_messages_updates_hook_log_state() {
+        use screens::hook_log::{HookLogState, HookOutputMessage};
+
+        let mut app = App::new();
+        let (tx, rx) = std::sync::mpsc::channel();
+        app.hook_log_state = Some(HookLogState::new("post_create"));
+        app.hook_rx = Some(rx);
+        app.push_screen(Screen::HookLog);
+
+        // Send messages through the channel
+        tx.send(HookOutputMessage::StepStarted { step: "run".into() }).unwrap();
+        tx.send(HookOutputMessage::OutputLine {
+            step: "run".into(), stream: "stdout".into(), line: "hello".into(),
+        }).unwrap();
+        tx.send(HookOutputMessage::StepCompleted {
+            step: "run".into(), success: true, duration: std::time::Duration::from_millis(100),
+        }).unwrap();
+        tx.send(HookOutputMessage::HookCompleted {
+            success: true, duration: std::time::Duration::from_secs(1), error: None,
+        }).unwrap();
+
+        // Process messages
+        app.process_hook_messages();
+
+        let state = app.hook_log_state.as_ref().unwrap();
+        assert_eq!(state.sections.len(), 1);
+        assert_eq!(state.sections[0].step, "run");
+        assert_eq!(state.sections[0].lines.len(), 1);
+        assert_eq!(state.sections[0].lines[0].text, "hello");
+        assert!(state.completed);
+        assert!(state.success);
+    }
+
+    #[test]
+    fn process_hook_messages_no_op_without_receiver() {
+        let mut app = App::new();
+        // No hook_rx set — should not panic
+        app.process_hook_messages();
     }
 }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -276,20 +276,33 @@ impl App {
     }
 
     /// Drain pending messages from the hook output channel and update state.
+    /// Continues draining even after dismiss (hook_log_state is None) so that
+    /// HookCompleted triggers a final refresh_list.
     pub fn process_hook_messages(&mut self) {
         let Some(ref rx) = self.hook_rx else { return };
-        let Some(ref mut state) = self.hook_log_state else {
-            return;
-        };
         let mut received = false;
+        let mut completed = false;
         while let Ok(msg) = rx.try_recv() {
-            state.process_message(msg);
-            received = true;
+            if matches!(
+                &msg,
+                screens::hook_log::HookOutputMessage::HookCompleted { .. }
+            ) {
+                completed = true;
+            }
+            if let Some(ref mut state) = self.hook_log_state {
+                state.process_message(msg);
+                received = true;
+            }
         }
-        // Auto-scroll to latest output when new messages arrive
         if received {
-            // Use a reasonable default visible height; actual height is set during render
-            state.auto_scroll(20);
+            if let Some(ref mut state) = self.hook_log_state {
+                state.auto_scroll(20);
+            }
+        }
+        if completed && self.hook_log_state.is_none() {
+            // Hook finished after user dismissed — refresh list to reflect changes
+            self.hook_rx = None;
+            self.refresh_list();
         }
     }
 
@@ -307,7 +320,7 @@ impl App {
             Screen::Create => self.create_state = None,
             Screen::HookLog => {
                 self.hook_log_state = None;
-                self.hook_rx = None;
+                // Keep hook_rx alive for post-dismiss draining
             }
             _ => {}
         }
@@ -318,7 +331,8 @@ impl App {
     /// underlying operation cannot be re-triggered.
     fn dismiss_hook_log(&mut self) {
         self.hook_log_state = None;
-        self.hook_rx = None;
+        // Keep hook_rx alive — process_hook_messages will drain it and
+        // call refresh_list when HookCompleted arrives after dismiss.
         self.create_state = None;
         self.sync_picker_state = None;
         self.delete_confirm_state = None;
@@ -2292,7 +2306,8 @@ mod tests {
         app.handle_key_event(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
         assert_eq!(app.active_screen(), Screen::List);
         assert!(app.hook_log_state.is_none());
-        assert!(app.hook_rx.is_none());
+        // hook_rx stays alive for post-dismiss draining
+        assert!(app.hook_rx.is_some());
     }
 
     #[test]
@@ -2336,6 +2351,38 @@ mod tests {
         assert!(
             app.create_state.is_none(),
             "source dialog state should be cleared"
+        );
+    }
+
+    #[test]
+    fn process_hook_messages_drains_after_dismiss() {
+        use screens::hook_log::HookOutputMessage;
+
+        let mut app = App::new();
+        let (tx, rx) = std::sync::mpsc::channel();
+        app.start_hook_log("test hooks", rx);
+        assert_eq!(app.active_screen(), Screen::HookLog);
+
+        // Dismiss the hook log (user pressed Esc)
+        app.handle_key_event(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
+        assert_eq!(app.active_screen(), Screen::List);
+        assert!(app.hook_log_state.is_none(), "state should be cleared");
+        // hook_rx should still be alive for draining
+        assert!(app.hook_rx.is_some(), "hook_rx should survive dismiss");
+
+        // Background thread sends completion after dismiss
+        tx.send(HookOutputMessage::HookCompleted {
+            success: true,
+            duration: std::time::Duration::from_secs(1),
+            error: None,
+        })
+        .unwrap();
+
+        // process_hook_messages should drain and clean up
+        app.process_hook_messages();
+        assert!(
+            app.hook_rx.is_none(),
+            "hook_rx should be cleaned up after HookCompleted"
         );
     }
 }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -458,7 +458,14 @@ impl App {
             std::thread::spawn(move || {
                 let rt = match tokio::runtime::Runtime::new() {
                     Ok(rt) => rt,
-                    Err(_) => return,
+                    Err(e) => {
+                        let _ = tx.send(screens::hook_log::HookOutputMessage::HookCompleted {
+                            success: false,
+                            duration: std::time::Duration::ZERO,
+                            error: Some(format!("Failed to start hook runtime: {e}")),
+                        });
+                        return;
+                    }
                 };
                 let result =
                     rt.block_on(crate::cli::commands::remove::execute_resolved_with_hooks(
@@ -612,7 +619,14 @@ impl App {
             std::thread::spawn(move || {
                 let rt = match tokio::runtime::Runtime::new() {
                     Ok(rt) => rt,
-                    Err(_) => return,
+                    Err(e) => {
+                        let _ = tx.send(screens::hook_log::HookOutputMessage::HookCompleted {
+                            success: false,
+                            duration: std::time::Duration::ZERO,
+                            error: Some(format!("Failed to start hook runtime: {e}")),
+                        });
+                        return;
+                    }
                 };
                 let result = rt.block_on(crate::cli::commands::sync::execute_with_hooks(
                     &worktree_name,
@@ -872,7 +886,14 @@ impl App {
             std::thread::spawn(move || {
                 let rt = match tokio::runtime::Runtime::new() {
                     Ok(rt) => rt,
-                    Err(_) => return,
+                    Err(e) => {
+                        let _ = tx.send(screens::hook_log::HookOutputMessage::HookCompleted {
+                            success: false,
+                            duration: std::time::Duration::ZERO,
+                            error: Some(format!("Failed to start hook runtime: {e}")),
+                        });
+                        return;
+                    }
                 };
                 let result = rt.block_on(crate::cli::commands::create::execute_with_hooks(
                     &branch_clone,

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -234,6 +234,15 @@ impl App {
         }
     }
 
+    /// Load hooks config from the project config.
+    fn load_hooks_config(cwd: &std::path::Path) -> Option<crate::config::HooksConfig> {
+        let repo_info = crate::git::discover_repo(cwd).ok()?;
+        let project_config = crate::config::load_project_config(&repo_info.path).ok()?;
+        let global_config = crate::config::load_global_config().ok()?;
+        let resolved = crate::config::resolve_config(None, project_config.as_ref(), &global_config);
+        resolved.hooks
+    }
+
     fn open_db() -> Option<(std::path::PathBuf, Database)> {
         let cwd = std::env::current_dir().ok()?;
         let db_path = paths::data_dir().ok()?.join("trench.db");
@@ -251,6 +260,17 @@ impl App {
                 self.list_state.selected = prev_selected;
             }
         }
+    }
+
+    /// Set up the hook log screen with a receiver for live streaming.
+    pub fn start_hook_log(
+        &mut self,
+        title: &str,
+        rx: std::sync::mpsc::Receiver<screens::hook_log::HookOutputMessage>,
+    ) {
+        self.hook_log_state = Some(screens::hook_log::HookLogState::new(title));
+        self.hook_rx = Some(rx);
+        self.push_screen(Screen::HookLog);
     }
 
     /// Drain pending messages from the hook output channel and update state.
@@ -361,22 +381,80 @@ impl App {
             return;
         };
 
-        match crate::cli::commands::remove::execute(&worktree_name, &cwd, &db, false) {
-            Ok(result) => {
-                let msg = format!("Removed '{}'", result.name);
-                if let Some(ref mut c) = self.delete_confirm_state {
-                    c.result = Some(screens::delete_confirm::DeleteResultMessage {
-                        success: true,
-                        message: msg,
+        // Check for hooks
+        let hooks_config = Self::load_hooks_config(&cwd);
+        let has_hooks = hooks_config
+            .as_ref()
+            .map(|h| h.pre_remove.is_some() || h.post_remove.is_some())
+            .unwrap_or(false);
+
+        if has_hooks {
+            // Resolve repo + worktree for background hook execution
+            let repo_info = match crate::git::discover_repo(&cwd) {
+                Ok(r) => r,
+                Err(e) => {
+                    if let Some(ref mut c) = self.delete_confirm_state {
+                        c.result = Some(screens::delete_confirm::DeleteResultMessage {
+                            success: false,
+                            message: format!("Delete failed: {e:#}"),
+                        });
+                    }
+                    return;
+                }
+            };
+            let resolve = crate::adopt::resolve_or_adopt(&worktree_name, &repo_info, &db);
+            let (repo, wt) = match resolve {
+                Ok((r, w)) => (r, w),
+                Err(e) => {
+                    if let Some(ref mut c) = self.delete_confirm_state {
+                        c.result = Some(screens::delete_confirm::DeleteResultMessage {
+                            success: false,
+                            message: format!("Delete failed: {e:#}"),
+                        });
+                    }
+                    return;
+                }
+            };
+
+            let (tx, rx) = std::sync::mpsc::channel();
+            let hooks = hooks_config.unwrap();
+            std::thread::spawn(move || {
+                let rt = match tokio::runtime::Runtime::new() {
+                    Ok(rt) => rt,
+                    Err(_) => return,
+                };
+                let result = rt.block_on(
+                    crate::cli::commands::remove::execute_resolved_with_hooks(
+                        &repo, &wt, &repo_info, &db, false, Some(&hooks), false, Some(&tx),
+                    ),
+                );
+                if let Err(e) = result {
+                    let _ = tx.send(screens::hook_log::HookOutputMessage::HookCompleted {
+                        success: false,
+                        duration: std::time::Duration::ZERO,
+                        error: Some(format!("{e:#}")),
                     });
                 }
-            }
-            Err(e) => {
-                if let Some(ref mut c) = self.delete_confirm_state {
-                    c.result = Some(screens::delete_confirm::DeleteResultMessage {
-                        success: false,
-                        message: format!("Delete failed: {e:#}"),
-                    });
+            });
+            self.start_hook_log("remove hooks", rx);
+        } else {
+            match crate::cli::commands::remove::execute(&worktree_name, &cwd, &db, false) {
+                Ok(result) => {
+                    let msg = format!("Removed '{}'", result.name);
+                    if let Some(ref mut c) = self.delete_confirm_state {
+                        c.result = Some(screens::delete_confirm::DeleteResultMessage {
+                            success: true,
+                            message: msg,
+                        });
+                    }
+                }
+                Err(e) => {
+                    if let Some(ref mut c) = self.delete_confirm_state {
+                        c.result = Some(screens::delete_confirm::DeleteResultMessage {
+                            success: false,
+                            message: format!("Delete failed: {e:#}"),
+                        });
+                    }
                 }
             }
         }
@@ -474,30 +552,65 @@ impl App {
             return;
         };
 
-        match crate::cli::commands::sync::execute(&worktree_name, &cwd, &db, strategy) {
-            Ok(result) => {
-                let msg = format!(
-                    "Synced '{}' via {}\nBefore: +{}/-{}  After: +{}/-{}",
-                    result.name,
-                    result.strategy,
-                    result.before_ahead,
-                    result.before_behind,
-                    result.after_ahead,
-                    result.after_behind,
-                );
-                if let Some(ref mut p) = self.sync_picker_state {
-                    p.result = Some(screens::sync_picker::SyncResultMessage {
-                        success: true,
-                        message: msg,
+        // Check for hooks
+        let hooks_config = Self::load_hooks_config(&cwd);
+        let has_hooks = hooks_config
+            .as_ref()
+            .map(|h| h.pre_sync.is_some() || h.post_sync.is_some())
+            .unwrap_or(false);
+
+        if has_hooks {
+            let (tx, rx) = std::sync::mpsc::channel();
+            let hooks = hooks_config.unwrap();
+            std::thread::spawn(move || {
+                let rt = match tokio::runtime::Runtime::new() {
+                    Ok(rt) => rt,
+                    Err(_) => return,
+                };
+                let result = rt.block_on(crate::cli::commands::sync::execute_with_hooks(
+                    &worktree_name,
+                    &cwd,
+                    &db,
+                    strategy,
+                    Some(&hooks),
+                    false,
+                    Some(&tx),
+                ));
+                if let Err(e) = result {
+                    let _ = tx.send(screens::hook_log::HookOutputMessage::HookCompleted {
+                        success: false,
+                        duration: std::time::Duration::ZERO,
+                        error: Some(format!("{e:#}")),
                     });
                 }
-            }
-            Err(e) => {
-                if let Some(ref mut p) = self.sync_picker_state {
-                    p.result = Some(screens::sync_picker::SyncResultMessage {
-                        success: false,
-                        message: format!("Sync failed: {e:#}"),
-                    });
+            });
+            self.start_hook_log("sync hooks", rx);
+        } else {
+            match crate::cli::commands::sync::execute(&worktree_name, &cwd, &db, strategy) {
+                Ok(result) => {
+                    let msg = format!(
+                        "Synced '{}' via {}\nBefore: +{}/-{}  After: +{}/-{}",
+                        result.name,
+                        result.strategy,
+                        result.before_ahead,
+                        result.before_behind,
+                        result.after_ahead,
+                        result.after_behind,
+                    );
+                    if let Some(ref mut p) = self.sync_picker_state {
+                        p.result = Some(screens::sync_picker::SyncResultMessage {
+                            success: true,
+                            message: msg,
+                        });
+                    }
+                }
+                Err(e) => {
+                    if let Some(ref mut p) = self.sync_picker_state {
+                        p.result = Some(screens::sync_picker::SyncResultMessage {
+                            success: false,
+                            message: format!("Sync failed: {e:#}"),
+                        });
+                    }
                 }
             }
         }
@@ -668,6 +781,7 @@ impl App {
 
         let branch = state.branch_input.clone();
         let base = state.selected_base_branch().map(|s| s.to_string());
+        let hooks_enabled = state.hooks_enabled;
 
         let Some((cwd, db)) = Self::open_db() else {
             state.result = Some(screens::create::CreateResultMessage {
@@ -688,30 +802,80 @@ impl App {
             }
         };
 
-        let template = &state.worktree_template;
-        match crate::cli::commands::create::execute(
-            &branch,
-            base.as_deref(),
-            &cwd,
-            &worktree_root,
-            template,
-            &db,
-        ) {
-            Ok(result) => {
-                let msg = format!("Created '{}' at {}", result.name, result.path.display());
-                if let Some(ref mut s) = self.create_state {
-                    s.result = Some(screens::create::CreateResultMessage {
-                        success: true,
-                        message: msg,
+        // Load config to check for hooks
+        let hooks_config = if hooks_enabled {
+            Self::load_hooks_config(&cwd)
+        } else {
+            None
+        };
+
+        let has_hooks = hooks_config
+            .as_ref()
+            .map(|h| h.pre_create.is_some() || h.post_create.is_some())
+            .unwrap_or(false);
+
+        let template = state.worktree_template.clone();
+
+        if has_hooks {
+            // Background execution with live streaming
+            let (tx, rx) = std::sync::mpsc::channel();
+            let hooks = hooks_config.unwrap();
+            let branch_clone = branch.clone();
+            let base_clone = base.clone();
+
+            std::thread::spawn(move || {
+                let rt = match tokio::runtime::Runtime::new() {
+                    Ok(rt) => rt,
+                    Err(_) => return,
+                };
+                let result = rt.block_on(crate::cli::commands::create::execute_with_hooks(
+                    &branch_clone,
+                    base_clone.as_deref(),
+                    &cwd,
+                    &worktree_root,
+                    &template,
+                    &db,
+                    Some(&hooks),
+                    false,
+                    Some(&tx),
+                ));
+                // Send completion if not already sent by execute_hook
+                if let Err(e) = result {
+                    let _ = tx.send(screens::hook_log::HookOutputMessage::HookCompleted {
+                        success: false,
+                        duration: std::time::Duration::ZERO,
+                        error: Some(format!("{e:#}")),
                     });
                 }
-            }
-            Err(e) => {
-                if let Some(ref mut s) = self.create_state {
-                    s.result = Some(screens::create::CreateResultMessage {
-                        success: false,
-                        message: format!("Create failed: {e:#}"),
-                    });
+            });
+
+            self.start_hook_log("create hooks", rx);
+        } else {
+            // Synchronous path without hooks
+            match crate::cli::commands::create::execute(
+                &branch,
+                base.as_deref(),
+                &cwd,
+                &worktree_root,
+                &template,
+                &db,
+            ) {
+                Ok(result) => {
+                    let msg = format!("Created '{}' at {}", result.name, result.path.display());
+                    if let Some(ref mut s) = self.create_state {
+                        s.result = Some(screens::create::CreateResultMessage {
+                            success: true,
+                            message: msg,
+                        });
+                    }
+                }
+                Err(e) => {
+                    if let Some(ref mut s) = self.create_state {
+                        s.result = Some(screens::create::CreateResultMessage {
+                            success: false,
+                            message: format!("Create failed: {e:#}"),
+                        });
+                    }
                 }
             }
         }
@@ -1895,5 +2059,16 @@ mod tests {
         let mut app = App::new();
         // No hook_rx set — should not panic
         app.process_hook_messages();
+    }
+
+    #[test]
+    fn start_hook_log_sets_up_state_and_pushes_screen() {
+        let mut app = App::new();
+        let (_tx, rx) = std::sync::mpsc::channel();
+        app.start_hook_log("post_create", rx);
+        assert_eq!(app.active_screen(), Screen::HookLog);
+        assert!(app.hook_log_state.is_some());
+        assert_eq!(app.hook_log_state.as_ref().unwrap().title, "post_create");
+        assert!(app.hook_rx.is_some());
     }
 }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -478,13 +478,15 @@ impl App {
                         false,
                         Some(&tx),
                     ));
-                if let Err(e) = result {
-                    let _ = tx.send(screens::hook_log::HookOutputMessage::HookCompleted {
-                        success: false,
-                        duration: std::time::Duration::ZERO,
-                        error: Some(format!("{e:#}")),
-                    });
-                }
+                let (success, error) = match result {
+                    Ok(_) => (true, None),
+                    Err(ref e) => (false, Some(format!("{e:#}"))),
+                };
+                let _ = tx.send(screens::hook_log::HookOutputMessage::HookCompleted {
+                    success,
+                    duration: std::time::Duration::ZERO,
+                    error,
+                });
             });
             self.start_hook_log("remove hooks", rx);
         } else {
@@ -637,13 +639,15 @@ impl App {
                     false,
                     Some(&tx),
                 ));
-                if let Err(e) = result {
-                    let _ = tx.send(screens::hook_log::HookOutputMessage::HookCompleted {
-                        success: false,
-                        duration: std::time::Duration::ZERO,
-                        error: Some(format!("{e:#}")),
-                    });
-                }
+                let (success, error) = match result {
+                    Ok(_) => (true, None),
+                    Err(ref e) => (false, Some(format!("{e:#}"))),
+                };
+                let _ = tx.send(screens::hook_log::HookOutputMessage::HookCompleted {
+                    success,
+                    duration: std::time::Duration::ZERO,
+                    error,
+                });
             });
             self.start_hook_log("sync hooks", rx);
         } else {
@@ -906,14 +910,15 @@ impl App {
                     false,
                     Some(&tx),
                 ));
-                // Send completion if not already sent by execute_hook
-                if let Err(e) = result {
-                    let _ = tx.send(screens::hook_log::HookOutputMessage::HookCompleted {
-                        success: false,
-                        duration: std::time::Duration::ZERO,
-                        error: Some(format!("{e:#}")),
-                    });
-                }
+                let (success, error) = match result {
+                    Ok(_) => (true, None),
+                    Err(ref e) => (false, Some(format!("{e:#}"))),
+                };
+                let _ = tx.send(screens::hook_log::HookOutputMessage::HookCompleted {
+                    success,
+                    duration: std::time::Duration::ZERO,
+                    error,
+                });
             });
 
             self.start_hook_log("create hooks", rx);

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -142,8 +142,8 @@ impl App {
                 if let Some(ref detail) = self.detail_state {
                     screens::detail::render(detail, frame, frame.area());
                 } else {
-                    let placeholder = Paragraph::new("trench TUI — press q to quit")
-                        .alignment(Alignment::Center);
+                    let placeholder =
+                        Paragraph::new("trench TUI — press q to quit").alignment(Alignment::Center);
                     frame.render_widget(placeholder, frame.area());
                 }
             }
@@ -252,7 +252,9 @@ impl App {
 
     /// Reload worktree data from git + DB for the list screen.
     pub fn refresh_list(&mut self) {
-        let Some((cwd, db)) = Self::open_db() else { return };
+        let Some((cwd, db)) = Self::open_db() else {
+            return;
+        };
         if let Ok(rows) = screens::list::load_worktrees(&cwd, &db, &[]) {
             let prev_selected = self.list_state.selected;
             self.list_state = screens::list::ListState::new(rows);
@@ -276,7 +278,9 @@ impl App {
     /// Drain pending messages from the hook output channel and update state.
     pub fn process_hook_messages(&mut self) {
         let Some(ref rx) = self.hook_rx else { return };
-        let Some(ref mut state) = self.hook_log_state else { return };
+        let Some(ref mut state) = self.hook_log_state else {
+            return;
+        };
         let mut received = false;
         while let Ok(msg) = rx.try_recv() {
             state.process_message(msg);
@@ -291,10 +295,9 @@ impl App {
 
     fn is_create_branch_text_entry_active(&self) -> bool {
         self.active_screen() == Screen::Create
-            && self
-                .create_state
-                .as_ref()
-                .is_some_and(|s| !s.is_result_mode() && s.focused_field == screens::create::CreateField::Branch)
+            && self.create_state.as_ref().is_some_and(|s| {
+                !s.is_result_mode() && s.focused_field == screens::create::CreateField::Branch
+            })
     }
 
     fn clear_active_screen_state(&mut self) {
@@ -310,6 +313,22 @@ impl App {
         }
     }
 
+    /// Dismiss the hook log screen and unwind to List, clearing any
+    /// intermediate source dialog state (Create/Sync/Delete) so the
+    /// underlying operation cannot be re-triggered.
+    fn dismiss_hook_log(&mut self) {
+        self.hook_log_state = None;
+        self.hook_rx = None;
+        self.create_state = None;
+        self.sync_picker_state = None;
+        self.delete_confirm_state = None;
+        self.nav_stack.retain(|s| *s == Screen::List);
+        if self.nav_stack.is_empty() {
+            self.nav_stack.push(Screen::List);
+        }
+        self.refresh_list();
+    }
+
     pub fn handle_key_event(&mut self, key: KeyEvent) {
         // Global keys handled at app level
         match (key.code, key.modifiers) {
@@ -322,12 +341,20 @@ impl App {
                 }
             }
             (KeyCode::Esc, _) => {
-                self.clear_active_screen_state();
-                self.pop_screen();
+                if self.active_screen() == Screen::HookLog {
+                    self.dismiss_hook_log();
+                } else {
+                    self.clear_active_screen_state();
+                    self.pop_screen();
+                }
             }
             (KeyCode::Char('q'), _) if !self.is_create_branch_text_entry_active() => {
-                self.clear_active_screen_state();
-                self.pop_screen();
+                if self.active_screen() == Screen::HookLog {
+                    self.dismiss_hook_log();
+                } else {
+                    self.clear_active_screen_state();
+                    self.pop_screen();
+                }
             }
             _ => self.handle_screen_key(key),
         }
@@ -433,11 +460,17 @@ impl App {
                     Ok(rt) => rt,
                     Err(_) => return,
                 };
-                let result = rt.block_on(
-                    crate::cli::commands::remove::execute_resolved_with_hooks(
-                        &repo, &wt, &repo_info, &db, false, Some(&hooks), false, Some(&tx),
-                    ),
-                );
+                let result =
+                    rt.block_on(crate::cli::commands::remove::execute_resolved_with_hooks(
+                        &repo,
+                        &wt,
+                        &repo_info,
+                        &db,
+                        false,
+                        Some(&hooks),
+                        false,
+                        Some(&tx),
+                    ));
                 if let Err(e) = result {
                     let _ = tx.send(screens::hook_log::HookOutputMessage::HookCompleted {
                         success: false,
@@ -482,7 +515,9 @@ impl App {
             row.branch.clone()
         };
 
-        let Some((cwd, db)) = Self::open_db() else { return };
+        let Some((cwd, db)) = Self::open_db() else {
+            return;
+        };
         let repo_info = match crate::git::discover_repo(&cwd) {
             Ok(r) => r,
             Err(_) => return,
@@ -493,7 +528,9 @@ impl App {
 
     fn load_detail(&mut self, name: &str) -> bool {
         self.detail_state = None;
-        let Some((cwd, db)) = Self::open_db() else { return false };
+        let Some((cwd, db)) = Self::open_db() else {
+            return false;
+        };
         self.detail_state = Some(screens::detail::load_detail(name, &cwd, &db));
         true
     }
@@ -662,13 +699,12 @@ impl App {
             }
             KeyCode::Char('D') => {
                 if let Some(row) = self.list_state.rows.get(self.list_state.selected) {
-                    self.delete_confirm_state = Some(
-                        screens::delete_confirm::DeleteConfirmState::new(
+                    self.delete_confirm_state =
+                        Some(screens::delete_confirm::DeleteConfirmState::new(
                             &row.name,
                             &row.path,
                             &row.branch,
-                        ),
-                    );
+                        ));
                     self.push_screen(Screen::DeleteConfirm);
                 }
             }
@@ -916,7 +952,15 @@ mod tests {
 
     #[test]
     fn screen_enum_has_seven_variants() {
-        let screens = [Screen::List, Screen::Detail, Screen::Create, Screen::Help, Screen::SyncPicker, Screen::DeleteConfirm, Screen::HookLog];
+        let screens = [
+            Screen::List,
+            Screen::Detail,
+            Screen::Create,
+            Screen::Help,
+            Screen::SyncPicker,
+            Screen::DeleteConfirm,
+            Screen::HookLog,
+        ];
         for (i, a) in screens.iter().enumerate() {
             for (j, b) in screens.iter().enumerate() {
                 if i == j {
@@ -1223,7 +1267,10 @@ mod tests {
         // Select second row
         app.list_state.selected = 1;
         app.handle_key_event(KeyEvent::new(KeyCode::Char('s'), KeyModifiers::NONE));
-        let state = app.sync_picker_state.as_ref().expect("sync_picker_state should be set");
+        let state = app
+            .sync_picker_state
+            .as_ref()
+            .expect("sync_picker_state should be set");
         assert_eq!(state.worktree_name, "feat-b");
     }
 
@@ -1241,7 +1288,10 @@ mod tests {
         let mut app = app_with_rows();
         app.list_state.selected = 1; // select feat-b
         app.handle_key_event(KeyEvent::new(KeyCode::Char('D'), KeyModifiers::SHIFT));
-        let state = app.delete_confirm_state.as_ref().expect("delete_confirm_state should be set");
+        let state = app
+            .delete_confirm_state
+            .as_ref()
+            .expect("delete_confirm_state should be set");
         assert_eq!(state.worktree_name, "feat-b");
         assert_eq!(state.worktree_path, "/tmp/wt/feat-b");
         assert_eq!(state.branch, "feat/b");
@@ -1368,7 +1418,10 @@ mod tests {
         assert_eq!(app.active_screen(), Screen::Create);
         app.handle_key_event(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
         assert_eq!(app.active_screen(), Screen::List);
-        assert!(app.create_state.is_none(), "create_state should be cleared on Esc");
+        assert!(
+            app.create_state.is_none(),
+            "create_state should be cleared on Esc"
+        );
     }
 
     #[test]
@@ -1481,7 +1534,10 @@ mod tests {
         // Without a real git repo, init_create_form will use fallback defaults
         app.handle_key_event(KeyEvent::new(KeyCode::Char('n'), KeyModifiers::NONE));
         assert_eq!(app.active_screen(), Screen::Create);
-        assert!(app.create_state.is_some(), "create_state should be initialized");
+        assert!(
+            app.create_state.is_some(),
+            "create_state should be initialized"
+        );
     }
 
     #[test]
@@ -1522,7 +1578,10 @@ mod tests {
         app.handle_key_event(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
         assert_eq!(app.active_screen(), Screen::Create);
         let state = app.create_state.as_ref().unwrap();
-        assert!(state.is_result_mode(), "should be in result mode after execute attempt");
+        assert!(
+            state.is_result_mode(),
+            "should be in result mode after execute attempt"
+        );
     }
 
     #[test]
@@ -1534,7 +1593,11 @@ mod tests {
             message: "Created 'test'".into(),
         });
         app.handle_key_event(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
-        assert_eq!(app.active_screen(), Screen::List, "Enter in result mode should pop to list");
+        assert_eq!(
+            app.active_screen(),
+            Screen::List,
+            "Enter in result mode should pop to list"
+        );
         assert!(app.create_state.is_none(), "create_state should be cleared");
     }
 
@@ -1649,8 +1712,15 @@ mod tests {
         let mut app = App::new();
         // Empty list — no rows
         app.handle_key_event(KeyEvent::new(KeyCode::Char('s'), KeyModifiers::NONE));
-        assert_eq!(app.active_screen(), Screen::List, "s on empty list should stay on List");
-        assert!(app.sync_picker_state.is_none(), "sync_picker_state should remain None");
+        assert_eq!(
+            app.active_screen(),
+            Screen::List,
+            "s on empty list should stay on List"
+        );
+        assert!(
+            app.sync_picker_state.is_none(),
+            "sync_picker_state should remain None"
+        );
     }
 
     #[test]
@@ -1661,7 +1731,10 @@ mod tests {
 
         app.handle_key_event(KeyEvent::new(KeyCode::Char('s'), KeyModifiers::NONE));
         assert_eq!(app.active_screen(), Screen::SyncPicker);
-        let picker = app.sync_picker_state.as_ref().expect("sync_picker_state should be set");
+        let picker = app
+            .sync_picker_state
+            .as_ref()
+            .expect("sync_picker_state should be set");
         assert_eq!(picker.worktree_name, "feat-a");
     }
 
@@ -1688,7 +1761,11 @@ mod tests {
         assert_eq!(app.sync_picker_state.as_ref().unwrap().selected, 0);
 
         app.handle_key_event(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE));
-        assert_eq!(app.sync_picker_state.as_ref().unwrap().selected, 1, "down should select Merge");
+        assert_eq!(
+            app.sync_picker_state.as_ref().unwrap().selected,
+            1,
+            "down should select Merge"
+        );
     }
 
     #[test]
@@ -1700,7 +1777,11 @@ mod tests {
         app.push_screen(Screen::SyncPicker);
 
         app.handle_key_event(KeyEvent::new(KeyCode::Up, KeyModifiers::NONE));
-        assert_eq!(app.sync_picker_state.as_ref().unwrap().selected, 0, "up should select Rebase");
+        assert_eq!(
+            app.sync_picker_state.as_ref().unwrap().selected,
+            0,
+            "up should select Rebase"
+        );
     }
 
     #[test]
@@ -1710,10 +1791,18 @@ mod tests {
         app.push_screen(Screen::SyncPicker);
 
         app.handle_key_event(KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE));
-        assert_eq!(app.sync_picker_state.as_ref().unwrap().selected, 1, "j should move down");
+        assert_eq!(
+            app.sync_picker_state.as_ref().unwrap().selected,
+            1,
+            "j should move down"
+        );
 
         app.handle_key_event(KeyEvent::new(KeyCode::Char('k'), KeyModifiers::NONE));
-        assert_eq!(app.sync_picker_state.as_ref().unwrap().selected, 0, "k should move up");
+        assert_eq!(
+            app.sync_picker_state.as_ref().unwrap().selected,
+            0,
+            "k should move up"
+        );
     }
 
     #[test]
@@ -1729,7 +1818,10 @@ mod tests {
         // Should still be on SyncPicker (showing result)
         assert_eq!(app.active_screen(), Screen::SyncPicker);
         let picker = app.sync_picker_state.as_ref().unwrap();
-        assert!(picker.is_result_mode(), "should be in result mode after Enter");
+        assert!(
+            picker.is_result_mode(),
+            "should be in result mode after Enter"
+        );
         assert!(picker.result.is_some());
     }
 
@@ -1745,8 +1837,15 @@ mod tests {
         app.push_screen(Screen::SyncPicker);
 
         app.handle_key_event(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
-        assert_eq!(app.active_screen(), Screen::List, "Enter in result mode should pop to list");
-        assert!(app.sync_picker_state.is_none(), "sync_picker_state should be cleared");
+        assert_eq!(
+            app.active_screen(),
+            Screen::List,
+            "Enter in result mode should pop to list"
+        );
+        assert!(
+            app.sync_picker_state.is_none(),
+            "sync_picker_state should be cleared"
+        );
     }
 
     #[test]
@@ -1765,8 +1864,15 @@ mod tests {
         assert_eq!(app.nav_stack_depth(), 3);
 
         app.handle_key_event(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
-        assert_eq!(app.active_screen(), Screen::List, "should pop all the way to List, not Detail");
-        assert!(app.sync_picker_state.is_none(), "sync_picker_state should be cleared");
+        assert_eq!(
+            app.active_screen(),
+            Screen::List,
+            "should pop all the way to List, not Detail"
+        );
+        assert!(
+            app.sync_picker_state.is_none(),
+            "sync_picker_state should be cleared"
+        );
     }
 
     #[test]
@@ -1809,7 +1915,9 @@ mod tests {
     fn push_delete_confirm_screen_works() {
         let mut app = App::new();
         app.delete_confirm_state = Some(screens::delete_confirm::DeleteConfirmState::new(
-            "feat-auth", "/tmp/wt/feat-auth", "feature/auth",
+            "feat-auth",
+            "/tmp/wt/feat-auth",
+            "feature/auth",
         ));
         app.push_screen(Screen::DeleteConfirm);
         assert_eq!(app.active_screen(), Screen::DeleteConfirm);
@@ -1822,7 +1930,9 @@ mod tests {
         // set a result message (failure) and stay on the DeleteConfirm screen.
         let mut app = App::new();
         app.delete_confirm_state = Some(screens::delete_confirm::DeleteConfirmState::new(
-            "feat-auth", "/tmp/wt/feat-auth", "feature/auth",
+            "feat-auth",
+            "/tmp/wt/feat-auth",
+            "feature/auth",
         ));
         app.push_screen(Screen::DeleteConfirm);
 
@@ -1830,7 +1940,10 @@ mod tests {
 
         assert_eq!(app.active_screen(), Screen::DeleteConfirm);
         let state = app.delete_confirm_state.as_ref().unwrap();
-        assert!(state.is_result_mode(), "should be in result mode after Enter");
+        assert!(
+            state.is_result_mode(),
+            "should be in result mode after Enter"
+        );
         assert!(state.result.is_some());
     }
 
@@ -1838,7 +1951,9 @@ mod tests {
     fn y_on_delete_confirm_triggers_delete_and_sets_result() {
         let mut app = App::new();
         app.delete_confirm_state = Some(screens::delete_confirm::DeleteConfirmState::new(
-            "feat-auth", "/tmp/wt/feat-auth", "feature/auth",
+            "feat-auth",
+            "/tmp/wt/feat-auth",
+            "feature/auth",
         ));
         app.push_screen(Screen::DeleteConfirm);
 
@@ -1853,21 +1968,32 @@ mod tests {
     fn n_on_delete_confirm_cancels_dialog() {
         let mut app = App::new();
         app.delete_confirm_state = Some(screens::delete_confirm::DeleteConfirmState::new(
-            "feat-auth", "/tmp/wt/feat-auth", "feature/auth",
+            "feat-auth",
+            "/tmp/wt/feat-auth",
+            "feature/auth",
         ));
         app.push_screen(Screen::DeleteConfirm);
 
         app.handle_key_event(KeyEvent::new(KeyCode::Char('n'), KeyModifiers::NONE));
 
-        assert_eq!(app.active_screen(), Screen::List, "n should pop back to list");
-        assert!(app.delete_confirm_state.is_none(), "state should be cleared on cancel");
+        assert_eq!(
+            app.active_screen(),
+            Screen::List,
+            "n should pop back to list"
+        );
+        assert!(
+            app.delete_confirm_state.is_none(),
+            "state should be cleared on cancel"
+        );
     }
 
     #[test]
     fn enter_in_delete_result_mode_pops_to_list() {
         let mut app = App::new();
         let mut state = screens::delete_confirm::DeleteConfirmState::new(
-            "feat-auth", "/tmp/wt/feat-auth", "feature/auth",
+            "feat-auth",
+            "/tmp/wt/feat-auth",
+            "feature/auth",
         );
         state.result = Some(screens::delete_confirm::DeleteResultMessage {
             success: true,
@@ -1877,15 +2003,24 @@ mod tests {
         app.push_screen(Screen::DeleteConfirm);
 
         app.handle_key_event(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
-        assert_eq!(app.active_screen(), Screen::List, "Enter in result mode should pop to list");
-        assert!(app.delete_confirm_state.is_none(), "state should be cleared");
+        assert_eq!(
+            app.active_screen(),
+            Screen::List,
+            "Enter in result mode should pop to list"
+        );
+        assert!(
+            app.delete_confirm_state.is_none(),
+            "state should be cleared"
+        );
     }
 
     #[test]
     fn space_in_delete_result_mode_pops_to_list() {
         let mut app = App::new();
         let mut state = screens::delete_confirm::DeleteConfirmState::new(
-            "feat-auth", "/tmp/wt/feat-auth", "feature/auth",
+            "feat-auth",
+            "/tmp/wt/feat-auth",
+            "feature/auth",
         );
         state.result = Some(screens::delete_confirm::DeleteResultMessage {
             success: true,
@@ -1895,7 +2030,11 @@ mod tests {
         app.push_screen(Screen::DeleteConfirm);
 
         app.handle_key_event(KeyEvent::new(KeyCode::Char(' '), KeyModifiers::NONE));
-        assert_eq!(app.active_screen(), Screen::List, "Space in result mode should pop to list");
+        assert_eq!(
+            app.active_screen(),
+            Screen::List,
+            "Space in result mode should pop to list"
+        );
         assert!(app.delete_confirm_state.is_none());
     }
 
@@ -1903,33 +2042,49 @@ mod tests {
     fn esc_on_delete_confirm_clears_state() {
         let mut app = App::new();
         app.delete_confirm_state = Some(screens::delete_confirm::DeleteConfirmState::new(
-            "feat-auth", "/tmp/wt/feat-auth", "feature/auth",
+            "feat-auth",
+            "/tmp/wt/feat-auth",
+            "feature/auth",
         ));
         app.push_screen(Screen::DeleteConfirm);
 
         app.handle_key_event(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
-        assert_eq!(app.active_screen(), Screen::List, "Esc should pop back to List");
-        assert!(app.delete_confirm_state.is_none(), "Esc should clear delete_confirm_state");
+        assert_eq!(
+            app.active_screen(),
+            Screen::List,
+            "Esc should pop back to List"
+        );
+        assert!(
+            app.delete_confirm_state.is_none(),
+            "Esc should clear delete_confirm_state"
+        );
     }
 
     #[test]
     fn q_on_delete_confirm_clears_state() {
         let mut app = App::new();
         app.delete_confirm_state = Some(screens::delete_confirm::DeleteConfirmState::new(
-            "feat-auth", "/tmp/wt/feat-auth", "feature/auth",
+            "feat-auth",
+            "/tmp/wt/feat-auth",
+            "feature/auth",
         ));
         app.push_screen(Screen::DeleteConfirm);
 
         app.handle_key_event(KeyEvent::new(KeyCode::Char('q'), KeyModifiers::NONE));
         assert_eq!(app.active_screen(), Screen::List);
-        assert!(app.delete_confirm_state.is_none(), "q should clear delete_confirm_state");
+        assert!(
+            app.delete_confirm_state.is_none(),
+            "q should clear delete_confirm_state"
+        );
     }
 
     #[test]
     fn esc_on_delete_result_mode_clears_state() {
         let mut app = App::new();
         let mut state = screens::delete_confirm::DeleteConfirmState::new(
-            "feat-auth", "/tmp/wt/feat-auth", "feature/auth",
+            "feat-auth",
+            "/tmp/wt/feat-auth",
+            "feature/auth",
         );
         state.result = Some(screens::delete_confirm::DeleteResultMessage {
             success: true,
@@ -1939,8 +2094,15 @@ mod tests {
         app.push_screen(Screen::DeleteConfirm);
 
         app.handle_key_event(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
-        assert_eq!(app.active_screen(), Screen::List, "Esc in result mode should pop to List");
-        assert!(app.delete_confirm_state.is_none(), "Esc in result mode should clear state");
+        assert_eq!(
+            app.active_screen(),
+            Screen::List,
+            "Esc in result mode should pop to List"
+        );
+        assert!(
+            app.delete_confirm_state.is_none(),
+            "Esc in result mode should clear state"
+        );
     }
 
     #[test]
@@ -1951,7 +2113,10 @@ mod tests {
 
         app.handle_key_event(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
         assert_eq!(app.active_screen(), Screen::List);
-        assert!(app.sync_picker_state.is_none(), "Esc should clear sync_picker_state");
+        assert!(
+            app.sync_picker_state.is_none(),
+            "Esc should clear sync_picker_state"
+        );
     }
 
     #[test]
@@ -1967,8 +2132,7 @@ mod tests {
     fn help_over_sync_picker_renders_sync_picker_underneath() {
         let mut app = app_with_rows();
         // Push SyncPicker, then Help
-        app.sync_picker_state =
-            Some(screens::sync_picker::SyncPickerState::new("feat-a"));
+        app.sync_picker_state = Some(screens::sync_picker::SyncPickerState::new("feat-a"));
         app.push_screen(Screen::SyncPicker);
         app.push_screen(Screen::Help);
         assert_eq!(app.active_screen(), Screen::Help);
@@ -2041,16 +2205,26 @@ mod tests {
         app.push_screen(Screen::HookLog);
 
         // Send messages through the channel
-        tx.send(HookOutputMessage::StepStarted { step: "run".into() }).unwrap();
+        tx.send(HookOutputMessage::StepStarted { step: "run".into() })
+            .unwrap();
         tx.send(HookOutputMessage::OutputLine {
-            step: "run".into(), stream: "stdout".into(), line: "hello".into(),
-        }).unwrap();
+            step: "run".into(),
+            stream: "stdout".into(),
+            line: "hello".into(),
+        })
+        .unwrap();
         tx.send(HookOutputMessage::StepCompleted {
-            step: "run".into(), success: true, duration: std::time::Duration::from_millis(100),
-        }).unwrap();
+            step: "run".into(),
+            success: true,
+            duration: std::time::Duration::from_millis(100),
+        })
+        .unwrap();
         tx.send(HookOutputMessage::HookCompleted {
-            success: true, duration: std::time::Duration::from_secs(1), error: None,
-        }).unwrap();
+            success: true,
+            duration: std::time::Duration::from_secs(1),
+            error: None,
+        })
+        .unwrap();
 
         // Process messages
         app.process_hook_messages();
@@ -2105,5 +2279,37 @@ mod tests {
         app.handle_key_event(KeyEvent::new(KeyCode::Char('q'), KeyModifiers::NONE));
         assert_eq!(app.active_screen(), Screen::List);
         assert!(app.hook_log_state.is_none());
+    }
+
+    #[test]
+    fn dismiss_hook_log_returns_to_list_not_source() {
+        let mut app = App::new();
+        // Simulate: List → Create → HookLog (as happens during create-with-hooks)
+        app.create_state = Some(screens::create::CreateState::new(
+            vec![],
+            String::new(),
+            String::new(),
+        ));
+        app.push_screen(Screen::Create);
+        let (_tx, rx) = std::sync::mpsc::channel();
+        app.start_hook_log("create hooks", rx);
+        assert_eq!(app.active_screen(), Screen::HookLog);
+        assert_eq!(app.nav_stack_depth(), 3); // List → Create → HookLog
+
+        // Esc should dismiss HookLog AND the source dialog, landing on List
+        app.handle_key_event(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
+        assert_eq!(
+            app.active_screen(),
+            Screen::List,
+            "dismiss from HookLog should return to List, not Create"
+        );
+        assert!(
+            app.hook_log_state.is_none(),
+            "hook_log_state should be cleared"
+        );
+        assert!(
+            app.create_state.is_none(),
+            "source dialog state should be cleared"
+        );
     }
 }

--- a/src/tui/screens/hook_log.rs
+++ b/src/tui/screens/hook_log.rs
@@ -1,7 +1,9 @@
 use std::time::Duration;
 
 use ratatui::{
-    layout::Rect,
+    layout::{Constraint, Layout, Rect},
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
     widgets::Paragraph,
     Frame,
 };
@@ -139,10 +141,114 @@ impl HookLogState {
     }
 }
 
+const FOOTER_RUNNING: &str = " Esc back (hooks continue) ";
+const FOOTER_DONE: &str = " Esc back  Enter dismiss ";
+
+fn format_duration(d: Duration) -> String {
+    let secs = d.as_secs_f64();
+    if secs < 1.0 {
+        format!("{:.0}ms", secs * 1000.0)
+    } else {
+        format!("{:.1}s", secs)
+    }
+}
+
 /// Render the hook log screen.
 pub fn render(state: &HookLogState, frame: &mut Frame, area: Rect) {
-    let text = format!("Hook: {} — running...", state.title);
-    frame.render_widget(Paragraph::new(text), area);
+    let chunks = Layout::vertical([
+        Constraint::Length(2), // title
+        Constraint::Min(1),   // output area
+        Constraint::Length(1), // footer
+    ])
+    .split(area);
+
+    // Title
+    let status_text = if state.completed {
+        if state.success {
+            " — Complete"
+        } else {
+            " — Failed"
+        }
+    } else {
+        " — running..."
+    };
+    let title = Line::from(vec![
+        Span::styled(
+            format!("Hook: {}", state.title),
+            Style::default().add_modifier(Modifier::BOLD),
+        ),
+        Span::raw(status_text),
+    ]);
+    frame.render_widget(Paragraph::new(title), chunks[0]);
+
+    // Build output lines with scrolling
+    let mut lines: Vec<Line> = Vec::new();
+
+    for section in &state.sections {
+        // Section header
+        let header_style = if section.completed {
+            if section.success {
+                Style::default().fg(Color::Green).add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(Color::Red).add_modifier(Modifier::BOLD)
+            }
+        } else {
+            Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)
+        };
+
+        let status_icon = if section.completed {
+            if section.success { "✓" } else { "✗" }
+        } else {
+            "●"
+        };
+
+        let elapsed = section
+            .duration
+            .map(|d| format!(" ({})", format_duration(d)))
+            .unwrap_or_default();
+
+        lines.push(Line::from(vec![
+            Span::styled(
+                format!("{status_icon} [{step}]{elapsed}", step = section.step),
+                header_style,
+            ),
+        ]));
+
+        // Output lines
+        for log_line in &section.lines {
+            let style = if log_line.stream == "stderr" {
+                Style::default().fg(Color::Red)
+            } else {
+                Style::default()
+            };
+            lines.push(Line::from(Span::styled(
+                format!("  {}", log_line.text),
+                style,
+            )));
+        }
+    }
+
+    // Error message at bottom
+    if let Some(ref err) = state.error {
+        lines.push(Line::from(""));
+        lines.push(Line::from(Span::styled(
+            format!("Error: {err}"),
+            Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
+        )));
+    }
+
+    // Apply scroll offset
+    let visible_height = chunks[1].height as usize;
+    let skip = state.scroll_offset.min(lines.len());
+    let visible_lines: Vec<Line> = lines.into_iter().skip(skip).take(visible_height).collect();
+
+    frame.render_widget(Paragraph::new(visible_lines), chunks[1]);
+
+    // Footer
+    let footer_text = if state.completed { FOOTER_DONE } else { FOOTER_RUNNING };
+    let footer = Paragraph::new(Line::from(footer_text))
+        .style(Style::default().add_modifier(Modifier::REVERSED));
+    frame.render_widget(footer, chunks[2]);
 }
 
 #[cfg(test)]
@@ -420,5 +526,118 @@ mod tests {
         });
         state.auto_scroll(20); // plenty of room
         assert_eq!(state.scroll_offset, 0);
+    }
+
+    fn render_to_buffer(state: &HookLogState, width: u16, height: u16) -> ratatui::buffer::Buffer {
+        let backend = ratatui::backend::TestBackend::new(width, height);
+        let mut terminal = ratatui::Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| render(state, frame, frame.area()))
+            .unwrap();
+        terminal.backend().buffer().clone()
+    }
+
+    fn buffer_text(buf: &ratatui::buffer::Buffer) -> String {
+        buf.content().iter().map(|cell| cell.symbol()).collect()
+    }
+
+    #[test]
+    fn render_shows_title_with_hook_name() {
+        let state = HookLogState::new("post_create");
+        let buf = render_to_buffer(&state, 80, 20);
+        let text = buffer_text(&buf);
+        assert!(text.contains("post_create"), "should show hook name in title, got: {text}");
+    }
+
+    #[test]
+    fn render_shows_section_header() {
+        let mut state = HookLogState::new("post_create");
+        state.process_message(HookOutputMessage::StepStarted { step: "run".into() });
+        let buf = render_to_buffer(&state, 80, 20);
+        let text = buffer_text(&buf);
+        assert!(text.contains("run"), "should show section header for 'run' step");
+    }
+
+    #[test]
+    fn render_shows_output_lines() {
+        let mut state = HookLogState::new("post_create");
+        state.process_message(HookOutputMessage::StepStarted { step: "run".into() });
+        state.process_message(HookOutputMessage::OutputLine {
+            step: "run".into(), stream: "stdout".into(), line: "installing packages".into(),
+        });
+        let buf = render_to_buffer(&state, 80, 20);
+        let text = buffer_text(&buf);
+        assert!(text.contains("installing packages"), "should show output line");
+    }
+
+    #[test]
+    fn render_shows_elapsed_time_for_completed_step() {
+        let mut state = HookLogState::new("post_create");
+        state.process_message(HookOutputMessage::StepStarted { step: "run".into() });
+        state.process_message(HookOutputMessage::StepCompleted {
+            step: "run".into(), success: true, duration: Duration::from_millis(1500),
+        });
+        let buf = render_to_buffer(&state, 80, 20);
+        let text = buffer_text(&buf);
+        assert!(text.contains("1.5s"), "should show elapsed time, got: {text}");
+    }
+
+    #[test]
+    fn render_shows_footer_with_esc() {
+        let state = HookLogState::new("post_create");
+        let buf = render_to_buffer(&state, 80, 20);
+        let text = buffer_text(&buf);
+        assert!(text.contains("Esc"), "footer should show Esc keybinding");
+    }
+
+    #[test]
+    fn render_completed_success_shows_status() {
+        let mut state = HookLogState::new("post_create");
+        state.process_message(HookOutputMessage::HookCompleted {
+            success: true, duration: Duration::from_secs(2), error: None,
+        });
+        let buf = render_to_buffer(&state, 80, 20);
+        let text = buffer_text(&buf);
+        assert!(text.contains("Complete") || text.contains("Success"), "should show success status, got: {text}");
+    }
+
+    #[test]
+    fn render_completed_failure_shows_error() {
+        let mut state = HookLogState::new("post_create");
+        state.process_message(HookOutputMessage::HookCompleted {
+            success: false, duration: Duration::from_secs(1), error: Some("exit code 1".into()),
+        });
+        let buf = render_to_buffer(&state, 80, 20);
+        let text = buffer_text(&buf);
+        assert!(text.contains("exit code 1"), "should show error message, got: {text}");
+    }
+
+    #[test]
+    fn render_success_step_header_has_green_style() {
+        let mut state = HookLogState::new("post_create");
+        state.process_message(HookOutputMessage::StepStarted { step: "run".into() });
+        state.process_message(HookOutputMessage::StepCompleted {
+            step: "run".into(), success: true, duration: Duration::from_millis(100),
+        });
+        let buf = render_to_buffer(&state, 80, 20);
+        // Find a cell in the header row that has green foreground
+        let has_green = buf.content().iter().any(|cell| {
+            cell.fg == ratatui::style::Color::Green
+        });
+        assert!(has_green, "successful step should have green-colored text");
+    }
+
+    #[test]
+    fn render_failure_step_header_has_red_style() {
+        let mut state = HookLogState::new("post_create");
+        state.process_message(HookOutputMessage::StepStarted { step: "run".into() });
+        state.process_message(HookOutputMessage::StepCompleted {
+            step: "run".into(), success: false, duration: Duration::from_millis(100),
+        });
+        let buf = render_to_buffer(&state, 80, 20);
+        let has_red = buf.content().iter().any(|cell| {
+            cell.fg == ratatui::style::Color::Red
+        });
+        assert!(has_red, "failed step should have red-colored text");
     }
 }

--- a/src/tui/screens/hook_log.rs
+++ b/src/tui/screens/hook_log.rs
@@ -66,6 +66,24 @@ impl HookLogState {
         }
     }
 
+    /// Total number of renderable lines (section headers + output lines).
+    pub fn total_lines(&self) -> usize {
+        self.sections
+            .iter()
+            .map(|s| 1 + s.lines.len()) // 1 header per section + output lines
+            .sum()
+    }
+
+    /// Auto-scroll to keep the latest output visible.
+    pub fn auto_scroll(&mut self, visible_height: usize) {
+        let total = self.total_lines();
+        if total > visible_height {
+            self.scroll_offset = total - visible_height;
+        } else {
+            self.scroll_offset = 0;
+        }
+    }
+
     /// Process an incoming message from the hook runner, updating state.
     pub fn process_message(&mut self, msg: HookOutputMessage) {
         match msg {
@@ -343,5 +361,52 @@ mod tests {
         assert_eq!(state.sections[0].step, "copy");
         assert_eq!(state.sections[1].step, "run");
         assert_eq!(state.sections[1].lines.len(), 1);
+    }
+
+    #[test]
+    fn total_lines_counts_across_all_sections() {
+        let mut state = HookLogState::new("test");
+        state.process_message(HookOutputMessage::StepStarted { step: "run".into() });
+        state.process_message(HookOutputMessage::OutputLine {
+            step: "run".into(), stream: "stdout".into(), line: "line1".into(),
+        });
+        state.process_message(HookOutputMessage::OutputLine {
+            step: "run".into(), stream: "stdout".into(), line: "line2".into(),
+        });
+        state.process_message(HookOutputMessage::StepStarted { step: "shell".into() });
+        state.process_message(HookOutputMessage::OutputLine {
+            step: "shell".into(), stream: "stdout".into(), line: "line3".into(),
+        });
+        // total_lines = output lines + section headers (1 per section)
+        assert_eq!(state.total_lines(), 5); // 2 headers + 3 output lines
+    }
+
+    #[test]
+    fn auto_scroll_advances_to_latest() {
+        let mut state = HookLogState::new("test");
+        state.process_message(HookOutputMessage::StepStarted { step: "run".into() });
+        for i in 0..20 {
+            state.process_message(HookOutputMessage::OutputLine {
+                step: "run".into(),
+                stream: "stdout".into(),
+                line: format!("line {i}"),
+            });
+        }
+        // After many lines, auto_scroll should set offset near the end
+        state.auto_scroll(10); // visible_height = 10
+        // scroll_offset should be total_lines - visible_height
+        let expected = state.total_lines().saturating_sub(10);
+        assert_eq!(state.scroll_offset, expected);
+    }
+
+    #[test]
+    fn auto_scroll_stays_zero_when_content_fits() {
+        let mut state = HookLogState::new("test");
+        state.process_message(HookOutputMessage::StepStarted { step: "run".into() });
+        state.process_message(HookOutputMessage::OutputLine {
+            step: "run".into(), stream: "stdout".into(), line: "one".into(),
+        });
+        state.auto_scroll(20); // plenty of room
+        assert_eq!(state.scroll_offset, 0);
     }
 }

--- a/src/tui/screens/hook_log.rs
+++ b/src/tui/screens/hook_log.rs
@@ -1,0 +1,178 @@
+use std::time::Duration;
+
+/// A message sent from the hook runner to the TUI for live streaming.
+#[derive(Debug, Clone)]
+pub enum HookOutputMessage {
+    /// A new hook step (copy/run/shell) has started.
+    StepStarted {
+        step: String,
+    },
+    /// A line of output from the current step.
+    OutputLine {
+        step: String,
+        stream: String,
+        line: String,
+    },
+    /// A step completed (success or failure).
+    StepCompleted {
+        step: String,
+        success: bool,
+        duration: Duration,
+    },
+    /// The entire hook execution completed.
+    HookCompleted {
+        success: bool,
+        duration: Duration,
+        error: Option<String>,
+    },
+}
+
+/// One section of the hook log, corresponding to a single step (copy/run/shell).
+#[derive(Debug, Clone)]
+pub struct HookLogSection {
+    pub step: String,
+    pub lines: Vec<HookLogLine>,
+    pub completed: bool,
+    pub success: bool,
+    pub duration: Option<Duration>,
+}
+
+/// A single line of hook output with stream label.
+#[derive(Debug, Clone)]
+pub struct HookLogLine {
+    pub stream: String,
+    pub text: String,
+}
+
+/// TUI state for the hook log screen.
+pub struct HookLogState {
+    pub title: String,
+    pub sections: Vec<HookLogSection>,
+    pub completed: bool,
+    pub success: bool,
+    pub scroll_offset: usize,
+    pub error: Option<String>,
+}
+
+impl HookLogState {
+    pub fn new(title: &str) -> Self {
+        Self {
+            title: title.to_string(),
+            sections: Vec::new(),
+            completed: false,
+            success: false,
+            scroll_offset: 0,
+            error: None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hook_output_message_step_started_holds_step_name() {
+        let msg = HookOutputMessage::StepStarted {
+            step: "run".to_string(),
+        };
+        match msg {
+            HookOutputMessage::StepStarted { step } => assert_eq!(step, "run"),
+            _ => panic!("expected StepStarted"),
+        }
+    }
+
+    #[test]
+    fn hook_output_message_output_line_holds_all_fields() {
+        let msg = HookOutputMessage::OutputLine {
+            step: "run".to_string(),
+            stream: "stdout".to_string(),
+            line: "hello world".to_string(),
+        };
+        match msg {
+            HookOutputMessage::OutputLine { step, stream, line } => {
+                assert_eq!(step, "run");
+                assert_eq!(stream, "stdout");
+                assert_eq!(line, "hello world");
+            }
+            _ => panic!("expected OutputLine"),
+        }
+    }
+
+    #[test]
+    fn hook_output_message_step_completed_holds_status_and_duration() {
+        let msg = HookOutputMessage::StepCompleted {
+            step: "shell".to_string(),
+            success: true,
+            duration: Duration::from_millis(1500),
+        };
+        match msg {
+            HookOutputMessage::StepCompleted {
+                step,
+                success,
+                duration,
+            } => {
+                assert_eq!(step, "shell");
+                assert!(success);
+                assert_eq!(duration, Duration::from_millis(1500));
+            }
+            _ => panic!("expected StepCompleted"),
+        }
+    }
+
+    #[test]
+    fn hook_output_message_hook_completed_with_error() {
+        let msg = HookOutputMessage::HookCompleted {
+            success: false,
+            duration: Duration::from_secs(5),
+            error: Some("command failed".to_string()),
+        };
+        match msg {
+            HookOutputMessage::HookCompleted {
+                success,
+                duration,
+                error,
+            } => {
+                assert!(!success);
+                assert_eq!(duration, Duration::from_secs(5));
+                assert_eq!(error.unwrap(), "command failed");
+            }
+            _ => panic!("expected HookCompleted"),
+        }
+    }
+
+    #[test]
+    fn hook_log_section_starts_empty() {
+        let section = HookLogSection {
+            step: "copy".to_string(),
+            lines: Vec::new(),
+            completed: false,
+            success: false,
+            duration: None,
+        };
+        assert_eq!(section.step, "copy");
+        assert!(section.lines.is_empty());
+        assert!(!section.completed);
+    }
+
+    #[test]
+    fn hook_log_line_holds_stream_and_text() {
+        let line = HookLogLine {
+            stream: "stderr".to_string(),
+            text: "error: not found".to_string(),
+        };
+        assert_eq!(line.stream, "stderr");
+        assert_eq!(line.text, "error: not found");
+    }
+
+    #[test]
+    fn hook_log_state_starts_empty_and_incomplete() {
+        let state = HookLogState::new("post_create");
+        assert_eq!(state.title, "post_create");
+        assert!(state.sections.is_empty());
+        assert!(!state.completed);
+        assert!(!state.success);
+        assert_eq!(state.scroll_offset, 0);
+        assert!(state.error.is_none());
+    }
+}

--- a/src/tui/screens/hook_log.rs
+++ b/src/tui/screens/hook_log.rs
@@ -65,6 +65,54 @@ impl HookLogState {
             error: None,
         }
     }
+
+    /// Process an incoming message from the hook runner, updating state.
+    pub fn process_message(&mut self, msg: HookOutputMessage) {
+        match msg {
+            HookOutputMessage::StepStarted { step } => {
+                self.sections.push(HookLogSection {
+                    step,
+                    lines: Vec::new(),
+                    completed: false,
+                    success: false,
+                    duration: None,
+                });
+            }
+            HookOutputMessage::OutputLine { step, stream, line } => {
+                let section = self
+                    .sections
+                    .iter_mut()
+                    .rfind(|s| s.step == step);
+                if let Some(section) = section {
+                    section.lines.push(HookLogLine { stream, text: line });
+                }
+            }
+            HookOutputMessage::StepCompleted {
+                step,
+                success,
+                duration,
+            } => {
+                let section = self
+                    .sections
+                    .iter_mut()
+                    .rfind(|s| s.step == step);
+                if let Some(section) = section {
+                    section.completed = true;
+                    section.success = success;
+                    section.duration = Some(duration);
+                }
+            }
+            HookOutputMessage::HookCompleted {
+                success,
+                error,
+                ..
+            } => {
+                self.completed = true;
+                self.success = success;
+                self.error = error;
+            }
+        }
+    }
 }
 
 #[cfg(test)]
@@ -174,5 +222,126 @@ mod tests {
         assert!(!state.success);
         assert_eq!(state.scroll_offset, 0);
         assert!(state.error.is_none());
+    }
+
+    #[test]
+    fn process_step_started_creates_new_section() {
+        let mut state = HookLogState::new("post_create");
+        state.process_message(HookOutputMessage::StepStarted {
+            step: "copy".to_string(),
+        });
+        assert_eq!(state.sections.len(), 1);
+        assert_eq!(state.sections[0].step, "copy");
+        assert!(!state.sections[0].completed);
+    }
+
+    #[test]
+    fn process_output_line_adds_to_current_section() {
+        let mut state = HookLogState::new("post_create");
+        state.process_message(HookOutputMessage::StepStarted {
+            step: "run".to_string(),
+        });
+        state.process_message(HookOutputMessage::OutputLine {
+            step: "run".to_string(),
+            stream: "stdout".to_string(),
+            line: "installing deps".to_string(),
+        });
+        state.process_message(HookOutputMessage::OutputLine {
+            step: "run".to_string(),
+            stream: "stderr".to_string(),
+            line: "warning: deprecated".to_string(),
+        });
+        assert_eq!(state.sections[0].lines.len(), 2);
+        assert_eq!(state.sections[0].lines[0].text, "installing deps");
+        assert_eq!(state.sections[0].lines[0].stream, "stdout");
+        assert_eq!(state.sections[0].lines[1].text, "warning: deprecated");
+        assert_eq!(state.sections[0].lines[1].stream, "stderr");
+    }
+
+    #[test]
+    fn process_step_completed_marks_section_done() {
+        let mut state = HookLogState::new("post_create");
+        state.process_message(HookOutputMessage::StepStarted {
+            step: "run".to_string(),
+        });
+        state.process_message(HookOutputMessage::StepCompleted {
+            step: "run".to_string(),
+            success: true,
+            duration: Duration::from_millis(500),
+        });
+        assert!(state.sections[0].completed);
+        assert!(state.sections[0].success);
+        assert_eq!(state.sections[0].duration, Some(Duration::from_millis(500)));
+    }
+
+    #[test]
+    fn process_step_completed_failure() {
+        let mut state = HookLogState::new("post_create");
+        state.process_message(HookOutputMessage::StepStarted {
+            step: "shell".to_string(),
+        });
+        state.process_message(HookOutputMessage::StepCompleted {
+            step: "shell".to_string(),
+            success: false,
+            duration: Duration::from_secs(2),
+        });
+        assert!(state.sections[0].completed);
+        assert!(!state.sections[0].success);
+    }
+
+    #[test]
+    fn process_hook_completed_marks_state_done() {
+        let mut state = HookLogState::new("post_create");
+        state.process_message(HookOutputMessage::HookCompleted {
+            success: true,
+            duration: Duration::from_secs(3),
+            error: None,
+        });
+        assert!(state.completed);
+        assert!(state.success);
+        assert!(state.error.is_none());
+    }
+
+    #[test]
+    fn process_hook_completed_with_error() {
+        let mut state = HookLogState::new("post_create");
+        state.process_message(HookOutputMessage::HookCompleted {
+            success: false,
+            duration: Duration::from_secs(1),
+            error: Some("exit code 1".to_string()),
+        });
+        assert!(state.completed);
+        assert!(!state.success);
+        assert_eq!(state.error.as_deref(), Some("exit code 1"));
+    }
+
+    #[test]
+    fn process_multiple_steps_creates_multiple_sections() {
+        let mut state = HookLogState::new("post_create");
+        state.process_message(HookOutputMessage::StepStarted {
+            step: "copy".to_string(),
+        });
+        state.process_message(HookOutputMessage::StepCompleted {
+            step: "copy".to_string(),
+            success: true,
+            duration: Duration::from_millis(100),
+        });
+        state.process_message(HookOutputMessage::StepStarted {
+            step: "run".to_string(),
+        });
+        state.process_message(HookOutputMessage::OutputLine {
+            step: "run".to_string(),
+            stream: "stdout".to_string(),
+            line: "done".to_string(),
+        });
+        state.process_message(HookOutputMessage::StepCompleted {
+            step: "run".to_string(),
+            success: true,
+            duration: Duration::from_millis(800),
+        });
+        assert_eq!(state.sections.len(), 2);
+        assert_eq!(state.sections[0].step, "copy");
+        assert_eq!(state.sections[1].step, "run");
+        assert_eq!(state.sections[1].lines.len(), 1);
     }
 }

--- a/src/tui/screens/hook_log.rs
+++ b/src/tui/screens/hook_log.rs
@@ -8,30 +8,7 @@ use ratatui::{
     Frame,
 };
 
-/// A message sent from the hook runner to the TUI for live streaming.
-#[derive(Debug, Clone)]
-pub enum HookOutputMessage {
-    /// A new hook step (copy/run/shell) has started.
-    StepStarted { step: String },
-    /// A line of output from the current step.
-    OutputLine {
-        step: String,
-        stream: String,
-        line: String,
-    },
-    /// A step completed (success or failure).
-    StepCompleted {
-        step: String,
-        success: bool,
-        duration: Duration,
-    },
-    /// The entire hook execution completed.
-    HookCompleted {
-        success: bool,
-        duration: Duration,
-        error: Option<String>,
-    },
-}
+pub use crate::hooks::types::HookOutputMessage;
 
 /// One section of the hook log, corresponding to a single step (copy/run/shell).
 #[derive(Debug, Clone)]

--- a/src/tui/screens/hook_log.rs
+++ b/src/tui/screens/hook_log.rs
@@ -1,5 +1,11 @@
 use std::time::Duration;
 
+use ratatui::{
+    layout::Rect,
+    widgets::Paragraph,
+    Frame,
+};
+
 /// A message sent from the hook runner to the TUI for live streaming.
 #[derive(Debug, Clone)]
 pub enum HookOutputMessage {
@@ -131,6 +137,12 @@ impl HookLogState {
             }
         }
     }
+}
+
+/// Render the hook log screen.
+pub fn render(state: &HookLogState, frame: &mut Frame, area: Rect) {
+    let text = format!("Hook: {} — running...", state.title);
+    frame.render_widget(Paragraph::new(text), area);
 }
 
 #[cfg(test)]

--- a/src/tui/screens/hook_log.rs
+++ b/src/tui/screens/hook_log.rs
@@ -12,9 +12,7 @@ use ratatui::{
 #[derive(Debug, Clone)]
 pub enum HookOutputMessage {
     /// A new hook step (copy/run/shell) has started.
-    StepStarted {
-        step: String,
-    },
+    StepStarted { step: String },
     /// A line of output from the current step.
     OutputLine {
         step: String,
@@ -74,12 +72,14 @@ impl HookLogState {
         }
     }
 
-    /// Total number of renderable lines (section headers + output lines).
+    /// Total number of renderable lines (section headers + output lines + error).
     pub fn total_lines(&self) -> usize {
-        self.sections
+        let content: usize = self
+            .sections
             .iter()
             .map(|s| 1 + s.lines.len()) // 1 header per section + output lines
-            .sum()
+            .sum();
+        content + if self.error.is_some() { 2 } else { 0 }
     }
 
     /// Auto-scroll to keep the latest output visible.
@@ -105,10 +105,7 @@ impl HookLogState {
                 });
             }
             HookOutputMessage::OutputLine { step, stream, line } => {
-                let section = self
-                    .sections
-                    .iter_mut()
-                    .rfind(|s| s.step == step);
+                let section = self.sections.iter_mut().rfind(|s| s.step == step);
                 if let Some(section) = section {
                     section.lines.push(HookLogLine { stream, text: line });
                 }
@@ -118,21 +115,14 @@ impl HookLogState {
                 success,
                 duration,
             } => {
-                let section = self
-                    .sections
-                    .iter_mut()
-                    .rfind(|s| s.step == step);
+                let section = self.sections.iter_mut().rfind(|s| s.step == step);
                 if let Some(section) = section {
                     section.completed = true;
                     section.success = success;
                     section.duration = Some(duration);
                 }
             }
-            HookOutputMessage::HookCompleted {
-                success,
-                error,
-                ..
-            } => {
+            HookOutputMessage::HookCompleted { success, error, .. } => {
                 self.completed = true;
                 self.success = success;
                 self.error = error;
@@ -157,7 +147,7 @@ fn format_duration(d: Duration) -> String {
 pub fn render(state: &HookLogState, frame: &mut Frame, area: Rect) {
     let chunks = Layout::vertical([
         Constraint::Length(2), // title
-        Constraint::Min(1),   // output area
+        Constraint::Min(1),    // output area
         Constraint::Length(1), // footer
     ])
     .split(area);
@@ -188,16 +178,24 @@ pub fn render(state: &HookLogState, frame: &mut Frame, area: Rect) {
         // Section header
         let header_style = if section.completed {
             if section.success {
-                Style::default().fg(Color::Green).add_modifier(Modifier::BOLD)
+                Style::default()
+                    .fg(Color::Green)
+                    .add_modifier(Modifier::BOLD)
             } else {
                 Style::default().fg(Color::Red).add_modifier(Modifier::BOLD)
             }
         } else {
-            Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD)
         };
 
         let status_icon = if section.completed {
-            if section.success { "✓" } else { "✗" }
+            if section.success {
+                "✓"
+            } else {
+                "✗"
+            }
         } else {
             "●"
         };
@@ -207,12 +205,10 @@ pub fn render(state: &HookLogState, frame: &mut Frame, area: Rect) {
             .map(|d| format!(" ({})", format_duration(d)))
             .unwrap_or_default();
 
-        lines.push(Line::from(vec![
-            Span::styled(
-                format!("{status_icon} [{step}]{elapsed}", step = section.step),
-                header_style,
-            ),
-        ]));
+        lines.push(Line::from(vec![Span::styled(
+            format!("{status_icon} [{step}]{elapsed}", step = section.step),
+            header_style,
+        )]));
 
         // Output lines
         for log_line in &section.lines {
@@ -245,7 +241,11 @@ pub fn render(state: &HookLogState, frame: &mut Frame, area: Rect) {
     frame.render_widget(Paragraph::new(visible_lines), chunks[1]);
 
     // Footer
-    let footer_text = if state.completed { FOOTER_DONE } else { FOOTER_RUNNING };
+    let footer_text = if state.completed {
+        FOOTER_DONE
+    } else {
+        FOOTER_RUNNING
+    };
     let footer = Paragraph::new(Line::from(footer_text))
         .style(Style::default().add_modifier(Modifier::REVERSED));
     frame.render_widget(footer, chunks[2]);
@@ -486,14 +486,22 @@ mod tests {
         let mut state = HookLogState::new("test");
         state.process_message(HookOutputMessage::StepStarted { step: "run".into() });
         state.process_message(HookOutputMessage::OutputLine {
-            step: "run".into(), stream: "stdout".into(), line: "line1".into(),
+            step: "run".into(),
+            stream: "stdout".into(),
+            line: "line1".into(),
         });
         state.process_message(HookOutputMessage::OutputLine {
-            step: "run".into(), stream: "stdout".into(), line: "line2".into(),
+            step: "run".into(),
+            stream: "stdout".into(),
+            line: "line2".into(),
         });
-        state.process_message(HookOutputMessage::StepStarted { step: "shell".into() });
+        state.process_message(HookOutputMessage::StepStarted {
+            step: "shell".into(),
+        });
         state.process_message(HookOutputMessage::OutputLine {
-            step: "shell".into(), stream: "stdout".into(), line: "line3".into(),
+            step: "shell".into(),
+            stream: "stdout".into(),
+            line: "line3".into(),
         });
         // total_lines = output lines + section headers (1 per section)
         assert_eq!(state.total_lines(), 5); // 2 headers + 3 output lines
@@ -512,7 +520,7 @@ mod tests {
         }
         // After many lines, auto_scroll should set offset near the end
         state.auto_scroll(10); // visible_height = 10
-        // scroll_offset should be total_lines - visible_height
+                               // scroll_offset should be total_lines - visible_height
         let expected = state.total_lines().saturating_sub(10);
         assert_eq!(state.scroll_offset, expected);
     }
@@ -522,7 +530,9 @@ mod tests {
         let mut state = HookLogState::new("test");
         state.process_message(HookOutputMessage::StepStarted { step: "run".into() });
         state.process_message(HookOutputMessage::OutputLine {
-            step: "run".into(), stream: "stdout".into(), line: "one".into(),
+            step: "run".into(),
+            stream: "stdout".into(),
+            line: "one".into(),
         });
         state.auto_scroll(20); // plenty of room
         assert_eq!(state.scroll_offset, 0);
@@ -546,7 +556,10 @@ mod tests {
         let state = HookLogState::new("post_create");
         let buf = render_to_buffer(&state, 80, 20);
         let text = buffer_text(&buf);
-        assert!(text.contains("post_create"), "should show hook name in title, got: {text}");
+        assert!(
+            text.contains("post_create"),
+            "should show hook name in title, got: {text}"
+        );
     }
 
     #[test]
@@ -555,7 +568,10 @@ mod tests {
         state.process_message(HookOutputMessage::StepStarted { step: "run".into() });
         let buf = render_to_buffer(&state, 80, 20);
         let text = buffer_text(&buf);
-        assert!(text.contains("run"), "should show section header for 'run' step");
+        assert!(
+            text.contains("run"),
+            "should show section header for 'run' step"
+        );
     }
 
     #[test]
@@ -563,11 +579,16 @@ mod tests {
         let mut state = HookLogState::new("post_create");
         state.process_message(HookOutputMessage::StepStarted { step: "run".into() });
         state.process_message(HookOutputMessage::OutputLine {
-            step: "run".into(), stream: "stdout".into(), line: "installing packages".into(),
+            step: "run".into(),
+            stream: "stdout".into(),
+            line: "installing packages".into(),
         });
         let buf = render_to_buffer(&state, 80, 20);
         let text = buffer_text(&buf);
-        assert!(text.contains("installing packages"), "should show output line");
+        assert!(
+            text.contains("installing packages"),
+            "should show output line"
+        );
     }
 
     #[test]
@@ -575,11 +596,16 @@ mod tests {
         let mut state = HookLogState::new("post_create");
         state.process_message(HookOutputMessage::StepStarted { step: "run".into() });
         state.process_message(HookOutputMessage::StepCompleted {
-            step: "run".into(), success: true, duration: Duration::from_millis(1500),
+            step: "run".into(),
+            success: true,
+            duration: Duration::from_millis(1500),
         });
         let buf = render_to_buffer(&state, 80, 20);
         let text = buffer_text(&buf);
-        assert!(text.contains("1.5s"), "should show elapsed time, got: {text}");
+        assert!(
+            text.contains("1.5s"),
+            "should show elapsed time, got: {text}"
+        );
     }
 
     #[test]
@@ -594,22 +620,32 @@ mod tests {
     fn render_completed_success_shows_status() {
         let mut state = HookLogState::new("post_create");
         state.process_message(HookOutputMessage::HookCompleted {
-            success: true, duration: Duration::from_secs(2), error: None,
+            success: true,
+            duration: Duration::from_secs(2),
+            error: None,
         });
         let buf = render_to_buffer(&state, 80, 20);
         let text = buffer_text(&buf);
-        assert!(text.contains("Complete") || text.contains("Success"), "should show success status, got: {text}");
+        assert!(
+            text.contains("Complete") || text.contains("Success"),
+            "should show success status, got: {text}"
+        );
     }
 
     #[test]
     fn render_completed_failure_shows_error() {
         let mut state = HookLogState::new("post_create");
         state.process_message(HookOutputMessage::HookCompleted {
-            success: false, duration: Duration::from_secs(1), error: Some("exit code 1".into()),
+            success: false,
+            duration: Duration::from_secs(1),
+            error: Some("exit code 1".into()),
         });
         let buf = render_to_buffer(&state, 80, 20);
         let text = buffer_text(&buf);
-        assert!(text.contains("exit code 1"), "should show error message, got: {text}");
+        assert!(
+            text.contains("exit code 1"),
+            "should show error message, got: {text}"
+        );
     }
 
     #[test]
@@ -617,13 +653,16 @@ mod tests {
         let mut state = HookLogState::new("post_create");
         state.process_message(HookOutputMessage::StepStarted { step: "run".into() });
         state.process_message(HookOutputMessage::StepCompleted {
-            step: "run".into(), success: true, duration: Duration::from_millis(100),
+            step: "run".into(),
+            success: true,
+            duration: Duration::from_millis(100),
         });
         let buf = render_to_buffer(&state, 80, 20);
         // Find a cell in the header row that has green foreground
-        let has_green = buf.content().iter().any(|cell| {
-            cell.fg == ratatui::style::Color::Green
-        });
+        let has_green = buf
+            .content()
+            .iter()
+            .any(|cell| cell.fg == ratatui::style::Color::Green);
         assert!(has_green, "successful step should have green-colored text");
     }
 
@@ -632,12 +671,41 @@ mod tests {
         let mut state = HookLogState::new("post_create");
         state.process_message(HookOutputMessage::StepStarted { step: "run".into() });
         state.process_message(HookOutputMessage::StepCompleted {
-            step: "run".into(), success: false, duration: Duration::from_millis(100),
+            step: "run".into(),
+            success: false,
+            duration: Duration::from_millis(100),
         });
         let buf = render_to_buffer(&state, 80, 20);
-        let has_red = buf.content().iter().any(|cell| {
-            cell.fg == ratatui::style::Color::Red
-        });
+        let has_red = buf
+            .content()
+            .iter()
+            .any(|cell| cell.fg == ratatui::style::Color::Red);
         assert!(has_red, "failed step should have red-colored text");
+    }
+
+    #[test]
+    fn total_lines_includes_error_lines() {
+        let mut state = HookLogState::new("test");
+        state.process_message(HookOutputMessage::StepStarted { step: "run".into() });
+        state.process_message(HookOutputMessage::OutputLine {
+            step: "run".into(),
+            stream: "stdout".into(),
+            line: "line1".into(),
+        });
+        state.process_message(HookOutputMessage::OutputLine {
+            step: "run".into(),
+            stream: "stdout".into(),
+            line: "line2".into(),
+        });
+        // Without error: 1 header + 2 output = 3
+        assert_eq!(state.total_lines(), 3);
+
+        state.process_message(HookOutputMessage::HookCompleted {
+            success: false,
+            duration: Duration::from_secs(1),
+            error: Some("command failed".into()),
+        });
+        // With error: 3 content + 2 error lines (blank + "Error: ...") = 5
+        assert_eq!(state.total_lines(), 5);
     }
 }

--- a/src/tui/screens/mod.rs
+++ b/src/tui/screens/mod.rs
@@ -2,5 +2,6 @@ pub mod create;
 pub mod delete_confirm;
 pub mod detail;
 pub mod help;
+pub mod hook_log;
 pub mod list;
 pub mod sync_picker;


### PR DESCRIPTION
Closes #53

## Summary
Implements TUI hook log view with live streaming during create/sync/remove operations. When hooks are configured, a new HookLog screen shows real-time output sectioned by step (copy/run/shell) with color-coded status, elapsed times, and auto-scroll. Hook execution runs in a background thread communicating via `std::sync::mpsc` channel, while the TUI event loop polls at 50ms intervals for non-blocking updates.

## User Stories Addressed
- US-11: TUI hook visibility — hook log view streams output live during execution and supports replay from history
- US-2: See hook output in real time — during create/sync/remove, a panel shows real-time hook output

## Automated Testing
- Total tests added: 34
- Tests passing: 34
- Tests failing: 0
- `cargo clippy`: pass (0 errors, pre-existing warnings only)
- `cargo test`: pass (762 total — 735 unit + 11 exit codes + 16 log command)

## UAT Checklist
- [ ] Configure `.trench.toml` with `[hooks.post_create] run = ["echo installing...", "sleep 2", "echo done"]`
- [ ] `trench` (TUI) → press `n` to create → fill form → Enter → verify hook log panel appears with live output
- [ ] Verify output is sectioned with `[run]` header and shows each line as it arrives
- [ ] Verify elapsed time appears next to completed step header (e.g., `✓ [run] (2.1s)`)
- [ ] Verify green color on successful step, red on failure
- [ ] Press `Esc` during hook execution → verify return to list view, hooks continue running
- [ ] Configure `[hooks.pre_sync]` and `[hooks.post_sync]` → sync a worktree → verify hook log appears
- [ ] Configure `[hooks.pre_remove]` → delete a worktree → verify hook log appears
- [ ] Create worktree WITHOUT hooks configured → verify existing synchronous behavior (no hook log panel)
- [ ] Hook that fails (e.g., `exit 1`) → verify red `✗` marker and error message in hook log

## Known Issues
- Hook output is currently streamed per-step (after each `run` command completes) rather than per-line during execution, because `stream_and_collect` captures output in bulk. True line-by-line streaming during command execution would require modifying `stream_and_collect` to also send through the channel, which is a follow-up improvement.
- Auto-scroll uses a fixed visible height estimate (20 lines) during message processing rather than the actual terminal height, since terminal dimensions are only available during render.
- DB-based hook log replay (viewing past hook output from history) is not yet implemented in the TUI — this is a separate concern from live streaming.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hook Log screen streams live hook output during create/remove/sync operations, showing step-by-step logs, statuses, durations, and errors.
  * Hook output streams into the UI with auto-scroll, manual scrolling, per-line stdout/stderr styling, and a footer indicating running/done.
  * Hook flows run in background and can be dismissed while messages continue to drain.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->