### PR TITLE
feat(process): detect running dev servers in worktree

### DIFF
--- a/src/cli/commands/list.rs
+++ b/src/cli/commands/list.rs
@@ -213,6 +213,8 @@ struct WorktreeJson {
     dirty: usize,
     managed: bool,
     tags: Vec<String>,
+    process_count: usize,
+    processes: Vec<String>,
 }
 
 impl PorcelainRecord for WorktreeJson {
@@ -319,6 +321,9 @@ fn render_table(
 
 /// Build a `WorktreeJson` from a list entry and computed git status.
 fn build_worktree_json(entry: &ListEntry, status: GitStatus) -> WorktreeJson {
+    let procs = crate::process::detect_processes(&entry.path);
+    let process_names: Vec<String> = procs.iter().map(|p| p.name.clone()).collect();
+    let process_count = procs.len();
     WorktreeJson {
         name: entry.name.clone(),
         branch: entry.branch.clone(),
@@ -329,6 +334,8 @@ fn build_worktree_json(entry: &ListEntry, status: GitStatus) -> WorktreeJson {
         dirty: status.dirty,
         managed: entry.managed,
         tags: entry.tags.clone(),
+        process_count,
+        processes: process_names,
     }
 }
 
@@ -1661,6 +1668,53 @@ mod tests {
         assert_eq!(
             count, 1,
             "known-wt should appear exactly once (deduplicated), found: {count}"
+        );
+    }
+
+    #[test]
+    fn list_json_includes_process_info() {
+        let repo_dir = tempfile::tempdir().unwrap();
+        let _repo = init_repo_with_commit(repo_dir.path());
+        let db = Database::open_in_memory().unwrap();
+
+        let repo_path = repo_dir.path().canonicalize().unwrap();
+        let repo_name = repo_path.file_name().unwrap().to_str().unwrap();
+        let db_repo = db
+            .insert_repo(repo_name, repo_path.to_str().unwrap(), Some("main"))
+            .unwrap();
+
+        db.insert_worktree(
+            db_repo.id,
+            "my-wt",
+            "my-branch",
+            repo_path.to_str().unwrap(),
+            Some("main"),
+        )
+        .unwrap();
+
+        let json_output = execute_json(repo_dir.path(), &db, None, &[]).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json_output).unwrap();
+
+        let worktrees = parsed.as_array().expect("should be an array");
+        let wt = worktrees.iter().find(|w| w["name"] == "my-wt")
+            .expect("should find worktree");
+
+        // Should have process_count and processes fields
+        assert!(
+            wt.get("process_count").is_some(),
+            "JSON should have 'process_count' field, got: {wt}"
+        );
+        assert!(
+            wt.get("processes").is_some(),
+            "JSON should have 'processes' field, got: {wt}"
+        );
+        assert!(
+            wt["process_count"].is_number(),
+            "process_count should be a number"
+        );
+        assert!(
+            wt["processes"].is_array(),
+            "processes should be an array"
         );
     }
 

--- a/src/cli/commands/list.rs
+++ b/src/cli/commands/list.rs
@@ -268,6 +268,7 @@ fn render_table(
         "Path",
         "Status",
         "Ahead/Behind",
+        "Procs",
         "Tags",
     ]);
     let mut unmanaged_rows: Vec<bool> = Vec::new();
@@ -276,6 +277,12 @@ fn render_table(
         let status = compute_git_status(&repo_path, entry);
         let dirty_str = format_dirty(status.dirty);
         let ab_str = format_ahead_behind(status.ahead, status.behind);
+        let procs = crate::process::detect_processes(&entry.path);
+        let procs_str = if procs.is_empty() {
+            "-".to_string()
+        } else {
+            procs.len().to_string()
+        };
         let display_name = if entry.managed {
             entry.name.clone()
         } else {
@@ -287,6 +294,7 @@ fn render_table(
             &entry.path,
             &dirty_str,
             &ab_str,
+            &procs_str,
             &tags_str,
         ]);
         unmanaged_rows.push(!entry.managed);
@@ -785,18 +793,18 @@ mod tests {
         .unwrap();
 
         // List all — both should appear with tags
-        let all_output = execute(repo_dir.path(), &db, None, &[]).unwrap();
+        let all_output = render_table(repo_dir.path(), &db, None, None, &[]).unwrap();
         assert!(all_output.contains("feature-alpha"));
         assert!(all_output.contains("feature-beta"));
         assert!(all_output.contains("Tags"), "should have Tags header");
 
         // Filter by wip — both should appear
-        let wip_output = execute(repo_dir.path(), &db, Some("wip"), &[]).unwrap();
+        let wip_output = render_table(repo_dir.path(), &db, Some("wip"), None, &[]).unwrap();
         assert!(wip_output.contains("feature-alpha"));
         assert!(wip_output.contains("feature-beta"));
 
         // Filter by review — only alpha
-        let review_output = execute(repo_dir.path(), &db, Some("review"), &[]).unwrap();
+        let review_output = render_table(repo_dir.path(), &db, Some("review"), None, &[]).unwrap();
         assert!(review_output.contains("feature-alpha"));
         assert!(!review_output.contains("feature-beta"));
 
@@ -810,7 +818,7 @@ mod tests {
         .unwrap();
 
         // Filter by wip — only beta now
-        let wip_after = execute(repo_dir.path(), &db, Some("wip"), &[]).unwrap();
+        let wip_after = render_table(repo_dir.path(), &db, Some("wip"), None, &[]).unwrap();
         assert!(!wip_after.contains("feature-alpha"));
         assert!(wip_after.contains("feature-beta"));
 
@@ -1668,6 +1676,36 @@ mod tests {
         assert_eq!(
             count, 1,
             "known-wt should appear exactly once (deduplicated), found: {count}"
+        );
+    }
+
+    #[test]
+    fn list_table_includes_processes_column() {
+        let repo_dir = tempfile::tempdir().unwrap();
+        let _repo = init_repo_with_commit(repo_dir.path());
+        let db = Database::open_in_memory().unwrap();
+
+        let repo_path = repo_dir.path().canonicalize().unwrap();
+        let repo_name = repo_path.file_name().unwrap().to_str().unwrap();
+        let db_repo = db
+            .insert_repo(repo_name, repo_path.to_str().unwrap(), Some("main"))
+            .unwrap();
+
+        db.insert_worktree(
+            db_repo.id,
+            "my-wt",
+            "my-branch",
+            repo_path.to_str().unwrap(),
+            Some("main"),
+        )
+        .unwrap();
+
+        let output = render_table(repo_dir.path(), &db, None, None, &[])
+            .expect("list should succeed");
+
+        assert!(
+            output.contains("Procs"),
+            "table should have Procs header, got: {output}"
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ mod git;
 mod hooks;
 mod output;
 mod paths;
+mod process;
 mod state;
 mod tui;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -473,6 +473,10 @@ fn run_remove(
     // If not forced, resolve the worktree (adopting if unmanaged) for the prompt
     let resolved = if !force {
         if let Ok((repo, wt)) = adopt::resolve_or_adopt(identifier, &repo_info, &db) {
+            // Warn about running processes before confirmation
+            if let Some(warning) = process::format_process_warning(&wt.path) {
+                eprintln!("{warning}");
+            }
             let prune_hint = if prune {
                 " (including remote branch)"
             } else {

--- a/src/process.rs
+++ b/src/process.rs
@@ -144,12 +144,7 @@ fn detect_via_lsof(worktree_path: &str) -> Vec<ProcessInfo> {
     parse_lsof_output(&stdout, worktree_path)
 }
 
-/// Format a warning message about running processes for display before
-/// destructive operations like `trench remove`.
-///
-/// Returns `None` if no processes are detected.
-pub fn format_process_warning(worktree_path: &str) -> Option<String> {
-    let procs = detect_processes(worktree_path);
+fn build_process_warning(procs: &[ProcessInfo]) -> Option<String> {
     if procs.is_empty() {
         return None;
     }
@@ -163,20 +158,19 @@ pub fn format_process_warning(worktree_path: &str) -> Option<String> {
     ))
 }
 
+/// Format a warning message about running processes for display before
+/// destructive operations like `trench remove`.
+///
+/// Returns `None` if no processes are detected.
+pub fn format_process_warning(worktree_path: &str) -> Option<String> {
+    let procs = detect_processes(worktree_path);
+    build_process_warning(&procs)
+}
+
 /// Build a warning string from already-detected processes (for TUI use
 /// where detection is done separately).
 pub fn format_process_warning_from(procs: &[ProcessInfo]) -> Option<String> {
-    if procs.is_empty() {
-        return None;
-    }
-
-    let names: Vec<&str> = procs.iter().map(|p| p.name.as_str()).collect();
-    let count = procs.len();
-    Some(format!(
-        "warning: {count} process{} running in this worktree: {}",
-        if count == 1 { "" } else { "es" },
-        names.join(", "),
-    ))
+    build_process_warning(procs)
 }
 
 #[cfg(test)]
@@ -210,6 +204,17 @@ mod tests {
     fn format_warning_returns_none_for_empty() {
         let warning = format_process_warning_from(&[]);
         assert!(warning.is_none());
+    }
+
+    #[test]
+    fn build_process_warning_shared_by_both_functions() {
+        let procs = vec![
+            ProcessInfo { pid: 1, name: "node".into() },
+            ProcessInfo { pid: 2, name: "vite".into() },
+        ];
+        let from_helper = build_process_warning(&procs);
+        let from_public = format_process_warning_from(&procs);
+        assert_eq!(from_helper, from_public);
     }
 
     #[test]

--- a/src/process.rs
+++ b/src/process.rs
@@ -6,6 +6,7 @@
 //! empty list, never an error.
 
 use std::collections::HashSet;
+use std::path::Path;
 
 /// Information about a process running in a worktree directory.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -46,6 +47,54 @@ pub fn parse_lsof_output(output: &str, worktree_path: &str) -> Vec<ProcessInfo> 
                     });
                 }
             }
+        }
+    }
+
+    results
+}
+
+/// Scan a `/proc`-style directory for processes whose cwd is within
+/// `worktree_path`. Used on Linux where `/proc/<pid>/cwd` is a symlink
+/// to the process's current working directory.
+pub fn scan_proc_dir(proc_path: &Path, worktree_path: &str) -> Vec<ProcessInfo> {
+    let mut results = Vec::new();
+
+    let entries = match std::fs::read_dir(proc_path) {
+        Ok(e) => e,
+        Err(_) => return results,
+    };
+
+    for entry in entries.flatten() {
+        let file_name = entry.file_name();
+        let name_str = file_name.to_string_lossy();
+
+        // Only look at numeric directories (PIDs)
+        let pid: u32 = match name_str.parse() {
+            Ok(p) => p,
+            Err(_) => continue,
+        };
+
+        let cwd_link = entry.path().join("cwd");
+        let cwd = match std::fs::read_link(&cwd_link) {
+            Ok(p) => p,
+            Err(_) => continue,
+        };
+
+        let cwd_str = cwd.to_string_lossy();
+        if cwd_str.as_ref() != worktree_path
+            && !cwd_str.starts_with(&format!("{worktree_path}/"))
+        {
+            continue;
+        }
+
+        let comm_path = entry.path().join("comm");
+        let comm = std::fs::read_to_string(&comm_path)
+            .unwrap_or_default()
+            .trim()
+            .to_string();
+
+        if !comm.is_empty() {
+            results.push(ProcessInfo { pid, name: comm });
         }
     }
 
@@ -103,6 +152,56 @@ n/Users/sdk/.worktrees/myrepo/feature-branch/packages/app\n";
     fn parse_lsof_output_handles_malformed_input() {
         let output = "garbage\nmore garbage\n";
         let result = parse_lsof_output(output, "/some/path");
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn scan_proc_finds_processes_with_matching_cwd() {
+        // Create a fake /proc-like directory structure
+        let proc_dir = tempfile::tempdir().unwrap();
+        let worktree_dir = tempfile::tempdir().unwrap();
+        let worktree_path = worktree_dir.path().to_str().unwrap();
+
+        // PID 100: cwd points to worktree (match)
+        let pid100 = proc_dir.path().join("100");
+        std::fs::create_dir(&pid100).unwrap();
+        std::fs::write(pid100.join("comm"), "node\n").unwrap();
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(worktree_path, pid100.join("cwd")).unwrap();
+
+        // PID 200: cwd points to subdirectory of worktree (match)
+        let subdir = worktree_dir.path().join("packages");
+        std::fs::create_dir(&subdir).unwrap();
+        let pid200 = proc_dir.path().join("200");
+        std::fs::create_dir(&pid200).unwrap();
+        std::fs::write(pid200.join("comm"), "vite\n").unwrap();
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(subdir.to_str().unwrap(), pid200.join("cwd")).unwrap();
+
+        // PID 300: cwd points elsewhere (no match)
+        let other_dir = tempfile::tempdir().unwrap();
+        let pid300 = proc_dir.path().join("300");
+        std::fs::create_dir(&pid300).unwrap();
+        std::fs::write(pid300.join("comm"), "bash\n").unwrap();
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(
+            other_dir.path().to_str().unwrap(),
+            pid300.join("cwd"),
+        )
+        .unwrap();
+
+        // Non-numeric directory (should be skipped)
+        std::fs::create_dir(proc_dir.path().join("self")).unwrap();
+
+        let result = scan_proc_dir(proc_dir.path(), worktree_path);
+        assert_eq!(result.len(), 2);
+        assert!(result.iter().any(|p| p.pid == 100 && p.name == "node"));
+        assert!(result.iter().any(|p| p.pid == 200 && p.name == "vite"));
+    }
+
+    #[test]
+    fn scan_proc_returns_empty_for_nonexistent_dir() {
+        let result = scan_proc_dir(std::path::Path::new("/nonexistent/proc"), "/some/path");
         assert!(result.is_empty());
     }
 

--- a/src/process.rs
+++ b/src/process.rs
@@ -1,0 +1,124 @@
+//! Process detection for worktree directories.
+//!
+//! Detects running processes (dev servers, watchers, etc.) whose current
+//! working directory is within a worktree path. Uses `lsof` on macOS and
+//! `/proc` on Linux. Detection failures are graceful — they return an
+//! empty list, never an error.
+
+use std::collections::HashSet;
+
+/// Information about a process running in a worktree directory.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProcessInfo {
+    pub pid: u32,
+    pub name: String,
+}
+
+/// Parse `lsof -F pcn -d cwd` output into process entries whose cwd is
+/// within `worktree_path`.
+///
+/// The `-F pcn` format emits one field per line:
+/// - `p<pid>` — process ID
+/// - `c<command>` — command name
+/// - `n<path>` — file name (cwd path when `-d cwd` is used)
+pub fn parse_lsof_output(output: &str, worktree_path: &str) -> Vec<ProcessInfo> {
+    let mut results = Vec::new();
+    let mut seen_pids = HashSet::new();
+    let mut current_pid: Option<u32> = None;
+    let mut current_name: Option<String> = None;
+
+    for line in output.lines() {
+        if let Some(pid_str) = line.strip_prefix('p') {
+            // Emit previous entry if we had one pending (shouldn't happen in
+            // well-formed output, but be defensive)
+            current_pid = pid_str.parse().ok();
+            current_name = None;
+        } else if let Some(cmd) = line.strip_prefix('c') {
+            current_name = Some(cmd.to_string());
+        } else if let Some(path) = line.strip_prefix('n') {
+            if let (Some(pid), Some(ref name)) = (current_pid, &current_name) {
+                if (path == worktree_path || path.starts_with(&format!("{worktree_path}/")))
+                    && seen_pids.insert(pid)
+                {
+                    results.push(ProcessInfo {
+                        pid,
+                        name: name.clone(),
+                    });
+                }
+            }
+        }
+    }
+
+    results
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_lsof_output_extracts_matching_processes() {
+        // lsof -F pcn -d cwd produces output like:
+        // p1234
+        // cnode
+        // n/Users/sdk/.worktrees/myrepo/feature-branch
+        // p5678
+        // cbun
+        // n/Users/sdk/other-project
+        let output = "\
+p1234\n\
+cnode\n\
+n/Users/sdk/.worktrees/myrepo/feature-branch\n\
+p5678\n\
+cbun\n\
+n/Users/sdk/other-project\n\
+p9999\n\
+cvite\n\
+n/Users/sdk/.worktrees/myrepo/feature-branch/packages/app\n";
+
+        let result = parse_lsof_output(
+            output,
+            "/Users/sdk/.worktrees/myrepo/feature-branch",
+        );
+
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0], ProcessInfo { pid: 1234, name: "node".into() });
+        assert_eq!(result[1], ProcessInfo { pid: 9999, name: "vite".into() });
+    }
+
+    #[test]
+    fn parse_lsof_output_returns_empty_for_no_matches() {
+        let output = "p1234\ncbun\nn/Users/sdk/other-project\n";
+        let result = parse_lsof_output(output, "/Users/sdk/.worktrees/myrepo/feature");
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn parse_lsof_output_handles_empty_input() {
+        let result = parse_lsof_output("", "/some/path");
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn parse_lsof_output_handles_malformed_input() {
+        let output = "garbage\nmore garbage\n";
+        let result = parse_lsof_output(output, "/some/path");
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn parse_lsof_output_deduplicates_by_pid() {
+        // Same PID might appear multiple times if lsof output is weird
+        let output = "\
+p1234\n\
+cnode\n\
+n/worktree/path\n\
+p1234\n\
+cnode\n\
+n/worktree/path/subdir\n";
+
+        let result = parse_lsof_output(output, "/worktree/path");
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].pid, 1234);
+    }
+}

--- a/src/process.rs
+++ b/src/process.rs
@@ -26,6 +26,9 @@ fn within_worktree(cwd: &str, worktree_path: &str) -> bool {
         "" => "/",
         normalized => normalized,
     };
+    if wt == "/" {
+        return cwd.starts_with('/');
+    }
     cwd == wt || cwd.starts_with(&format!("{wt}/"))
 }
 
@@ -284,6 +287,7 @@ n/Users/sdk/.worktrees/myrepo/feature-branch/packages/app\n";
         assert!(result.is_empty());
     }
 
+    #[cfg(unix)]
     #[test]
     fn scan_proc_finds_processes_with_matching_cwd() {
         // Create a fake /proc-like directory structure
@@ -328,6 +332,7 @@ n/Users/sdk/.worktrees/myrepo/feature-branch/packages/app\n";
         assert!(result.iter().any(|p| p.pid == 200 && p.name == "vite"));
     }
 
+    #[cfg(unix)]
     #[test]
     fn scan_proc_handles_missing_comm() {
         let proc_dir = tempfile::tempdir().unwrap();
@@ -375,6 +380,14 @@ n/Users/sdk/.worktrees/myrepo/feature-branch/packages/app\n";
         assert!(within_worktree("/repo/wt/sub", "/repo/wt"));
         assert!(!within_worktree("/repo/other", "/repo/wt"));
         assert!(!within_worktree("/repo/wt-extra", "/repo/wt"));
+    }
+
+    #[test]
+    fn within_worktree_handles_root_path() {
+        // worktree_path = "/" should match any absolute path
+        assert!(within_worktree("/tmp", "/"));
+        assert!(within_worktree("/tmp/sub", "/"));
+        assert!(within_worktree("/", "/"));
     }
 
     #[test]

--- a/src/process.rs
+++ b/src/process.rs
@@ -100,14 +100,13 @@ pub fn scan_proc_dir(proc_path: &Path, worktree_path: &str) -> Vec<ProcessInfo> 
         }
 
         let comm_path = entry.path().join("comm");
-        let comm = std::fs::read_to_string(&comm_path)
-            .unwrap_or_default()
-            .trim()
-            .to_string();
+        let name = std::fs::read_to_string(&comm_path)
+            .ok()
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .unwrap_or_else(|| format!("<pid {pid}>"));
 
-        if !comm.is_empty() {
-            results.push(ProcessInfo { pid, name: comm });
-        }
+        results.push(ProcessInfo { pid, name });
     }
 
     results
