### PR TITLE
feat(tui): session persistence — last repo, worktree, scroll position

### DIFF
--- a/src/state/queries.rs
+++ b/src/state/queries.rs
@@ -348,11 +348,21 @@ impl Database {
     }
 
     /// Save TUI list session state for a repo (selected worktree name + scroll position).
+    ///
+    /// Both fields are written in a single transaction so they stay consistent.
     pub fn save_list_session(&self, repo_path: &str, worktree_name: &str, scroll_position: usize) -> Result<()> {
         let key_name = format!("{repo_path}:selected_worktree");
         let key_scroll = format!("{repo_path}:scroll_position");
-        self.set_session(&key_name, worktree_name)?;
-        self.set_session(&key_scroll, &scroll_position.to_string())?;
+        let updated_at = now();
+        let sql = "INSERT INTO session (key, value, updated_at) VALUES (?1, ?2, ?3)
+                   ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at";
+        let tx = self.conn.unchecked_transaction()
+            .context("failed to begin session transaction")?;
+        tx.execute(sql, rusqlite::params![key_name, worktree_name, updated_at])
+            .context("failed to set selected_worktree")?;
+        tx.execute(sql, rusqlite::params![key_scroll, scroll_position.to_string(), updated_at])
+            .context("failed to set scroll_position")?;
+        tx.commit().context("failed to commit session")?;
         Ok(())
     }
 
@@ -872,6 +882,24 @@ mod tests {
         let (name_b, pos_b) = db.load_list_session("/repos/beta").unwrap().unwrap();
         assert_eq!(name_b, "wt-b");
         assert_eq!(pos_b, 7);
+    }
+
+    #[test]
+    fn save_list_session_writes_both_keys_atomically() {
+        let db = Database::open_in_memory().unwrap();
+        db.save_list_session("/repos/atomic", "wt-x", 42).unwrap();
+
+        // Verify both keys individually via raw get_session
+        let name = db.get_session("/repos/atomic:selected_worktree").unwrap();
+        let scroll = db.get_session("/repos/atomic:scroll_position").unwrap();
+        assert_eq!(name.as_deref(), Some("wt-x"), "worktree name should be set");
+        assert_eq!(scroll.as_deref(), Some("42"), "scroll position should be set");
+
+        // Connection should be in autocommit mode (no dangling transaction)
+        assert!(
+            db.conn_for_test().is_autocommit(),
+            "connection should be in autocommit after save (no dangling tx)"
+        );
     }
 
     #[test]

--- a/src/state/queries.rs
+++ b/src/state/queries.rs
@@ -347,6 +347,30 @@ impl Database {
         Ok(value)
     }
 
