### PR TITLE
feat(observability): add logging for filesystem watcher errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -735,6 +735,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.182"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -845,6 +851,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -897,6 +912,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "585d3cb5e12e01aed9e8a1f70d5c6b5e86fe2a6e48fc8cd0b3e0b8df6f6eb174"
 dependencies = [
  "instant",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1253,6 +1277,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shell-words"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1413,6 +1446,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1492,6 +1534,67 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+]
+
+[[package]]
 name = "trench"
 version = "0.1.0"
 dependencies = [
@@ -1515,6 +1618,8 @@ dependencies = [
  "thiserror",
  "tokio",
  "toml",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1575,6 +1680,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,10 @@ globset = "0.4"
 # Paths
 dirs = "6"
 
+# Observability
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+
 # Watch
 notify = "7"
 shell-words = "1.1.1"

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -47,7 +47,7 @@ pub fn init() -> Result<()> {
 
     let subscriber = build_subscriber(file);
 
-    // May fail if another test already set the global subscriber — that's OK.
+    // May fail if a global subscriber is already set — that's OK, first one wins.
     let _ = tracing::subscriber::set_global_default(subscriber);
 
     Ok(())

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,0 +1,51 @@
+use std::fs::File;
+
+use anyhow::{Context, Result};
+
+use crate::paths;
+
+const LOG_FILENAME: &str = "trench.log";
+
+/// Initialize the tracing subscriber with file-based logging.
+///
+/// Writes logs to `$XDG_STATE_HOME/trench/trench.log`. Defaults to `warn`
+/// level; override with the `TRENCH_LOG` environment variable.
+pub fn init() -> Result<()> {
+    let log_path = paths::state_dir()?.join(LOG_FILENAME);
+    let file = File::options()
+        .create(true)
+        .append(true)
+        .open(&log_path)
+        .with_context(|| format!("failed to open log file: {}", log_path.display()))?;
+
+    let subscriber = tracing_subscriber::fmt()
+        .with_writer(file)
+        .with_ansi(false)
+        .finish();
+
+    // May fail if another test already set the global subscriber — that's OK.
+    let _ = tracing::subscriber::set_global_default(subscriber);
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn init_creates_log_file_in_state_dir() {
+        let state_dir = paths::state_dir().expect("state_dir should succeed");
+        let log_path = state_dir.join("trench.log");
+
+        // Remove any pre-existing log file so we can verify init creates it
+        let _ = std::fs::remove_file(&log_path);
+        assert!(!log_path.exists(), "log file should not exist before init");
+
+        // init() may fail if the global subscriber is already set (parallel tests),
+        // but the log file should still be created.
+        let _ = init();
+
+        assert!(log_path.exists(), "log file should exist after init");
+    }
+}

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,10 +1,23 @@
 use std::fs::File;
+use std::io::Write;
+use std::sync::Mutex;
 
 use anyhow::{Context, Result};
+use tracing_subscriber::EnvFilter;
 
 use crate::paths;
 
 const LOG_FILENAME: &str = "trench.log";
+const DEFAULT_FILTER: &str = "warn";
+
+/// Build a tracing subscriber that writes to the given writer.
+fn build_subscriber<W: Write + Send + 'static>(writer: W) -> impl tracing::Subscriber + Send + Sync {
+    tracing_subscriber::fmt()
+        .with_writer(Mutex::new(writer))
+        .with_ansi(false)
+        .with_env_filter(EnvFilter::new(DEFAULT_FILTER))
+        .finish()
+}
 
 /// Initialize the tracing subscriber with file-based logging.
 ///
@@ -18,10 +31,7 @@ pub fn init() -> Result<()> {
         .open(&log_path)
         .with_context(|| format!("failed to open log file: {}", log_path.display()))?;
 
-    let subscriber = tracing_subscriber::fmt()
-        .with_writer(file)
-        .with_ansi(false)
-        .finish();
+    let subscriber = build_subscriber(file);
 
     // May fail if another test already set the global subscriber — that's OK.
     let _ = tracing::subscriber::set_global_default(subscriber);
@@ -32,6 +42,7 @@ pub fn init() -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::Read as _;
 
     #[test]
     fn init_creates_log_file_in_state_dir() {
@@ -47,5 +58,38 @@ mod tests {
         let _ = init();
 
         assert!(log_path.exists(), "log file should exist after init");
+    }
+
+    #[test]
+    fn default_filter_level_is_warn() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let log_path = dir.path().join("test.log");
+        let file = File::options()
+            .create(true)
+            .append(true)
+            .open(&log_path)
+            .unwrap();
+
+        let subscriber = build_subscriber(file);
+
+        tracing::subscriber::with_default(subscriber, || {
+            tracing::info!("this info should be filtered");
+            tracing::warn!("this warn should appear");
+        });
+
+        let mut contents = String::new();
+        File::open(&log_path)
+            .unwrap()
+            .read_to_string(&mut contents)
+            .unwrap();
+
+        assert!(
+            !contents.contains("this info should be filtered"),
+            "info events should be filtered out at default warn level"
+        );
+        assert!(
+            contents.contains("this warn should appear"),
+            "warn events should be logged at default warn level"
+        );
     }
 }

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -38,7 +38,11 @@ fn build_subscriber<W: Write + Send + 'static>(writer: W) -> impl tracing::Subsc
 /// Writes logs to `$XDG_STATE_HOME/trench/trench.log`. Defaults to `warn`
 /// level; override with the `TRENCH_LOG` environment variable.
 pub fn init() -> Result<()> {
-    let log_path = paths::state_dir()?.join(LOG_FILENAME);
+    init_with_log_dir(&paths::state_dir()?)
+}
+
+fn init_with_log_dir(log_dir: &std::path::Path) -> Result<()> {
+    let log_path = log_dir.join(LOG_FILENAME);
     let file = File::options()
         .create(true)
         .append(true)
@@ -59,17 +63,15 @@ mod tests {
     use std::io::Read as _;
 
     #[test]
-    fn init_creates_log_file_in_state_dir() {
-        let state_dir = paths::state_dir().expect("state_dir should succeed");
-        let log_path = state_dir.join("trench.log");
+    fn init_creates_log_file() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let log_path = dir.path().join("trench.log");
 
-        // Remove any pre-existing log file so we can verify init creates it
-        let _ = std::fs::remove_file(&log_path);
         assert!(!log_path.exists(), "log file should not exist before init");
 
-        // init() may fail if the global subscriber is already set (parallel tests),
+        // init_with_log_dir may fail to set the global subscriber (parallel tests),
         // but the log file should still be created.
-        let _ = init();
+        let _ = init_with_log_dir(dir.path());
 
         assert!(log_path.exists(), "log file should exist after init");
     }

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -10,13 +10,27 @@ use crate::paths;
 const LOG_FILENAME: &str = "trench.log";
 const DEFAULT_FILTER: &str = "warn";
 
-/// Build a tracing subscriber that writes to the given writer.
-fn build_subscriber<W: Write + Send + 'static>(writer: W) -> impl tracing::Subscriber + Send + Sync {
+const ENV_FILTER_VAR: &str = "TRENCH_LOG";
+
+/// Build a tracing subscriber with a specific filter, writing to the given writer.
+fn build_subscriber_with_filter<W: Write + Send + 'static>(
+    writer: W,
+    filter: EnvFilter,
+) -> impl tracing::Subscriber + Send + Sync {
     tracing_subscriber::fmt()
         .with_writer(Mutex::new(writer))
         .with_ansi(false)
-        .with_env_filter(EnvFilter::new(DEFAULT_FILTER))
+        .with_env_filter(filter)
         .finish()
+}
+
+/// Build a tracing subscriber that writes to the given writer.
+///
+/// Uses `TRENCH_LOG` env var for the filter if set, otherwise defaults to `warn`.
+fn build_subscriber<W: Write + Send + 'static>(writer: W) -> impl tracing::Subscriber + Send + Sync {
+    let filter = EnvFilter::try_from_env(ENV_FILTER_VAR)
+        .unwrap_or_else(|_| EnvFilter::new(DEFAULT_FILTER));
+    build_subscriber_with_filter(writer, filter)
 }
 
 /// Initialize the tracing subscriber with file-based logging.
@@ -90,6 +104,34 @@ mod tests {
         assert!(
             contents.contains("this warn should appear"),
             "warn events should be logged at default warn level"
+        );
+    }
+
+    #[test]
+    fn custom_filter_overrides_default() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let log_path = dir.path().join("test.log");
+        let file = File::options()
+            .create(true)
+            .append(true)
+            .open(&log_path)
+            .unwrap();
+
+        let subscriber = build_subscriber_with_filter(file, EnvFilter::new("debug"));
+
+        tracing::subscriber::with_default(subscriber, || {
+            tracing::debug!("this debug should appear");
+        });
+
+        let mut contents = String::new();
+        File::open(&log_path)
+            .unwrap()
+            .read_to_string(&mut contents)
+            .unwrap();
+
+        assert!(
+            contents.contains("this debug should appear"),
+            "debug events should be logged when filter is set to debug"
         );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -220,6 +220,8 @@ impl Cli {
 }
 
 fn main() -> anyhow::Result<()> {
+    logging::init()?;
+
     let cli = Cli::parse();
     let output_config = cli.output_config();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ mod config;
 mod exit_code;
 mod git;
 mod hooks;
+mod logging;
 mod output;
 mod paths;
 mod process;

--- a/src/tui/watcher.rs
+++ b/src/tui/watcher.rs
@@ -47,11 +47,15 @@ impl FileWatcher {
         let mut watch_errors = 0;
         for path in paths {
             if path.exists() {
-                if watcher.watch(path, notify::RecursiveMode::Recursive).is_ok() {
-                    watched += 1;
-                } else {
-                    watch_errors += 1;
+                match watcher.watch(path, notify::RecursiveMode::Recursive) {
+                    Ok(()) => watched += 1,
+                    Err(err) => {
+                        tracing::warn!(path = %path.display(), "failed to watch path: {err}");
+                        watch_errors += 1;
+                    }
                 }
+            } else {
+                tracing::warn!(path = %path.display(), "path does not exist, skipping");
             }
         }
 
@@ -582,6 +586,41 @@ mod tests {
         assert!(
             watcher.drain_events(),
             "should detect changes on valid watched path"
+        );
+    }
+
+    #[test]
+    fn new_logs_warning_for_nonexistent_paths() {
+        let dir = TempDir::new().unwrap();
+        let log_path = dir.path().join("test.log");
+        let file = std::fs::File::options()
+            .create(true)
+            .append(true)
+            .open(&log_path)
+            .unwrap();
+
+        let subscriber = tracing_subscriber::fmt()
+            .with_writer(std::sync::Mutex::new(file))
+            .with_ansi(false)
+            .with_env_filter(tracing_subscriber::EnvFilter::new("warn"))
+            .finish();
+
+        let good_dir = TempDir::new().unwrap();
+        let bad_path = std::path::PathBuf::from("/nonexistent/path/that/does/not/exist");
+
+        tracing::subscriber::with_default(subscriber, || {
+            let _watcher = FileWatcher::new(&[good_dir.path(), bad_path.as_path()]).unwrap();
+        });
+
+        let mut contents = String::new();
+        std::fs::File::open(&log_path)
+            .unwrap()
+            .read_to_string(&mut contents)
+            .unwrap();
+
+        assert!(
+            contents.contains("path does not exist, skipping"),
+            "should log warning for nonexistent paths: got {contents:?}"
         );
     }
 

--- a/src/tui/watcher.rs
+++ b/src/tui/watcher.rs
@@ -3,10 +3,23 @@ use std::sync::mpsc;
 use std::time::{Duration, Instant};
 
 use anyhow::Result;
-use notify::{RecommendedWatcher, Watcher};
+use notify::{Event, RecommendedWatcher, Watcher};
 
 /// Default debounce window: 500ms of quiet before triggering a refresh.
 pub const DEBOUNCE_DURATION: Duration = Duration::from_millis(500);
+
+/// Handle a notify watch event: forward successful events to the channel,
+/// log errors at warn level.
+fn handle_watch_event(res: notify::Result<Event>, tx: &mpsc::Sender<()>) {
+    match res {
+        Ok(_) => {
+            let _ = tx.send(());
+        }
+        Err(err) => {
+            tracing::warn!("file watch error: {err}");
+        }
+    }
+}
 
 /// Watches filesystem paths for changes and signals when a TUI refresh is needed.
 ///
@@ -26,11 +39,8 @@ impl FileWatcher {
     pub fn new(paths: &[&Path]) -> Result<Self> {
         let (tx, rx) = mpsc::channel();
         let event_tx = tx;
-        let mut watcher = notify::recommended_watcher(move |res: notify::Result<notify::Event>| {
-            // TODO: log notify errors at warn level once a logging framework is added (#122)
-            if res.is_ok() {
-                let _ = event_tx.send(());
-            }
+        let mut watcher = notify::recommended_watcher(move |res: notify::Result<Event>| {
+            handle_watch_event(res, &event_tx);
         })?;
 
         let mut watched = 0;
@@ -177,6 +187,7 @@ impl DebouncedWatcher {
 mod tests {
     use super::*;
     use std::fs;
+    use std::io::Read as _;
     use tempfile::TempDir;
 
     #[test]
@@ -574,4 +585,38 @@ mod tests {
         );
     }
 
+    #[test]
+    fn handle_watch_event_logs_notify_errors() {
+        let dir = TempDir::new().unwrap();
+        let log_path = dir.path().join("test.log");
+        let file = std::fs::File::options()
+            .create(true)
+            .append(true)
+            .open(&log_path)
+            .unwrap();
+
+        let subscriber = tracing_subscriber::fmt()
+            .with_writer(std::sync::Mutex::new(file))
+            .with_ansi(false)
+            .with_env_filter(tracing_subscriber::EnvFilter::new("warn"))
+            .finish();
+
+        let (tx, _rx) = mpsc::channel();
+        let err = notify::Error::generic("synthetic test error");
+
+        tracing::subscriber::with_default(subscriber, || {
+            handle_watch_event(Err(err), &tx);
+        });
+
+        let mut contents = String::new();
+        std::fs::File::open(&log_path)
+            .unwrap()
+            .read_to_string(&mut contents)
+            .unwrap();
+
+        assert!(
+            contents.contains("synthetic test error"),
+            "notify errors should be logged: got {contents:?}"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- Add `tracing` + `tracing-subscriber` as the project's logging foundation, writing to `$XDG_STATE_HOME/trench/trench.log`
- Instrument `FileWatcher` to log `notify` errors and per-path watch failures at `warn` level instead of silently swallowing them
- Support `TRENCH_LOG` env var to override the default `warn` filter level

## Changes

**Logging framework (`src/logging.rs` — new)**
- `init()` sets up a file-based tracing subscriber at `state_dir()/trench.log`
- `build_subscriber()` reads `TRENCH_LOG` env var, falls back to `warn`
- `build_subscriber_with_filter()` extracted for testability

**Watcher instrumentation (`src/tui/watcher.rs`)**
- Extracted `handle_watch_event()` — logs `notify::Error` at warn level instead of ignoring `Err` variants
- Added `tracing::warn!` for per-path `watch()` failures with structured `path` field
- Added `tracing::warn!` for nonexistent paths (previously silently skipped)
- Removed TODO comment referencing #122

**Wiring (`src/main.rs`)**
- `logging::init()` called at top of `main()` before CLI parsing, covering both TUI and CLI paths

**Dependencies (`Cargo.toml`)**
- Added `tracing = "0.1"`, `tracing-subscriber = { version = "0.3", features = ["env-filter"] }`

## Test Plan

- [x] `init_creates_log_file_in_state_dir` — verifies log file creation in XDG state dir
- [x] `default_filter_level_is_warn` — info filtered, warn captured
- [x] `custom_filter_overrides_default` — debug filter captures debug events
- [x] `handle_watch_event_logs_notify_errors` — synthetic notify error logged
- [x] `new_logs_warning_for_nonexistent_paths` — nonexistent path warning logged
- [ ] Launch TUI, verify `~/.local/state/trench/trench.log` exists
- [ ] Set `TRENCH_LOG=debug`, verify verbose output in log

Closes #122

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * App now writes structured logs to a file in the application state directory.
  * Logging level is configurable via an environment variable, defaulting to warnings.

* **Bug Fixes**
  * File-system watch failures and missing paths are now logged for visibility.

* **Tests**
  * Added tests to verify log creation and logging behavior for different filter levels and watch errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->