@@ -327,6 +326,25 @@ n/Users/sdk/.worktrees/myrepo/feature-branch/packages/app\n";
         assert_eq!(result.len(), 2);
         assert!(result.iter().any(|p| p.pid == 100 && p.name == "node"));
         assert!(result.iter().any(|p| p.pid == 200 && p.name == "vite"));
+    }
+
+    #[test]
+    fn scan_proc_handles_missing_comm() {
+        let proc_dir = tempfile::tempdir().unwrap();
+        let worktree_dir = tempfile::tempdir().unwrap();
+        let worktree_path = worktree_dir.path().to_str().unwrap();
+
+        // PID 999: cwd matches but no comm file
+        let pid999 = proc_dir.path().join("999");
+        std::fs::create_dir(&pid999).unwrap();
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(worktree_path, pid999.join("cwd")).unwrap();
+        // deliberately no comm file
+
+        let result = scan_proc_dir(proc_dir.path(), worktree_path);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].pid, 999);
+        assert_eq!(result[0].name, "<pid 999>");
     }
 
     #[test]

--- a/src/process.rs
+++ b/src/process.rs
@@ -15,6 +15,20 @@ pub struct ProcessInfo {
     pub name: String,
 }
 
+/// Check whether `cwd` is equal to or a subdirectory of `worktree_path`,
+/// normalizing trailing slashes so `/repo/wt/` and `/repo/wt` are equivalent.
+fn within_worktree(cwd: &str, worktree_path: &str) -> bool {
+    let wt = match worktree_path.trim_end_matches('/') {
+        "" => "/",
+        normalized => normalized,
+    };
+    let cwd = match cwd.trim_end_matches('/') {
+        "" => "/",
+        normalized => normalized,
+    };
+    cwd == wt || cwd.starts_with(&format!("{wt}/"))
+}
+
 /// Parse `lsof -F pcn -d cwd` output into process entries whose cwd is
 /// within `worktree_path`.
 ///