+    /// Save TUI list session state for a repo (selected worktree name + scroll position).
+    pub fn save_list_session(&self, repo_path: &str, worktree_name: &str, scroll_position: usize) -> Result<()> {
+        let key_name = format!("{repo_path}:selected_worktree");
+        let key_scroll = format!("{repo_path}:scroll_position");
+        self.set_session(&key_name, worktree_name)?;
+        self.set_session(&key_scroll, &scroll_position.to_string())?;
+        Ok(())
+    }
+
+    /// Load TUI list session state for a repo. Returns `(worktree_name, scroll_position)`.
+    pub fn load_list_session(&self, repo_path: &str) -> Result<Option<(String, usize)>> {
+        let key_name = format!("{repo_path}:selected_worktree");
+        let key_scroll = format!("{repo_path}:scroll_position");
+        let name = self.get_session(&key_name)?;
+        let scroll = self.get_session(&key_scroll)?;
+        match (name, scroll) {
+            (Some(n), Some(s)) => {
+                let pos = s.parse::<usize>().unwrap_or(0);
+                Ok(Some((n, pos)))
+            }
+            _ => Ok(None),
+        }
+    }
+
     /// Add a tag to a worktree. Idempotent — duplicate adds are silently ignored.
     pub fn add_tag(&self, worktree_id: i64, name: &str) -> Result<()> {
         let created_at = now();
@@ -797,6 +821,57 @@ mod tests {
             .list_events_filtered(repo.id, Some("alpha"), Some(2))
             .unwrap();
         assert_eq!(limited.len(), 2);
+    }
+
+    #[test]
+    fn save_and_load_list_session_round_trip() {
+        let db = Database::open_in_memory().unwrap();
+
+        // Save session for a repo
+        db.save_list_session("/repos/my-project", "feat-auth", 3).unwrap();
+
+        // Load it back
+        let session = db.load_list_session("/repos/my-project").unwrap();
+        assert!(session.is_some(), "should find saved session");
+        let (name, pos) = session.unwrap();
+        assert_eq!(name, "feat-auth");
+        assert_eq!(pos, 3);
+    }
+
+    #[test]
+    fn load_list_session_returns_none_when_no_session() {
+        let db = Database::open_in_memory().unwrap();
+
+        let session = db.load_list_session("/repos/no-such-repo").unwrap();
+        assert!(session.is_none(), "should return None for unknown repo");
+    }
+
+    #[test]
+    fn save_list_session_overwrites_previous() {
+        let db = Database::open_in_memory().unwrap();
+
+        db.save_list_session("/repos/r", "feat-a", 1).unwrap();
+        db.save_list_session("/repos/r", "feat-b", 5).unwrap();
+
+        let (name, pos) = db.load_list_session("/repos/r").unwrap().unwrap();
+        assert_eq!(name, "feat-b");
+        assert_eq!(pos, 5);
+    }
+
+    #[test]
+    fn save_list_session_isolates_per_repo() {
+        let db = Database::open_in_memory().unwrap();
+
+        db.save_list_session("/repos/alpha", "wt-a", 2).unwrap();
+        db.save_list_session("/repos/beta", "wt-b", 7).unwrap();
+
+        let (name_a, pos_a) = db.load_list_session("/repos/alpha").unwrap().unwrap();
+        assert_eq!(name_a, "wt-a");
+        assert_eq!(pos_a, 2);
+
+        let (name_b, pos_b) = db.load_list_session("/repos/beta").unwrap().unwrap();
+        assert_eq!(name_b, "wt-b");
+        assert_eq!(pos_b, 7);
     }
 
     #[test]

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -45,6 +45,9 @@ pub fn run() -> Result<()> {
     // Load worktree data before entering the event loop
     app.refresh_list();
 
+    // Restore session state (selected worktree, scroll position) from last run
+    app.restore_list_session();
+
     let result = (|| -> Result<()> {
         while app.is_running() {
             // Process any pending hook output messages
@@ -308,6 +311,12 @@ impl App {
         let Some((cwd, db)) = Self::open_db() else {
             return;
         };
+        // Discover and cache repo path for session scoping
+        if self.repo_path.is_none() {
+            if let Ok(repo_info) = crate::git::discover_repo(&cwd) {
+                self.repo_path = Some(repo_info.path.to_string_lossy().to_string());
+            }
+        }
         if let Ok(rows) = screens::list::load_worktrees(&cwd, &db, &[]) {
             let prev_selected = self.list_state.selected;
             self.list_state = screens::list::ListState::new(rows);
@@ -840,6 +849,7 @@ impl App {
                 }
                 // Load detail data for the selected worktree
                 if let Some(name) = identity {
+                    self.save_list_session();
                     if self.load_detail(&name) {
                         self.push_screen(Screen::Detail);
                     }
@@ -849,8 +859,14 @@ impl App {
                 self.init_create_form();
                 self.push_screen(Screen::Create);
             }
-            KeyCode::Down | KeyCode::Char('j') => self.list_state.select_next(),
-            KeyCode::Up | KeyCode::Char('k') => self.list_state.select_previous(),
+            KeyCode::Down | KeyCode::Char('j') => {
+                self.list_state.select_next();
+                self.save_list_session();
+            }
+            KeyCode::Up | KeyCode::Char('k') => {
+                self.list_state.select_previous();
+                self.save_list_session();
+            }
             KeyCode::Char('s') => {
                 if let Some(row) = self.list_state.rows.get(self.list_state.selected) {
                     self.sync_picker_state =

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -110,6 +110,7 @@ pub struct App {
     pub hook_log_state: Option<screens::hook_log::HookLogState>,
     pub hook_rx: Option<std::sync::mpsc::Receiver<screens::hook_log::HookOutputMessage>>,
     pub editor_request: Option<String>,
+    pub repo_path: Option<String>,
 }
 
 impl App {
@@ -126,6 +127,7 @@ impl App {
             hook_log_state: None,
             hook_rx: None,
             editor_request: None,
+            repo_path: None,
         }
     }
 
@@ -263,6 +265,42 @@ impl App {
         let db_path = paths::data_dir().ok()?.join("trench.db");
         let db = Database::open(&db_path).ok()?;
         Some((cwd, db))
+    }
+
+    /// Save the current list selection to the session table (testable variant).
+    pub fn save_list_session_to(&self, db: &Database) {
+        let Some(ref repo_path) = self.repo_path else {
+            return;
+        };
+        if let Some(row) = self.list_state.rows.get(self.list_state.selected) {
+            let _ = db.save_list_session(repo_path, &row.name, self.list_state.selected);
+        }
+    }
+
+    /// Restore list selection from the session table (testable variant).
+    pub fn restore_list_session_from(&mut self, db: &Database) {
+        let Some(ref repo_path) = self.repo_path else {
+            return;
+        };
+        if let Ok(Some((name, pos))) = db.load_list_session(repo_path) {
+            self.list_state.restore_selection(&name, pos);
+        }
+    }
+
+    /// Save the current list selection to the session table.
+    fn save_list_session(&self) {
+        let Some((_, db)) = Self::open_db() else {
+            return;
+        };
+        self.save_list_session_to(&db);
+    }
+
+    /// Restore list selection from the session table.
+    fn restore_list_session(&mut self) {
+        let Some((_, db)) = Self::open_db() else {
+            return;
+        };
+        self.restore_list_session_from(&db);
     }
 
     /// Reload worktree data from git + DB for the list screen.
@@ -1070,6 +1108,88 @@ mod tests {
     use super::*;
     use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
     use serial_test::serial;
+
+    #[test]
+    fn app_has_repo_path_initially_none() {
+        let app = App::new();
+        assert!(app.repo_path.is_none());
+    }
+
+    #[test]
+    fn save_list_session_to_db_persists_selection() {
+        let db = crate::state::Database::open_in_memory().unwrap();
+        let mut app = app_with_rows();
+        app.repo_path = Some("/repos/test".into());
+        app.list_state.selected = 1; // "feat-b"
+
+        app.save_list_session_to(&db);
+
+        let session = db.load_list_session("/repos/test").unwrap();
+        assert!(session.is_some());
+        let (name, pos) = session.unwrap();
+        assert_eq!(name, "feat-b");
+        assert_eq!(pos, 1);
+    }
+
+    #[test]
+    fn save_list_session_to_db_noop_without_repo_path() {
+        let db = crate::state::Database::open_in_memory().unwrap();
+        let mut app = app_with_rows();
+        app.list_state.selected = 2;
+        // repo_path is None — should not save
+
+        app.save_list_session_to(&db);
+
+        let session = db.load_list_session("").unwrap();
+        assert!(session.is_none(), "should not save without repo_path");
+    }
+
+    #[test]
+    fn restore_list_session_from_db_restores_selection() {
+        let db = crate::state::Database::open_in_memory().unwrap();
+        db.save_list_session("/repos/test", "feat-b", 1).unwrap();
+
+        let mut app = app_with_rows();
+        app.repo_path = Some("/repos/test".into());
+        app.restore_list_session_from(&db);
+
+        assert_eq!(app.list_state.selected, 1);
+    }
+
+    #[test]
+    fn restore_list_session_from_db_handles_stale_worktree() {
+        let db = crate::state::Database::open_in_memory().unwrap();
+        db.save_list_session("/repos/test", "deleted-worktree", 99).unwrap();
+
+        let mut app = app_with_rows();
+        app.repo_path = Some("/repos/test".into());
+        app.restore_list_session_from(&db);
+
+        assert_eq!(app.list_state.selected, 0, "should fall back to 0 for stale state");
+    }
+
+    #[test]
+    fn restore_list_session_noop_without_repo_path() {
+        let db = crate::state::Database::open_in_memory().unwrap();
+        db.save_list_session("/repos/test", "feat-b", 1).unwrap();
+
+        let mut app = app_with_rows();
+        // repo_path is None
+        app.restore_list_session_from(&db);
+
+        assert_eq!(app.list_state.selected, 0, "should not restore without repo_path");
+    }
+
+    #[test]
+    fn restore_list_session_noop_with_no_saved_session() {
+        let db = crate::state::Database::open_in_memory().unwrap();
+
+        let mut app = app_with_rows();
+        app.repo_path = Some("/repos/test".into());
+        app.restore_list_session_from(&db);
+
+        assert_eq!(app.list_state.selected, 0, "should stay at 0 with no saved session");
+    }
 
     #[test]
     fn app_starts_in_running_state() {

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1208,6 +1208,94 @@ mod tests {
     }
 
     #[test]
+    fn session_full_round_trip_save_restart_restore() {
+        let db = crate::state::Database::open_in_memory().unwrap();
+        let repo_path = "/repos/round-trip";
+
+        // Simulate first TUI session: user navigates to "feat-b" (index 1)
+        let mut app1 = app_with_rows();
+        app1.repo_path = Some(repo_path.into());
+        app1.list_state.selected = 1;
+        app1.save_list_session_to(&db);
+
+        // Simulate TUI restart: new App, same rows, restore session
+        let mut app2 = app_with_rows();
+        app2.repo_path = Some(repo_path.into());
+        assert_eq!(app2.list_state.selected, 0, "new app starts at 0");
+        app2.restore_list_session_from(&db);
+        assert_eq!(app2.list_state.selected, 1, "should restore to feat-b");
+    }
+
+    #[test]
+    fn session_round_trip_with_stale_worktree() {
+        let db = crate::state::Database::open_in_memory().unwrap();
+        let repo_path = "/repos/stale";
+
+        // First session: user selects "feat-b" (index 1)
+        let mut app1 = app_with_rows();
+        app1.repo_path = Some(repo_path.into());
+        app1.list_state.selected = 1;
+        app1.save_list_session_to(&db);
+
+        // Restart with different rows — "feat-b" was removed
+        let mut app2 = App::new();
+        app2.list_state = screens::list::ListState::new(vec![
+            screens::list::WorktreeRow {
+                name: "feat-a".into(),
+                branch: "feat/a".into(),
+                path: "/tmp/wt/feat-a".into(),
+                status: "clean".into(),
+                ahead_behind: "+0/-0".into(),
+                managed: true,
+            },
+            screens::list::WorktreeRow {
+                name: "feat-c".into(),
+                branch: "feat/c".into(),
+                path: "/tmp/wt/feat-c".into(),
+                status: "clean".into(),
+                ahead_behind: "-".into(),
+                managed: true,
+            },
+        ]);
+        app2.repo_path = Some(repo_path.into());
+        app2.restore_list_session_from(&db);
+
+        // "feat-b" is gone. scroll_position (1) is still valid,
+        // so it falls back to index 1
+        assert_eq!(app2.list_state.selected, 1,
+            "should fall back to scroll position when worktree name not found");
+    }
+
+    #[test]
+    fn session_per_repo_isolation() {
+        let db = crate::state::Database::open_in_memory().unwrap();
+
+        // Save session for repo A
+        let mut app_a = app_with_rows();
+        app_a.repo_path = Some("/repos/alpha".into());
+        app_a.list_state.selected = 2; // "main"
+        app_a.save_list_session_to(&db);
+
+        // Save session for repo B
+        let mut app_b = app_with_rows();
+        app_b.repo_path = Some("/repos/beta".into());
+        app_b.list_state.selected = 0; // "feat-a"
+        app_b.save_list_session_to(&db);
+
+        // Restore repo A — should get index 2
+        let mut restore_a = app_with_rows();
+        restore_a.repo_path = Some("/repos/alpha".into());
+        restore_a.restore_list_session_from(&db);
+        assert_eq!(restore_a.list_state.selected, 2);
+
+        // Restore repo B — should get index 0
+        let mut restore_b = app_with_rows();
+        restore_b.repo_path = Some("/repos/beta".into());
+        restore_b.restore_list_session_from(&db);
+        assert_eq!(restore_b.list_state.selected, 0);
+    }
+
+    #[test]
     fn app_starts_in_running_state() {
         let app = App::new();
         assert!(app.is_running(), "newly created app should be running");

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -860,12 +860,18 @@ impl App {
                 self.push_screen(Screen::Create);
             }
             KeyCode::Down | KeyCode::Char('j') => {
+                let prev = self.list_state.selected;
                 self.list_state.select_next();
-                self.save_list_session();
+                if self.list_state.selected != prev {
+                    self.save_list_session();
+                }
             }
             KeyCode::Up | KeyCode::Char('k') => {
+                let prev = self.list_state.selected;
                 self.list_state.select_previous();
-                self.save_list_session();
+                if self.list_state.selected != prev {
+                    self.save_list_session();
+                }
             }
             KeyCode::Char('s') => {
                 if let Some(row) = self.list_state.rows.get(self.list_state.selected) {

--- a/src/tui/screens/list.rs
+++ b/src/tui/screens/list.rs
@@ -45,6 +45,26 @@ impl ListState {
     pub fn select_previous(&mut self) {
         self.selected = self.selected.saturating_sub(1);
     }
+
+    /// Restore selection from session state. Tries to find the worktree by name;
+    /// if not found, falls back to `scroll_position` (clamped to bounds).
+    /// Returns `true` if the worktree was found by name.
+    pub fn restore_selection(&mut self, worktree_name: &str, scroll_position: usize) -> bool {
+        if self.rows.is_empty() {
+            self.selected = 0;
+            return false;
+        }
+        if let Some(idx) = self.rows.iter().position(|r| r.name == worktree_name) {
+            self.selected = idx;
+            true
+        } else if scroll_position < self.rows.len() {
+            self.selected = scroll_position;
+            false
+        } else {
+            self.selected = 0;
+            false
+        }
+    }
 }
 
 /// Load worktree data from the database and git, returning rows for the list view.
@@ -275,6 +295,41 @@ mod tests {
                 managed: false,
             },
         ]
+    }
+
+    #[test]
+    fn restore_selection_finds_worktree_by_name() {
+        let mut state = ListState::new(sample_rows());
+        // "fix-bug" is at index 1
+        let found = state.restore_selection("fix-bug", 0);
+        assert!(found, "should find worktree by name");
+        assert_eq!(state.selected, 1);
+    }
+
+    #[test]
+    fn restore_selection_falls_back_to_scroll_position() {
+        let mut state = ListState::new(sample_rows());
+        // Name not found, but scroll position 2 is valid
+        let found = state.restore_selection("nonexistent", 2);
+        assert!(!found, "should not find nonexistent worktree");
+        assert_eq!(state.selected, 2, "should fall back to scroll position");
+    }
+
+    #[test]
+    fn restore_selection_clamps_scroll_position() {
+        let mut state = ListState::new(sample_rows());
+        // Name not found, scroll position 99 is out of bounds
+        let found = state.restore_selection("nonexistent", 99);
+        assert!(!found);
+        assert_eq!(state.selected, 0, "should clamp to 0 when out of bounds");
+    }
+
+    #[test]
+    fn restore_selection_on_empty_list() {
+        let mut state = ListState::new(vec![]);
+        let found = state.restore_selection("anything", 5);
+        assert!(!found);
+        assert_eq!(state.selected, 0);
     }
 
     #[test]


### PR DESCRIPTION
Closes #56

## Summary
Implements TUI session persistence across runs: the last selected worktree and scroll position are saved to the SQLite `session` table (per-repo scoped) on every navigation action, and restored on TUI launch. Stale state (deleted worktree) is handled gracefully by falling back to the scroll position or first available worktree.

## User Stories Addressed
- US-11: TUI persistence — remember last selected worktree and scroll position across restarts

## Automated Testing
- Total tests added: 15
- Tests passing: 15
- Tests failing: 0
- `cargo clippy`: pass (pre-existing warnings only, no new warnings)
- `cargo test`: pass (832 total: 805 unit + 27 integration)

## UAT Checklist
- [ ] Launch TUI (`trench`), navigate to a worktree with j/k, quit with q, relaunch → same worktree is selected
- [ ] Navigate to a different worktree, quit, remove that worktree via CLI (`trench remove`), relaunch → TUI selects closest available row (not crash)
- [ ] Open TUI in repo A, select worktree, quit. Open TUI in repo B, select different worktree, quit. Relaunch in repo A → repo A's last selection is restored (per-repo isolation)
- [ ] Launch TUI with no prior session data → starts at first worktree (index 0), no errors
- [ ] Select a worktree, press Enter to view detail, press Esc to return → selection is preserved

## Known Issues
None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic session persistence for the List screen: selected worktree and scroll position are saved and restored across runs.
  * Session state is scoped per repository so different repos keep separate selections.
  * State is saved during navigation and when opening a worktree; restored on startup after the list is refreshed.
  * If the previously selected worktree no longer exists, the app falls back to a sensible scroll-position or the top of the list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->