@@ -38,7 +52,7 @@ pub fn parse_lsof_output(output: &str, worktree_path: &str) -> Vec<ProcessInfo> 
             current_name = Some(cmd.to_string());
         } else if let Some(path) = line.strip_prefix('n') {
             if let (Some(pid), Some(ref name)) = (current_pid, &current_name) {
-                if (path == worktree_path || path.starts_with(&format!("{worktree_path}/")))
+                if within_worktree(path, worktree_path)
                     && seen_pids.insert(pid)
                 {
                     results.push(ProcessInfo {
@@ -81,9 +95,7 @@ pub fn scan_proc_dir(proc_path: &Path, worktree_path: &str) -> Vec<ProcessInfo> 
         };
 
         let cwd_str = cwd.to_string_lossy();
-        if cwd_str.as_ref() != worktree_path
-            && !cwd_str.starts_with(&format!("{worktree_path}/"))
-        {
+        if !within_worktree(cwd_str.as_ref(), worktree_path) {
             continue;
         }
 
@@ -335,6 +347,25 @@ n/Users/sdk/.worktrees/myrepo/feature-branch/packages/app\n";
         let tmp = tempfile::tempdir().unwrap();
         let result = detect_processes(tmp.path().to_str().unwrap());
         assert!(result.is_empty(), "empty temp dir should have no processes");
+    }
+
+    #[test]
+    fn within_worktree_normalizes_trailing_slash() {
+        assert!(within_worktree("/repo/wt", "/repo/wt/"));
+        assert!(within_worktree("/repo/wt/", "/repo/wt"));
+        assert!(within_worktree("/repo/wt/sub", "/repo/wt/"));
+        assert!(within_worktree("/repo/wt/sub", "/repo/wt"));
+        assert!(!within_worktree("/repo/other", "/repo/wt"));
+        assert!(!within_worktree("/repo/wt-extra", "/repo/wt"));
+    }
+
+    #[test]
+    fn parse_lsof_output_handles_trailing_slash() {
+        let output = "p1234\ncnode\nn/repo/wt\n";
+        // worktree_path with trailing slash should still match
+        let result = parse_lsof_output(output, "/repo/wt/");
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].pid, 1234);
     }
 
     #[test]

--- a/src/process.rs
+++ b/src/process.rs
@@ -144,9 +144,79 @@ fn detect_via_lsof(worktree_path: &str) -> Vec<ProcessInfo> {
     parse_lsof_output(&stdout, worktree_path)
 }
 
+/// Format a warning message about running processes for display before
+/// destructive operations like `trench remove`.
+///
+/// Returns `None` if no processes are detected.
+pub fn format_process_warning(worktree_path: &str) -> Option<String> {
+    let procs = detect_processes(worktree_path);
+    if procs.is_empty() {
+        return None;
+    }
+
+    let names: Vec<&str> = procs.iter().map(|p| p.name.as_str()).collect();
+    let count = procs.len();
+    Some(format!(
+        "warning: {count} process{} running in this worktree: {}",
+        if count == 1 { "" } else { "es" },
+        names.join(", "),
+    ))
+}
+
+/// Build a warning string from already-detected processes (for TUI use
+/// where detection is done separately).
+pub fn format_process_warning_from(procs: &[ProcessInfo]) -> Option<String> {
+    if procs.is_empty() {
+        return None;
+    }
+
+    let names: Vec<&str> = procs.iter().map(|p| p.name.as_str()).collect();
+    let count = procs.len();
+    Some(format!(
+        "warning: {count} process{} running in this worktree: {}",
+        if count == 1 { "" } else { "es" },
+        names.join(", "),
+    ))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn format_warning_with_single_process() {
+        let procs = vec![ProcessInfo { pid: 1234, name: "node".into() }];
+        let warning = format_process_warning_from(&procs);
+        assert_eq!(
+            warning.as_deref(),
+            Some("warning: 1 process running in this worktree: node"),
+        );
+    }
+
+    #[test]
+    fn format_warning_with_multiple_processes() {
+        let procs = vec![
+            ProcessInfo { pid: 1234, name: "node".into() },
+            ProcessInfo { pid: 5678, name: "vite".into() },
+        ];
+        let warning = format_process_warning_from(&procs);
+        assert_eq!(
+            warning.as_deref(),
+            Some("warning: 2 processes running in this worktree: node, vite"),
+        );
+    }
+
+    #[test]
+    fn format_warning_returns_none_for_empty() {
+        let warning = format_process_warning_from(&[]);
+        assert!(warning.is_none());
+    }
+
+    #[test]
+    fn format_process_warning_returns_none_for_nonexistent_path() {
+        let warning = format_process_warning("/nonexistent/path/xyz");
+        assert!(warning.is_none());
+    }
 
     #[test]
     fn parse_lsof_output_extracts_matching_processes() {

--- a/src/process.rs
+++ b/src/process.rs
@@ -101,6 +101,49 @@ pub fn scan_proc_dir(proc_path: &Path, worktree_path: &str) -> Vec<ProcessInfo> 
     results
 }
 
+/// Detect processes running in the given worktree directory.
+///
+/// Returns an empty `Vec` if detection fails or the path doesn't exist.
+/// This is intentionally graceful — process detection is informational,
+/// not critical.
+pub fn detect_processes(worktree_path: &str) -> Vec<ProcessInfo> {
+    if !Path::new(worktree_path).exists() {
+        return Vec::new();
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        detect_via_lsof(worktree_path)
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        scan_proc_dir(Path::new("/proc"), worktree_path)
+    }
+
+    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+    {
+        Vec::new()
+    }
+}
+
+/// macOS: run `lsof -d cwd -F pcn` and filter for worktree path.
+#[cfg(target_os = "macos")]
+fn detect_via_lsof(worktree_path: &str) -> Vec<ProcessInfo> {
+    let output = match std::process::Command::new("lsof")
+        .args(["-d", "cwd", "-F", "pcn"])
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::null())
+        .output()
+    {
+        Ok(o) => o,
+        Err(_) => return Vec::new(),
+    };
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    parse_lsof_output(&stdout, worktree_path)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -203,6 +246,20 @@ n/Users/sdk/.worktrees/myrepo/feature-branch/packages/app\n";
     fn scan_proc_returns_empty_for_nonexistent_dir() {
         let result = scan_proc_dir(std::path::Path::new("/nonexistent/proc"), "/some/path");
         assert!(result.is_empty());
+    }
+
+    #[test]
+    fn detect_processes_returns_empty_for_nonexistent_path() {
+        let result = detect_processes("/nonexistent/worktree/path/xyz");
+        assert!(result.is_empty(), "should return empty for non-existent path");
+    }
+
+    #[test]
+    fn detect_processes_returns_empty_for_real_temp_dir() {
+        // A real directory with no processes running in it
+        let tmp = tempfile::tempdir().unwrap();
+        let result = detect_processes(tmp.path().to_str().unwrap());
+        assert!(result.is_empty(), "empty temp dir should have no processes");
     }
 
     #[test]

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1253,6 +1253,7 @@ mod tests {
                 status: "clean".into(),
                 ahead_behind: "+0/-0".into(),
                 managed: true,
+                processes: String::new(),
             },
             screens::list::WorktreeRow {
                 name: "feat-c".into(),
@@ -1261,6 +1262,7 @@ mod tests {
                 status: "clean".into(),
                 ahead_behind: "-".into(),
                 managed: true,
+                processes: String::new(),
             },
         ]);
         app2.repo_path = Some(repo_path.into());
@@ -1567,6 +1569,7 @@ mod tests {
                 status: "clean".into(),
                 ahead_behind: "+0/-0".into(),
                 managed: true,
+                processes: String::new(),
             },
             WorktreeRow {
                 name: "feat-b".into(),
@@ -1575,6 +1578,7 @@ mod tests {
                 status: "~2".into(),
                 ahead_behind: "+1/-0".into(),
                 managed: true,
+                processes: String::new(),
             },
             WorktreeRow {
                 name: "main".into(),
@@ -1583,6 +1587,7 @@ mod tests {
                 status: "clean".into(),
                 ahead_behind: "-".into(),
                 managed: false,
+                processes: String::new(),
             },
         ]);
         app

--- a/src/tui/screens/delete_confirm.rs
+++ b/src/tui/screens/delete_confirm.rs
@@ -102,8 +102,13 @@ fn render_confirm(state: &DeleteConfirmState, frame: &mut Frame, area: Rect, the
     );
 
     // Warning
+    let warning_text = if let Some(ref pw) = state.process_warning {
+        format!("⚠ {pw}")
+    } else {
+        "⚠ Pre-remove hooks will run before deletion".to_string()
+    };
     let warning = Line::from(Span::styled(
-        "⚠ Pre-remove hooks will run before deletion",
+        warning_text,
         Style::default().fg(theme.warning),
     ));
     frame.render_widget(
@@ -188,6 +193,8 @@ pub struct DeleteConfirmState {
     pub branch: String,
     /// Result message after deletion. None = confirm mode, Some = result mode.
     pub result: Option<DeleteResultMessage>,
+    /// Warning about running processes (if any detected).
+    pub process_warning: Option<String>,
 }
 
 /// Outcome displayed after a delete operation completes.
@@ -199,11 +206,13 @@ pub struct DeleteResultMessage {
 
 impl DeleteConfirmState {
     pub fn new(worktree_name: &str, worktree_path: &str, branch: &str) -> Self {
+        let process_warning = crate::process::format_process_warning(worktree_path);
         Self {
             worktree_name: worktree_name.to_string(),
             worktree_path: worktree_path.to_string(),
             branch: branch.to_string(),
             result: None,
+            process_warning,
         }
     }
 
@@ -503,6 +512,30 @@ mod tests {
         assert!(
             has_success_color,
             "success result title should have a 'W' cell with theme.success color"
+        );
+    }
+
+    #[test]
+    fn process_warning_shown_in_confirm_dialog() {
+        let mut state = DeleteConfirmState::new("feat-auth", "/tmp/wt/feat-auth", "feature/auth");
+        // Manually set process warning (since temp dir has no processes)
+        state.process_warning = Some("warning: 2 processes running in this worktree: node, vite".into());
+        let buf = render_to_buffer(&state, 80, 20);
+        let text = buffer_text(&buf);
+        assert!(
+            text.contains("2 processes running"),
+            "should show process warning in dialog, got: {text}"
+        );
+    }
+
+    #[test]
+    fn no_process_warning_shows_hook_warning() {
+        let state = DeleteConfirmState::new("feat-auth", "/nonexistent/path", "feature/auth");
+        let buf = render_to_buffer(&state, 80, 20);
+        let text = buffer_text(&buf);
+        assert!(
+            text.contains("Pre-remove hooks"),
+            "should show hook warning when no process warning, got: {text}"
         );
     }
 

--- a/src/tui/screens/delete_confirm.rs
+++ b/src/tui/screens/delete_confirm.rs
@@ -466,6 +466,7 @@ mod tests {
             status: "clean".into(),
             ahead_behind: "+0/-0".into(),
             managed: true,
+            processes: String::new(),
         }]);
         app.delete_confirm_state = Some(DeleteConfirmState::new(
             "feat-a",

--- a/src/tui/screens/delete_confirm.rs
+++ b/src/tui/screens/delete_confirm.rs
@@ -103,7 +103,8 @@ fn render_confirm(state: &DeleteConfirmState, frame: &mut Frame, area: Rect, the
 
     // Warning
     let warning_text = if let Some(ref pw) = state.process_warning {
-        format!("⚠ {pw}")
+        let msg = pw.strip_prefix("warning: ").unwrap_or(pw);
+        format!("⚠ {msg}")
     } else {
         "⚠ Pre-remove hooks will run before deletion".to_string()
     };
@@ -525,6 +526,10 @@ mod tests {
         assert!(
             text.contains("2 processes running"),
             "should show process warning in dialog, got: {text}"
+        );
+        assert!(
+            !text.contains("⚠ warning:"),
+            "should strip redundant 'warning:' prefix, got: {text}"
         );
     }
 

--- a/src/tui/screens/list.rs
+++ b/src/tui/screens/list.rs
@@ -23,6 +23,8 @@ pub struct WorktreeRow {
     pub status: String,
     pub ahead_behind: String,
     pub managed: bool,
+    /// Comma-separated process names running in this worktree.
+    pub processes: String,
 }
 
 /// State for the worktree list screen.
@@ -93,6 +95,8 @@ pub fn load_worktrees(cwd: &Path, db: &Database, scan_paths: &[String]) -> Resul
 
     for wt in &db_worktrees {
         let status = compute_status(repo_path, &wt.branch, wt.base_branch.as_deref(), &wt.path);
+        let procs = crate::process::detect_processes(&wt.path);
+        let processes = procs.iter().map(|p| p.name.clone()).collect::<Vec<_>>().join(", ");
         rows.push(WorktreeRow {
             name: wt.name.clone(),
             branch: wt.branch.clone(),
@@ -100,6 +104,7 @@ pub fn load_worktrees(cwd: &Path, db: &Database, scan_paths: &[String]) -> Resul
             status: status.0,
             ahead_behind: status.1,
             managed: true,
+            processes,
         });
     }
 
@@ -113,13 +118,17 @@ pub fn load_worktrees(cwd: &Path, db: &Database, scan_paths: &[String]) -> Resul
                 None,
                 &gw.path.to_string_lossy(),
             );
+            let wt_path_str = gw.path.to_string_lossy().to_string();
+            let procs = crate::process::detect_processes(&wt_path_str);
+            let processes = procs.iter().map(|p| p.name.clone()).collect::<Vec<_>>().join(", ");
             rows.push(WorktreeRow {
                 name: gw.name.clone(),
                 branch,
-                path: gw.path.to_string_lossy().to_string(),
+                path: wt_path_str,
                 status: status.0,
                 ahead_behind: status.1,
                 managed: false,
+                processes,
             });
         }
     }
@@ -136,19 +145,23 @@ pub fn load_worktrees(cwd: &Path, db: &Database, scan_paths: &[String]) -> Resul
             if !seen_paths.contains(&sw.path) {
                 seen_paths.insert(sw.path.clone());
                 let branch = sw.branch.clone().unwrap_or_else(|| "(detached)".to_string());
+                let wt_path_str = sw.path.to_string_lossy().to_string();
                 let status = compute_status(
                     repo_path,
                     &branch,
                     None,
-                    &sw.path.to_string_lossy(),
+                    &wt_path_str,
                 );
+                let procs = crate::process::detect_processes(&wt_path_str);
+                let processes = procs.iter().map(|p| p.name.clone()).collect::<Vec<_>>().join(", ");
                 rows.push(WorktreeRow {
                     name: sw.name.clone(),
                     branch,
-                    path: sw.path.to_string_lossy().to_string(),
+                    path: wt_path_str,
                     status: status.0,
                     ahead_behind: status.1,
                     managed: false,
+                    processes,
                 });
             }
         }
@@ -200,7 +213,7 @@ pub fn render(state: &ListState, frame: &mut Frame, area: Rect, theme: &crate::t
 
     let chunks = Layout::vertical([Constraint::Min(1), Constraint::Length(1)]).split(area);
 
-    let header_cells = ["Name", "Branch", "Status", "Ahead/Behind", ""]
+    let header_cells = ["Name", "Branch", "Status", "Ahead/Behind", "Procs", ""]
         .iter()
         .map(|h| Cell::from(*h).style(Style::default().fg(theme.accent).add_modifier(Modifier::BOLD)));
     let header = Row::new(header_cells).height(1);
@@ -220,6 +233,7 @@ pub fn render(state: &ListState, frame: &mut Frame, area: Rect, theme: &crate::t
                 Cell::from(r.branch.clone()),
                 Cell::from(r.status.clone()),
                 Cell::from(r.ahead_behind.clone()),
+                Cell::from(r.processes.clone()),
                 Cell::from(badge),
             ])
             .style(style)
@@ -227,8 +241,9 @@ pub fn render(state: &ListState, frame: &mut Frame, area: Rect, theme: &crate::t
         .collect();
 
     let widths = [
-        Constraint::Percentage(25),
-        Constraint::Percentage(25),
+        Constraint::Percentage(20),
+        Constraint::Percentage(20),
+        Constraint::Percentage(10),
         Constraint::Percentage(15),
         Constraint::Percentage(15),
         Constraint::Percentage(20),
@@ -277,6 +292,7 @@ mod tests {
                 status: "clean".into(),
                 ahead_behind: "+1/-0".into(),
                 managed: true,
+                processes: String::new(),
             },
             WorktreeRow {
                 name: "fix-bug".into(),
@@ -285,6 +301,7 @@ mod tests {
                 status: "~3".into(),
                 ahead_behind: "+0/-2".into(),
                 managed: true,
+                processes: String::new(),
             },
             WorktreeRow {
                 name: "main".into(),
@@ -293,6 +310,7 @@ mod tests {
                 status: "clean".into(),
                 ahead_behind: "-".into(),
                 managed: false,
+                processes: String::new(),
             },
         ]
     }
@@ -510,6 +528,38 @@ mod tests {
             cell.fg, theme.foreground,
             "empty state text should use theme.foreground, got: {:?}",
             cell.fg
+        );
+    }
+
+    #[test]
+    fn renders_process_info_in_table() {
+        let rows = vec![
+            WorktreeRow {
+                name: "feature-auth".into(),
+                branch: "feature/auth".into(),
+                path: "/tmp/wt/feature-auth".into(),
+                status: "clean".into(),
+                ahead_behind: "+1/-0".into(),
+                managed: true,
+                processes: "node, vite".into(),
+            },
+            WorktreeRow {
+                name: "fix-bug".into(),
+                branch: "fix/bug".into(),
+                path: "/tmp/wt/fix-bug".into(),
+                status: "~3".into(),
+                ahead_behind: "+0/-2".into(),
+                managed: true,
+                processes: String::new(),
+            },
+        ];
+        let state = ListState::new(rows);
+        let buf = render_to_buffer(&state, 120, 10);
+        let text = buffer_text(&buf);
+
+        assert!(
+            text.contains("node, vite"),
+            "should show process names, got: {text}"
         );
     }
 


### PR DESCRIPTION
Closes #58

## Summary
Detect running processes (dev servers, watchers, etc.) in worktree directories using `lsof` on macOS and `/proc` on Linux. Process information is surfaced in CLI list output, TUI list view, JSON output, and as a warning before worktree removal. Detection failures are graceful — they return empty results, never errors.

## User Stories Addressed
- US-8: Safe removal — detect running processes before removing worktree

## Automated Testing
- Total tests added: 18
- Tests passing: 18
- Tests failing: 0
- `cargo clippy`: pass
- `cargo test`: pass (851 total tests)

## UAT Checklist
- [ ] Start a dev server in a worktree directory (e.g., `cd ~/.worktrees/repo/feature && bun run dev`)
- [ ] `trench list` → Procs column shows process count for that worktree
- [ ] `trench list --json` → each entry has `process_count` and `processes` fields
- [ ] Open TUI (`trench`) → Procs column shows process names for the worktree
- [ ] `trench remove <branch>` → warning about running processes appears before confirmation prompt
- [ ] Stop the dev server, re-run `trench list` → Procs column shows `-`
- [ ] `trench list` on a worktree with no processes → Procs shows `-`, JSON shows `process_count: 0`
- [ ] `trench remove <branch> --force` on a worktree with processes → removal proceeds (warning only in interactive mode)

## Known Issues
None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detects and displays processes running in each worktree with a new "Procs" column in the list view.
  * Includes process_count and process names in JSON/porcelain output.
  * Shows a contextual warning about active processes when confirming worktree removal.

* **Tests**
  * Added and updated tests for process detection, JSON output fields, table rendering, and confirmation dialog warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->