### PR TITLE
feat: tmux window spawning on switch

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -142,8 +142,20 @@ pub struct ResolvedConfig {
     pub ui: ResolvedUiConfig,
     pub git: ResolvedGitConfig,
     pub editor_command: Option<String>,
+    pub shell: ResolvedShellConfig,
     pub worktrees: ResolvedWorktreesConfig,
     pub hooks: Option<HooksConfig>,
+}
+
+#[derive(Debug, PartialEq)]
+pub struct ResolvedShellConfig {
+    pub tmux: bool,
+}
+
+impl Default for ResolvedShellConfig {
+    fn default() -> Self {
+        Self { tmux: false }
+    }
 }
 
 #[derive(Debug, PartialEq)]
@@ -227,6 +239,11 @@ pub fn resolve_config(
         .and_then(|e| e.command.clone())
         .or_else(|| g_editor.and_then(|e| e.command.clone()));
 
+    // Shell: project > global > defaults
+    let p_shell = project.and_then(|p| p.shell.as_ref());
+    let g_shell = global.shell.as_ref();
+    let defaults_shell = ResolvedShellConfig::default();
+
     // Hooks: project replaces global entirely (FR-2)
     let p_hooks = project.and_then(|p| p.hooks.as_ref());
     let hooks = p_hooks.or(global.hooks.as_ref()).cloned();
@@ -270,6 +287,12 @@ pub fn resolve_config(
                 .unwrap_or(defaults_git.fetch_on_open),
         },
         editor_command,
+        shell: ResolvedShellConfig {
+            tmux: p_shell
+                .and_then(|s| s.tmux)
+                .or_else(|| g_shell.and_then(|s| s.tmux))
+                .unwrap_or(defaults_shell.tmux),
+        },
         worktrees: ResolvedWorktreesConfig {
             root: cli
                 .and_then(|c| c.worktree_root.clone())
@@ -1228,6 +1251,42 @@ tmux = true
     fn shell_config_absent_by_default() {
         let config = GlobalConfig::default();
         assert!(config.shell.is_none());
+    }
+
+    #[test]
+    fn shell_tmux_defaults_to_false_in_resolved() {
+        let resolved = resolve_config(None, None, &GlobalConfig::default());
+        assert!(!resolved.shell.tmux, "shell.tmux should default to false");
+    }
+
+    #[test]
+    fn shell_tmux_enabled_via_global_config() {
+        let global = GlobalConfig {
+            shell: Some(ShellConfig {
+                tmux: Some(true),
+            }),
+            ..GlobalConfig::default()
+        };
+        let resolved = resolve_config(None, None, &global);
+        assert!(resolved.shell.tmux, "shell.tmux should be true when set in global");
+    }
+
+    #[test]
+    fn shell_tmux_project_overrides_global() {
+        let global = GlobalConfig {
+            shell: Some(ShellConfig {
+                tmux: Some(true),
+            }),
+            ..GlobalConfig::default()
+        };
+        let project = ProjectConfig {
+            shell: Some(ShellConfig {
+                tmux: Some(false),
+            }),
+            ..ProjectConfig::default()
+        };
+        let resolved = resolve_config(None, Some(&project), &global);
+        assert!(!resolved.shell.tmux, "project shell.tmux should override global");
     }
 
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -50,6 +50,7 @@ pub struct GlobalConfig {
     pub ui: Option<UiConfig>,
     pub git: Option<GitConfig>,
     pub editor: Option<EditorConfig>,
+    pub shell: Option<ShellConfig>,
     pub worktrees: Option<WorktreesConfig>,
     pub hooks: Option<HooksConfig>,
 }
@@ -60,6 +61,7 @@ pub struct ProjectConfig {
     pub ui: Option<UiConfig>,
     pub git: Option<GitConfig>,
     pub editor: Option<EditorConfig>,
+    pub shell: Option<ShellConfig>,
     pub worktrees: Option<WorktreesConfig>,
     pub hooks: Option<HooksConfig>,
 }
@@ -89,6 +91,11 @@ pub struct EditorConfig {
 pub struct WorktreesConfig {
     pub root: Option<String>,
     pub scan: Option<Vec<String>>,
+}
+
+#[derive(Debug, Default, Deserialize, PartialEq)]
+pub struct ShellConfig {
+    pub tmux: Option<bool>,
 }
 
 /// Read and parse an optional TOML config file.
@@ -1188,6 +1195,39 @@ command = "code"
     fn editor_config_none_when_not_set() {
         let resolved = resolve_config(None, None, &GlobalConfig::default());
         assert!(resolved.editor_command.is_none());
+    }
+
+    #[test]
+    fn shell_config_tmux_deserializes_from_global() {
+        let dir = TempDir::new().unwrap();
+        let path = write_config(
+            &dir,
+            r#"
+[shell]
+tmux = true
+"#,
+        );
+
+        let config = load_global_config_from(&path).unwrap();
+        let shell = config.shell.expect("shell section should be present");
+        assert_eq!(shell.tmux, Some(true));
+    }
+
+    #[test]
+    fn shell_config_tmux_deserializes_from_project() {
+        let toml_str = r#"
+[shell]
+tmux = true
+"#;
+        let config: ProjectConfig = toml::from_str(toml_str).unwrap();
+        let shell = config.shell.expect("shell section should be present");
+        assert_eq!(shell.tmux, Some(true));
+    }
+
+    #[test]
+    fn shell_config_absent_by_default() {
+        let config = GlobalConfig::default();
+        assert!(config.shell.is_none());
     }
 
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -591,12 +591,6 @@ fn run_switch(identifier: &str, print_path: bool, tmux_flag: bool) -> anyhow::Re
     let db_path = paths::data_dir()?.join("trench.db");
     let db = state::Database::open(&db_path)?;
 
-    // Load config for shell.tmux setting
-    let repo_info = git::discover_repo(&cwd)?;
-    let project_config = config::load_project_config(&repo_info.path)?;
-    let global_config = config::load_global_config()?;
-    let resolved = config::resolve_config(None, project_config.as_ref(), &global_config);
-
     match cli::commands::switch::execute(identifier, &cwd, &db) {
         Ok(result) => {
             // --print-path must always write to stdout (shell-init depends on it),
@@ -606,9 +600,22 @@ fn run_switch(identifier: &str, print_path: bool, tmux_flag: bool) -> anyhow::Re
                 return Ok(());
             }
 
+            // Defer config loading until after early-exit paths so that
+            // malformed config files don't break --print-path or --tmux.
+            let config_tmux = if tmux_flag {
+                false // --tmux overrides config; skip loading
+            } else {
+                let repo_info = git::discover_repo(&cwd)?;
+                let project_config = config::load_project_config(&repo_info.path)?;
+                let global_config = config::load_global_config()?;
+                let resolved =
+                    config::resolve_config(None, project_config.as_ref(), &global_config);
+                resolved.shell.tmux
+            };
+
             let action = tmux::resolve_switch_action(
                 tmux_flag,
-                resolved.shell.tmux,
+                config_tmux,
                 tmux::is_inside_tmux(),
                 &result.path,
                 &result.name,
@@ -630,10 +637,7 @@ fn run_switch(identifier: &str, print_path: bool, tmux_flag: bool) -> anyhow::Re
                             "warning: --tmux specified but not running inside a tmux session, falling back to default behavior"
                         );
                     }
-                    println!(
-                        "Switched to worktree '{}' at {}",
-                        result.name, result.path
-                    );
+                    println!("Switched to worktree '{}' at {}", result.name, result.path);
                 }
             }
             Ok(())
@@ -655,14 +659,10 @@ fn run_open(identifier: &str, tmux_flag: bool) -> anyhow::Result<()> {
     let db = state::Database::open(&db_path)?;
 
     let repo_info = git::discover_repo(&cwd)?;
-    let project_config = config::load_project_config(&repo_info.path)?;
-    let global_config = config::load_global_config()?;
-    let resolved = config::resolve_config(None, project_config.as_ref(), &global_config);
 
-    // When --tmux is passed, open a tmux window instead of the editor
-    let use_tmux = tmux_flag;
-
-    if use_tmux {
+    // When --tmux is passed, open a tmux window instead of the editor.
+    // Defer config loading so that malformed config files don't break --tmux.
+    if tmux_flag {
         // Resolve the worktree (and auto-adopt if needed)
         let (repo, wt) = crate::adopt::resolve_or_adopt(identifier, &repo_info, &db)?;
 
@@ -689,12 +689,21 @@ fn run_open(identifier: &str, tmux_flag: bool) -> anyhow::Result<()> {
                 eprintln!(
                     "warning: --tmux specified but not running inside a tmux session, falling back to $EDITOR"
                 );
+                // Load config only for the editor fallback path
+                let project_config = config::load_project_config(&repo_info.path)?;
+                let global_config = config::load_global_config()?;
+                let resolved =
+                    config::resolve_config(None, project_config.as_ref(), &global_config);
                 return run_open_editor(identifier, &cwd, &db, resolved.editor_command.as_deref());
             }
         }
         return Ok(());
     }
 
+    // Non-tmux path: load config for editor_command
+    let project_config = config::load_project_config(&repo_info.path)?;
+    let global_config = config::load_global_config()?;
+    let resolved = config::resolve_config(None, project_config.as_ref(), &global_config);
     run_open_editor(identifier, &cwd, &db, resolved.editor_command.as_deref())
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -96,6 +96,10 @@ enum Commands {
         /// Print only the worktree path (for shell integration)
         #[arg(long)]
         print_path: bool,
+
+        /// Open worktree in a new tmux window (requires running inside tmux)
+        #[arg(long)]
+        tmux: bool,
     },
     /// Manage tags on a worktree
     Tag {
@@ -249,7 +253,11 @@ fn main() -> anyhow::Result<()> {
             prune,
             no_hooks,
         }) => run_remove(&branch, force, prune, no_hooks, dry_run, json),
-        Some(Commands::Switch { branch, print_path }) => run_switch(&branch, print_path),
+        Some(Commands::Switch {
+            branch,
+            print_path,
+            tmux: tmux_flag,
+        }) => run_switch(&branch, print_path, tmux_flag),
         Some(Commands::Tag { branch, tags }) => run_tag(&branch, &tags),
         Some(Commands::Open { branch }) => run_open(&branch),
         Some(Commands::List { tag }) => run_list(tag.as_deref(), json, porcelain),
@@ -571,17 +579,52 @@ fn run_remove(
     }
 }
 
-fn run_switch(identifier: &str, print_path: bool) -> anyhow::Result<()> {
+fn run_switch(identifier: &str, print_path: bool, tmux_flag: bool) -> anyhow::Result<()> {
     let cwd = std::env::current_dir().context("failed to determine current directory")?;
     let db_path = paths::data_dir()?.join("trench.db");
     let db = state::Database::open(&db_path)?;
 
+    // Load config for shell.tmux setting
+    let repo_info = git::discover_repo(&cwd)?;
+    let project_config = config::load_project_config(&repo_info.path)?;
+    let global_config = config::load_global_config()?;
+    let resolved = config::resolve_config(None, project_config.as_ref(), &global_config);
+
     match cli::commands::switch::execute(identifier, &cwd, &db) {
         Ok(result) => {
-            if print_path {
-                println!("{}", result.path);
-            } else {
-                println!("Switched to worktree '{}' at {}", result.name, result.path);
+            let action = tmux::resolve_switch_action(
+                tmux_flag,
+                resolved.shell.tmux,
+                tmux::is_inside_tmux(),
+                &result.path,
+                &result.name,
+            );
+
+            match action {
+                tmux::SwitchAction::TmuxNewWindow(cmd) => {
+                    let status = std::process::Command::new(&cmd[0])
+                        .args(&cmd[1..])
+                        .status()
+                        .context("failed to execute tmux")?;
+                    if !status.success() {
+                        anyhow::bail!("tmux exited with status {}", status);
+                    }
+                }
+                tmux::SwitchAction::PrintPath { warn_not_in_tmux } => {
+                    if warn_not_in_tmux {
+                        eprintln!(
+                            "warning: --tmux specified but not running inside a tmux session, falling back to default behavior"
+                        );
+                    }
+                    if print_path {
+                        println!("{}", result.path);
+                    } else {
+                        println!(
+                            "Switched to worktree '{}' at {}",
+                            result.name, result.path
+                        );
+                    }
+                }
             }
             Ok(())
         }
@@ -1520,9 +1563,14 @@ mod tests {
         let cli = Cli::try_parse_from(["trench", "switch", "my-feature"])
             .expect("switch with branch should succeed");
         match cli.command {
-            Some(Commands::Switch { branch, print_path }) => {
+            Some(Commands::Switch {
+                branch,
+                print_path,
+                tmux,
+            }) => {
                 assert_eq!(branch, "my-feature");
                 assert!(!print_path);
+                assert!(!tmux);
             }
             _ => panic!("expected Commands::Switch"),
         }
@@ -1533,9 +1581,32 @@ mod tests {
         let cli = Cli::try_parse_from(["trench", "switch", "my-feature", "--print-path"])
             .expect("switch with --print-path should succeed");
         match cli.command {
-            Some(Commands::Switch { branch, print_path }) => {
+            Some(Commands::Switch {
+                branch,
+                print_path,
+                tmux,
+            }) => {
                 assert_eq!(branch, "my-feature");
                 assert!(print_path);
+                assert!(!tmux);
+            }
+            _ => panic!("expected Commands::Switch"),
+        }
+    }
+
+    #[test]
+    fn switch_subcommand_accepts_tmux_flag() {
+        let cli = Cli::try_parse_from(["trench", "switch", "my-feature", "--tmux"])
+            .expect("switch with --tmux should succeed");
+        match cli.command {
+            Some(Commands::Switch {
+                branch,
+                print_path,
+                tmux,
+            }) => {
+                assert_eq!(branch, "my-feature");
+                assert!(!print_path);
+                assert!(tmux);
             }
             _ => panic!("expected Commands::Switch"),
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -660,15 +660,24 @@ fn run_open(identifier: &str, tmux_flag: bool) -> anyhow::Result<()> {
 
     let repo_info = git::discover_repo(&cwd)?;
 
-    // When --tmux is passed, open a tmux window instead of the editor.
-    // Defer config loading so that malformed config files don't break --tmux.
-    if tmux_flag {
-        // Resolve the worktree (and auto-adopt if needed)
+    // Defer config loading: skip when --tmux is explicit (same as run_switch)
+    let config_tmux = if tmux_flag {
+        false // --tmux overrides config; skip loading
+    } else {
+        let project_config = config::load_project_config(&repo_info.path)?;
+        let global_config = config::load_global_config()?;
+        let resolved = config::resolve_config(None, project_config.as_ref(), &global_config);
+        resolved.shell.tmux
+    };
+
+    let use_tmux = tmux_flag || config_tmux;
+
+    if use_tmux {
         let (repo, wt) = crate::adopt::resolve_or_adopt(identifier, &repo_info, &db)?;
 
         let action = tmux::resolve_switch_action(
-            true, // force tmux
-            false,
+            tmux_flag,
+            config_tmux,
             tmux::is_inside_tmux(),
             &wt.path,
             &wt.name,
@@ -685,11 +694,13 @@ fn run_open(identifier: &str, tmux_flag: bool) -> anyhow::Result<()> {
                 }
                 cli::commands::open::record_open(&db, repo.id, wt.id)?;
             }
-            tmux::SwitchAction::PrintPath { .. } => {
-                eprintln!(
-                    "warning: --tmux specified but not running inside a tmux session, falling back to $EDITOR"
-                );
-                // Load config only for the editor fallback path
+            tmux::SwitchAction::PrintPath { warn_not_in_tmux } => {
+                if warn_not_in_tmux {
+                    eprintln!(
+                        "warning: --tmux specified but not running inside a tmux session, falling back to $EDITOR"
+                    );
+                }
+                // Fall back to editor — load config for editor_command
                 let project_config = config::load_project_config(&repo_info.path)?;
                 let global_config = config::load_global_config()?;
                 let resolved =
@@ -700,7 +711,7 @@ fn run_open(identifier: &str, tmux_flag: bool) -> anyhow::Result<()> {
         return Ok(());
     }
 
-    // Non-tmux path: load config for editor_command
+    // Non-tmux path: config already loaded above (config_tmux was false)
     let project_config = config::load_project_config(&repo_info.path)?;
     let global_config = config::load_global_config()?;
     let resolved = config::resolve_config(None, project_config.as_ref(), &global_config);

--- a/src/main.rs
+++ b/src/main.rs
@@ -114,6 +114,10 @@ enum Commands {
     Open {
         /// Branch name or sanitized name of the worktree
         branch: String,
+
+        /// Open worktree in a new tmux window instead of $EDITOR (requires running inside tmux)
+        #[arg(long)]
+        tmux: bool,
     },
     /// List all worktrees
     List {
@@ -259,7 +263,10 @@ fn main() -> anyhow::Result<()> {
             tmux: tmux_flag,
         }) => run_switch(&branch, print_path, tmux_flag),
         Some(Commands::Tag { branch, tags }) => run_tag(&branch, &tags),
-        Some(Commands::Open { branch }) => run_open(&branch),
+        Some(Commands::Open {
+            branch,
+            tmux: tmux_flag,
+        }) => run_open(&branch, tmux_flag),
         Some(Commands::List { tag }) => run_list(tag.as_deref(), json, porcelain),
         Some(Commands::Status { branch }) => run_status(
             branch.as_deref(),
@@ -639,7 +646,7 @@ fn run_switch(identifier: &str, print_path: bool, tmux_flag: bool) -> anyhow::Re
     }
 }
 
-fn run_open(identifier: &str) -> anyhow::Result<()> {
+fn run_open(identifier: &str, tmux_flag: bool) -> anyhow::Result<()> {
     let cwd = std::env::current_dir().context("failed to determine current directory")?;
     let db_path = paths::data_dir()?.join("trench.db");
     let db = state::Database::open(&db_path)?;
@@ -649,7 +656,62 @@ fn run_open(identifier: &str) -> anyhow::Result<()> {
     let global_config = config::load_global_config()?;
     let resolved = config::resolve_config(None, project_config.as_ref(), &global_config);
 
-    match cli::commands::open::resolve(identifier, &cwd, &db, resolved.editor_command.as_deref()) {
+    // When --tmux is passed, open a tmux window instead of the editor
+    let use_tmux = tmux_flag;
+
+    if use_tmux {
+        // Resolve the worktree without needing an editor
+        let (repo, wt) = {
+            let repo_path_str = repo_info
+                .path
+                .to_str()
+                .ok_or_else(|| anyhow::anyhow!("repo path is not valid UTF-8"))?;
+            let repo = db
+                .get_repo_by_path(repo_path_str)?
+                .ok_or_else(|| anyhow::anyhow!("repository not tracked by trench"))?;
+            let wt = crate::adopt::resolve_or_adopt(identifier, &repo_info, &db)?.1;
+            (repo, wt)
+        };
+
+        let action = tmux::resolve_switch_action(
+            true, // force tmux
+            false,
+            tmux::is_inside_tmux(),
+            &wt.path,
+            &wt.name,
+        );
+
+        match action {
+            tmux::SwitchAction::TmuxNewWindow(cmd) => {
+                let status = std::process::Command::new(&cmd[0])
+                    .args(&cmd[1..])
+                    .status()
+                    .context("failed to execute tmux")?;
+                if !status.success() {
+                    anyhow::bail!("tmux exited with status {}", status);
+                }
+                cli::commands::open::record_open(&db, repo.id, wt.id)?;
+            }
+            tmux::SwitchAction::PrintPath { .. } => {
+                eprintln!(
+                    "warning: --tmux specified but not running inside a tmux session, falling back to $EDITOR"
+                );
+                return run_open_editor(identifier, &cwd, &db, resolved.editor_command.as_deref());
+            }
+        }
+        return Ok(());
+    }
+
+    run_open_editor(identifier, &cwd, &db, resolved.editor_command.as_deref())
+}
+
+fn run_open_editor(
+    identifier: &str,
+    cwd: &std::path::Path,
+    db: &state::Database,
+    editor_command: Option<&str>,
+) -> anyhow::Result<()> {
+    match cli::commands::open::resolve(identifier, cwd, db, editor_command) {
         Ok(result) => {
             let parts = shell_words::split(&result.editor)
                 .with_context(|| format!("invalid editor command: '{}'", result.editor))?;
@@ -667,8 +729,7 @@ fn run_open(identifier: &str) -> anyhow::Result<()> {
                 ExitCode::GeneralError.exit();
             }
 
-            // Record DB side-effects only after a successful launch
-            cli::commands::open::record_open(&db, result.repo_id, result.wt_id)?;
+            cli::commands::open::record_open(db, result.repo_id, result.wt_id)?;
 
             Ok(())
         }
@@ -1349,8 +1410,22 @@ mod tests {
         let cli = Cli::try_parse_from(["trench", "open", "my-feature"])
             .expect("open with branch should succeed");
         match cli.command {
-            Some(Commands::Open { branch }) => {
+            Some(Commands::Open { branch, tmux }) => {
                 assert_eq!(branch, "my-feature");
+                assert!(!tmux);
+            }
+            _ => panic!("expected Commands::Open"),
+        }
+    }
+
+    #[test]
+    fn open_subcommand_accepts_tmux_flag() {
+        let cli = Cli::try_parse_from(["trench", "open", "my-feature", "--tmux"])
+            .expect("open with --tmux should succeed");
+        match cli.command {
+            Some(Commands::Open { branch, tmux }) => {
+                assert_eq!(branch, "my-feature");
+                assert!(tmux);
             }
             _ => panic!("expected Commands::Open"),
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -663,18 +663,8 @@ fn run_open(identifier: &str, tmux_flag: bool) -> anyhow::Result<()> {
     let use_tmux = tmux_flag;
 
     if use_tmux {
-        // Resolve the worktree without needing an editor
-        let (repo, wt) = {
-            let repo_path_str = repo_info
-                .path
-                .to_str()
-                .ok_or_else(|| anyhow::anyhow!("repo path is not valid UTF-8"))?;
-            let repo = db
-                .get_repo_by_path(repo_path_str)?
-                .ok_or_else(|| anyhow::anyhow!("repository not tracked by trench"))?;
-            let wt = crate::adopt::resolve_or_adopt(identifier, &repo_info, &db)?.1;
-            (repo, wt)
-        };
+        // Resolve the worktree (and auto-adopt if needed)
+        let (repo, wt) = crate::adopt::resolve_or_adopt(identifier, &repo_info, &db)?;
 
         let action = tmux::resolve_switch_action(
             true, // force tmux

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ mod output;
 mod paths;
 mod process;
 mod state;
+mod tmux;
 mod tui;
 
 use anyhow::Context;

--- a/src/main.rs
+++ b/src/main.rs
@@ -586,6 +586,24 @@ fn run_remove(
     }
 }
 
+/// Execute a tmux command, returning whether it succeeded.
+///
+/// Returns `Ok(true)` on success, `Ok(false)` if `tmux` was not found on PATH
+/// (caller should fall back), or `Err` for other failures.
+fn execute_tmux_command(cmd: &[String]) -> anyhow::Result<bool> {
+    match std::process::Command::new(&cmd[0])
+        .args(&cmd[1..])
+        .status()
+    {
+        Ok(status) if !status.success() => {
+            anyhow::bail!("tmux exited with status {}", status);
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(e) => Err(e).context("failed to execute tmux"),
+        Ok(_) => Ok(true),
+    }
+}
+
 fn run_switch(identifier: &str, print_path: bool, tmux_flag: bool) -> anyhow::Result<()> {
     let cwd = std::env::current_dir().context("failed to determine current directory")?;
     let db_path = paths::data_dir()?.join("trench.db");
@@ -623,22 +641,12 @@ fn run_switch(identifier: &str, print_path: bool, tmux_flag: bool) -> anyhow::Re
 
             match action {
                 tmux::TmuxAction::TmuxNewWindow(cmd) => {
-                    match std::process::Command::new(&cmd[0])
-                        .args(&cmd[1..])
-                        .status()
-                    {
-                        Ok(status) if !status.success() => {
-                            anyhow::bail!("tmux exited with status {}", status);
-                        }
-                        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-                            eprintln!("warning: tmux not found, falling back to default behavior");
-                            println!(
-                                "Switched to worktree '{}' at {}",
-                                result.name, result.path
-                            );
-                        }
-                        Err(e) => return Err(e).context("failed to execute tmux"),
-                        Ok(_) => {}
+                    if !execute_tmux_command(&cmd)? {
+                        eprintln!("warning: tmux not found, falling back to default behavior");
+                        println!(
+                            "Switched to worktree '{}' at {}",
+                            result.name, result.path
+                        );
                     }
                 }
                 tmux::TmuxAction::Fallback { warn_not_in_tmux } => {
@@ -696,28 +704,16 @@ fn run_open(identifier: &str, tmux_flag: bool) -> anyhow::Result<()> {
 
         match action {
             tmux::TmuxAction::TmuxNewWindow(cmd) => {
-                match std::process::Command::new(&cmd[0])
-                    .args(&cmd[1..])
-                    .status()
-                {
-                    Ok(status) if !status.success() => {
-                        anyhow::bail!("tmux exited with status {}", status);
-                    }
-                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-                        eprintln!(
-                            "warning: tmux not found, falling back to $EDITOR"
-                        );
-                        return run_open_editor(
-                            identifier,
-                            &cwd,
-                            &db,
-                            editor_command.as_deref(),
-                        );
-                    }
-                    Err(e) => return Err(e).context("failed to execute tmux"),
-                    Ok(_) => {
-                        cli::commands::open::record_open(&db, repo.id, wt.id)?;
-                    }
+                if execute_tmux_command(&cmd)? {
+                    cli::commands::open::record_open(&db, repo.id, wt.id)?;
+                } else {
+                    eprintln!("warning: tmux not found, falling back to $EDITOR");
+                    return run_open_editor(
+                        identifier,
+                        &cwd,
+                        &db,
+                        editor_command.as_deref(),
+                    );
                 }
             }
             tmux::TmuxAction::Fallback { warn_not_in_tmux } => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -599,6 +599,13 @@ fn run_switch(identifier: &str, print_path: bool, tmux_flag: bool) -> anyhow::Re
 
     match cli::commands::switch::execute(identifier, &cwd, &db) {
         Ok(result) => {
+            // --print-path must always write to stdout (shell-init depends on it),
+            // so short-circuit before any tmux resolution.
+            if print_path {
+                println!("{}", result.path);
+                return Ok(());
+            }
+
             let action = tmux::resolve_switch_action(
                 tmux_flag,
                 resolved.shell.tmux,
@@ -623,14 +630,10 @@ fn run_switch(identifier: &str, print_path: bool, tmux_flag: bool) -> anyhow::Re
                             "warning: --tmux specified but not running inside a tmux session, falling back to default behavior"
                         );
                     }
-                    if print_path {
-                        println!("{}", result.path);
-                    } else {
-                        println!(
-                            "Switched to worktree '{}' at {}",
-                            result.name, result.path
-                        );
-                    }
+                    println!(
+                        "Switched to worktree '{}' at {}",
+                        result.name, result.path
+                    );
                 }
             }
             Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -613,7 +613,7 @@ fn run_switch(identifier: &str, print_path: bool, tmux_flag: bool) -> anyhow::Re
                 resolved.shell.tmux
             };
 
-            let action = tmux::resolve_switch_action(
+            let action = tmux::resolve_tmux_action(
                 tmux_flag,
                 config_tmux,
                 tmux::is_inside_tmux(),
@@ -622,16 +622,26 @@ fn run_switch(identifier: &str, print_path: bool, tmux_flag: bool) -> anyhow::Re
             );
 
             match action {
-                tmux::SwitchAction::TmuxNewWindow(cmd) => {
-                    let status = std::process::Command::new(&cmd[0])
+                tmux::TmuxAction::TmuxNewWindow(cmd) => {
+                    match std::process::Command::new(&cmd[0])
                         .args(&cmd[1..])
                         .status()
-                        .context("failed to execute tmux")?;
-                    if !status.success() {
-                        anyhow::bail!("tmux exited with status {}", status);
+                    {
+                        Ok(status) if !status.success() => {
+                            anyhow::bail!("tmux exited with status {}", status);
+                        }
+                        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                            eprintln!("warning: tmux not found, falling back to default behavior");
+                            println!(
+                                "Switched to worktree '{}' at {}",
+                                result.name, result.path
+                            );
+                        }
+                        Err(e) => return Err(e).context("failed to execute tmux"),
+                        Ok(_) => {}
                     }
                 }
-                tmux::SwitchAction::PrintPath { warn_not_in_tmux } => {
+                tmux::TmuxAction::Fallback { warn_not_in_tmux } => {
                     if warn_not_in_tmux {
                         eprintln!(
                             "warning: --tmux specified but not running inside a tmux session, falling back to default behavior"
@@ -660,14 +670,15 @@ fn run_open(identifier: &str, tmux_flag: bool) -> anyhow::Result<()> {
 
     let repo_info = git::discover_repo(&cwd)?;
 
-    // Defer config loading: skip when --tmux is explicit (same as run_switch)
-    let config_tmux = if tmux_flag {
-        false // --tmux overrides config; skip loading
+    // Load config once. When --tmux is explicit, skip loading so malformed
+    // config files don't break --tmux (same as run_switch).
+    let (config_tmux, editor_command) = if tmux_flag {
+        (false, None) // --tmux overrides config; defer editor lookup to fallback
     } else {
         let project_config = config::load_project_config(&repo_info.path)?;
         let global_config = config::load_global_config()?;
         let resolved = config::resolve_config(None, project_config.as_ref(), &global_config);
-        resolved.shell.tmux
+        (resolved.shell.tmux, resolved.editor_command)
     };
 
     let use_tmux = tmux_flag || config_tmux;
@@ -675,7 +686,7 @@ fn run_open(identifier: &str, tmux_flag: bool) -> anyhow::Result<()> {
     if use_tmux {
         let (repo, wt) = crate::adopt::resolve_or_adopt(identifier, &repo_info, &db)?;
 
-        let action = tmux::resolve_switch_action(
+        let action = tmux::resolve_tmux_action(
             tmux_flag,
             config_tmux,
             tmux::is_inside_tmux(),
@@ -684,38 +695,44 @@ fn run_open(identifier: &str, tmux_flag: bool) -> anyhow::Result<()> {
         );
 
         match action {
-            tmux::SwitchAction::TmuxNewWindow(cmd) => {
-                let status = std::process::Command::new(&cmd[0])
+            tmux::TmuxAction::TmuxNewWindow(cmd) => {
+                match std::process::Command::new(&cmd[0])
                     .args(&cmd[1..])
                     .status()
-                    .context("failed to execute tmux")?;
-                if !status.success() {
-                    anyhow::bail!("tmux exited with status {}", status);
+                {
+                    Ok(status) if !status.success() => {
+                        anyhow::bail!("tmux exited with status {}", status);
+                    }
+                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                        eprintln!(
+                            "warning: tmux not found, falling back to $EDITOR"
+                        );
+                        return run_open_editor(
+                            identifier,
+                            &cwd,
+                            &db,
+                            editor_command.as_deref(),
+                        );
+                    }
+                    Err(e) => return Err(e).context("failed to execute tmux"),
+                    Ok(_) => {
+                        cli::commands::open::record_open(&db, repo.id, wt.id)?;
+                    }
                 }
-                cli::commands::open::record_open(&db, repo.id, wt.id)?;
             }
-            tmux::SwitchAction::PrintPath { warn_not_in_tmux } => {
+            tmux::TmuxAction::Fallback { warn_not_in_tmux } => {
                 if warn_not_in_tmux {
                     eprintln!(
                         "warning: --tmux specified but not running inside a tmux session, falling back to $EDITOR"
                     );
                 }
-                // Fall back to editor — load config for editor_command
-                let project_config = config::load_project_config(&repo_info.path)?;
-                let global_config = config::load_global_config()?;
-                let resolved =
-                    config::resolve_config(None, project_config.as_ref(), &global_config);
-                return run_open_editor(identifier, &cwd, &db, resolved.editor_command.as_deref());
+                return run_open_editor(identifier, &cwd, &db, editor_command.as_deref());
             }
         }
         return Ok(());
     }
 
-    // Non-tmux path: config already loaded above (config_tmux was false)
-    let project_config = config::load_project_config(&repo_info.path)?;
-    let global_config = config::load_global_config()?;
-    let resolved = config::resolve_config(None, project_config.as_ref(), &global_config);
-    run_open_editor(identifier, &cwd, &db, resolved.editor_command.as_deref())
+    run_open_editor(identifier, &cwd, &db, editor_command.as_deref())
 }
 
 fn run_open_editor(

--- a/src/main.rs
+++ b/src/main.rs
@@ -1701,6 +1701,25 @@ mod tests {
     }
 
     #[test]
+    fn switch_subcommand_print_path_and_tmux_both_parse() {
+        let cli =
+            Cli::try_parse_from(["trench", "switch", "my-feature", "--print-path", "--tmux"])
+                .expect("switch with --print-path and --tmux should succeed");
+        match cli.command {
+            Some(Commands::Switch {
+                branch,
+                print_path,
+                tmux,
+            }) => {
+                assert_eq!(branch, "my-feature");
+                assert!(print_path, "--print-path should be true");
+                assert!(tmux, "--tmux should be true");
+            }
+            _ => panic!("expected Commands::Switch"),
+        }
+    }
+
+    #[test]
     fn tag_subcommand_requires_branch() {
         let result = Cli::try_parse_from(["trench", "tag"]);
         assert!(result.is_err(), "tag without branch should fail");

--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -9,7 +9,7 @@ pub fn is_inside_tmux() -> bool {
 }
 
 /// Build the argument list for `tmux new-window` targeting the given
-/// worktree path with the window named after the branch.
+/// worktree path with the window named after the worktree.
 ///
 /// Returns the full argv including "tmux".
 pub fn build_new_window_command(worktree_path: &str, window_name: &str) -> Vec<String> {
@@ -23,13 +23,51 @@ pub fn build_new_window_command(worktree_path: &str, window_name: &str) -> Vec<S
     ]
 }
 
+/// The action that `run_switch` should take after resolving the worktree.
+#[derive(Debug, PartialEq)]
+pub enum SwitchAction {
+    /// Open a new tmux window. Contains the argv for `tmux new-window`.
+    TmuxNewWindow(Vec<String>),
+    /// Print path or message (normal behavior). Includes a warning if
+    /// the user explicitly asked for tmux but we're not inside a session.
+    PrintPath { warn_not_in_tmux: bool },
+}
+
+/// Decide what action to take for a switch operation.
+///
+/// `tmux_flag`: whether `--tmux` was passed on the CLI.
+/// `config_tmux`: whether `[shell] tmux = true` is set in config.
+/// `inside_tmux`: whether we're currently inside a tmux session.
+pub fn resolve_switch_action(
+    tmux_flag: bool,
+    config_tmux: bool,
+    inside_tmux: bool,
+    worktree_path: &str,
+    window_name: &str,
+) -> SwitchAction {
+    let use_tmux = tmux_flag || config_tmux;
+
+    if use_tmux && inside_tmux {
+        SwitchAction::TmuxNewWindow(build_new_window_command(worktree_path, window_name))
+    } else if use_tmux && tmux_flag && !inside_tmux {
+        // User explicitly asked for tmux but we're not in a session
+        SwitchAction::PrintPath {
+            warn_not_in_tmux: true,
+        }
+    } else {
+        // Not using tmux (either not enabled, or config-only and not in tmux)
+        SwitchAction::PrintPath {
+            warn_not_in_tmux: false,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
     fn is_inside_tmux_returns_false_when_unset() {
-        // Remove TMUX env var for this test
         std::env::remove_var("TMUX");
         assert!(!is_inside_tmux());
     }
@@ -52,7 +90,8 @@ mod tests {
 
     #[test]
     fn build_new_window_command_constructs_correct_args() {
-        let cmd = build_new_window_command("/home/user/.worktrees/repo/feature-auth", "feature-auth");
+        let cmd =
+            build_new_window_command("/home/user/.worktrees/repo/feature-auth", "feature-auth");
         assert_eq!(
             cmd,
             vec![
@@ -71,5 +110,99 @@ mod tests {
         let cmd = build_new_window_command("/wt/feat-login", "feat-login");
         assert_eq!(cmd[3], "feat-login");
         assert_eq!(cmd[5], "/wt/feat-login");
+    }
+
+    // --- resolve_switch_action tests ---
+
+    #[test]
+    fn action_tmux_flag_inside_tmux_opens_window() {
+        let action = resolve_switch_action(true, false, true, "/wt/feat", "feat");
+        assert_eq!(
+            action,
+            SwitchAction::TmuxNewWindow(vec![
+                "tmux".into(),
+                "new-window".into(),
+                "-n".into(),
+                "feat".into(),
+                "-c".into(),
+                "/wt/feat".into(),
+            ])
+        );
+    }
+
+    #[test]
+    fn action_config_tmux_inside_tmux_opens_window() {
+        let action = resolve_switch_action(false, true, true, "/wt/feat", "feat");
+        assert_eq!(
+            action,
+            SwitchAction::TmuxNewWindow(vec![
+                "tmux".into(),
+                "new-window".into(),
+                "-n".into(),
+                "feat".into(),
+                "-c".into(),
+                "/wt/feat".into(),
+            ])
+        );
+    }
+
+    #[test]
+    fn action_tmux_flag_not_in_tmux_warns_and_falls_back() {
+        let action = resolve_switch_action(true, false, false, "/wt/feat", "feat");
+        assert_eq!(
+            action,
+            SwitchAction::PrintPath {
+                warn_not_in_tmux: true
+            }
+        );
+    }
+
+    #[test]
+    fn action_config_tmux_not_in_tmux_silent_fallback() {
+        let action = resolve_switch_action(false, true, false, "/wt/feat", "feat");
+        assert_eq!(
+            action,
+            SwitchAction::PrintPath {
+                warn_not_in_tmux: false
+            }
+        );
+    }
+
+    #[test]
+    fn action_no_tmux_at_all_prints_path() {
+        let action = resolve_switch_action(false, false, false, "/wt/feat", "feat");
+        assert_eq!(
+            action,
+            SwitchAction::PrintPath {
+                warn_not_in_tmux: false
+            }
+        );
+    }
+
+    #[test]
+    fn action_no_tmux_even_inside_tmux_prints_path() {
+        let action = resolve_switch_action(false, false, true, "/wt/feat", "feat");
+        assert_eq!(
+            action,
+            SwitchAction::PrintPath {
+                warn_not_in_tmux: false
+            }
+        );
+    }
+
+    #[test]
+    fn action_both_flag_and_config_inside_tmux_opens_window() {
+        let action = resolve_switch_action(true, true, true, "/wt/feat", "feat");
+        assert_eq!(
+            action,
+            SwitchAction::TmuxNewWindow(vec![
+                "tmux".into(),
+                "new-window".into(),
+                "-n".into(),
+                "feat".into(),
+                "-c".into(),
+                "/wt/feat".into(),
+            ])
+        );
     }
 }

--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -1,7 +1,7 @@
-/// Tmux integration for worktree switching.
+/// Tmux integration for worktree operations.
 ///
-/// When enabled, `trench switch` opens a new tmux window in the worktree
-/// directory instead of just printing the path.
+/// When enabled, `trench switch` and `trench open` open a new tmux window
+/// in the worktree directory instead of their default behavior.
 
 /// Check whether the current process is running inside a tmux session.
 pub fn is_inside_tmux() -> bool {
@@ -23,40 +23,41 @@ pub fn build_new_window_command(worktree_path: &str, window_name: &str) -> Vec<S
     ]
 }
 
-/// The action that `run_switch` should take after resolving the worktree.
+/// The action that a command should take after resolving tmux intent.
 #[derive(Debug, PartialEq)]
-pub enum SwitchAction {
+pub enum TmuxAction {
     /// Open a new tmux window. Contains the argv for `tmux new-window`.
     TmuxNewWindow(Vec<String>),
-    /// Print path or message (normal behavior). Includes a warning if
-    /// the user explicitly asked for tmux but we're not inside a session.
-    PrintPath { warn_not_in_tmux: bool },
+    /// Fall back to default behavior (print path for switch, open editor for
+    /// open). Includes a warning if the user explicitly asked for tmux but
+    /// we're not inside a session.
+    Fallback { warn_not_in_tmux: bool },
 }
 
-/// Decide what action to take for a switch operation.
+/// Decide what action to take based on tmux flags and environment.
 ///
 /// `tmux_flag`: whether `--tmux` was passed on the CLI.
 /// `config_tmux`: whether `[shell] tmux = true` is set in config.
 /// `inside_tmux`: whether we're currently inside a tmux session.
-pub fn resolve_switch_action(
+pub fn resolve_tmux_action(
     tmux_flag: bool,
     config_tmux: bool,
     inside_tmux: bool,
     worktree_path: &str,
     window_name: &str,
-) -> SwitchAction {
+) -> TmuxAction {
     let use_tmux = tmux_flag || config_tmux;
 
     if use_tmux && inside_tmux {
-        SwitchAction::TmuxNewWindow(build_new_window_command(worktree_path, window_name))
+        TmuxAction::TmuxNewWindow(build_new_window_command(worktree_path, window_name))
     } else if tmux_flag && !inside_tmux {
         // User explicitly asked for tmux but we're not in a session
-        SwitchAction::PrintPath {
+        TmuxAction::Fallback {
             warn_not_in_tmux: true,
         }
     } else {
         // Not using tmux (either not enabled, or config-only and not in tmux)
-        SwitchAction::PrintPath {
+        TmuxAction::Fallback {
             warn_not_in_tmux: false,
         }
     }
@@ -139,14 +140,14 @@ mod tests {
         assert_eq!(cmd[5], "/wt/feat-login");
     }
 
-    // --- resolve_switch_action tests ---
+    // --- resolve_tmux_action tests ---
 
     #[test]
     fn action_tmux_flag_inside_tmux_opens_window() {
-        let action = resolve_switch_action(true, false, true, "/wt/feat", "feat");
+        let action = resolve_tmux_action(true, false, true, "/wt/feat", "feat");
         assert_eq!(
             action,
-            SwitchAction::TmuxNewWindow(vec![
+            TmuxAction::TmuxNewWindow(vec![
                 "tmux".into(),
                 "new-window".into(),
                 "-n".into(),
@@ -159,10 +160,10 @@ mod tests {
 
     #[test]
     fn action_config_tmux_inside_tmux_opens_window() {
-        let action = resolve_switch_action(false, true, true, "/wt/feat", "feat");
+        let action = resolve_tmux_action(false, true, true, "/wt/feat", "feat");
         assert_eq!(
             action,
-            SwitchAction::TmuxNewWindow(vec![
+            TmuxAction::TmuxNewWindow(vec![
                 "tmux".into(),
                 "new-window".into(),
                 "-n".into(),
@@ -175,10 +176,10 @@ mod tests {
 
     #[test]
     fn action_tmux_flag_not_in_tmux_warns_and_falls_back() {
-        let action = resolve_switch_action(true, false, false, "/wt/feat", "feat");
+        let action = resolve_tmux_action(true, false, false, "/wt/feat", "feat");
         assert_eq!(
             action,
-            SwitchAction::PrintPath {
+            TmuxAction::Fallback {
                 warn_not_in_tmux: true
             }
         );
@@ -186,32 +187,32 @@ mod tests {
 
     #[test]
     fn action_config_tmux_not_in_tmux_silent_fallback() {
-        let action = resolve_switch_action(false, true, false, "/wt/feat", "feat");
+        let action = resolve_tmux_action(false, true, false, "/wt/feat", "feat");
         assert_eq!(
             action,
-            SwitchAction::PrintPath {
+            TmuxAction::Fallback {
                 warn_not_in_tmux: false
             }
         );
     }
 
     #[test]
-    fn action_no_tmux_at_all_prints_path() {
-        let action = resolve_switch_action(false, false, false, "/wt/feat", "feat");
+    fn action_no_tmux_at_all_falls_back() {
+        let action = resolve_tmux_action(false, false, false, "/wt/feat", "feat");
         assert_eq!(
             action,
-            SwitchAction::PrintPath {
+            TmuxAction::Fallback {
                 warn_not_in_tmux: false
             }
         );
     }
 
     #[test]
-    fn action_no_tmux_even_inside_tmux_prints_path() {
-        let action = resolve_switch_action(false, false, true, "/wt/feat", "feat");
+    fn action_no_tmux_even_inside_tmux_falls_back() {
+        let action = resolve_tmux_action(false, false, true, "/wt/feat", "feat");
         assert_eq!(
             action,
-            SwitchAction::PrintPath {
+            TmuxAction::Fallback {
                 warn_not_in_tmux: false
             }
         );
@@ -219,10 +220,10 @@ mod tests {
 
     #[test]
     fn action_both_flag_and_config_inside_tmux_opens_window() {
-        let action = resolve_switch_action(true, true, true, "/wt/feat", "feat");
+        let action = resolve_tmux_action(true, true, true, "/wt/feat", "feat");
         assert_eq!(
             action,
-            SwitchAction::TmuxNewWindow(vec![
+            TmuxAction::TmuxNewWindow(vec![
                 "tmux".into(),
                 "new-window".into(),
                 "-n".into(),

--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -65,27 +65,54 @@ pub fn resolve_switch_action(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
+    use std::ffi::OsString;
+
+    /// RAII guard that saves the current value of an env var and restores it on drop.
+    struct EnvGuard {
+        key: &'static str,
+        prev: Option<OsString>,
+    }
+
+    impl EnvGuard {
+        fn set(key: &'static str, value: Option<&str>) -> Self {
+            let prev = std::env::var_os(key);
+            match value {
+                Some(v) => std::env::set_var(key, v),
+                None => std::env::remove_var(key),
+            }
+            Self { key, prev }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match &self.prev {
+                Some(v) => std::env::set_var(self.key, v),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
 
     #[test]
+    #[serial]
     fn is_inside_tmux_returns_false_when_unset() {
-        std::env::remove_var("TMUX");
+        let _guard = EnvGuard::set("TMUX", None);
         assert!(!is_inside_tmux());
     }
 
     #[test]
+    #[serial]
     fn is_inside_tmux_returns_false_when_empty() {
-        std::env::set_var("TMUX", "");
-        let result = is_inside_tmux();
-        std::env::remove_var("TMUX");
-        assert!(!result);
+        let _guard = EnvGuard::set("TMUX", Some(""));
+        assert!(!is_inside_tmux());
     }
 
     #[test]
+    #[serial]
     fn is_inside_tmux_returns_true_when_set() {
-        std::env::set_var("TMUX", "/tmp/tmux-501/default,12345,0");
-        let result = is_inside_tmux();
-        std::env::remove_var("TMUX");
-        assert!(result);
+        let _guard = EnvGuard::set("TMUX", Some("/tmp/tmux-501/default,12345,0"));
+        assert!(is_inside_tmux());
     }
 
     #[test]

--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -1,0 +1,75 @@
+/// Tmux integration for worktree switching.
+///
+/// When enabled, `trench switch` opens a new tmux window in the worktree
+/// directory instead of just printing the path.
+
+/// Check whether the current process is running inside a tmux session.
+pub fn is_inside_tmux() -> bool {
+    std::env::var("TMUX").is_ok_and(|v| !v.is_empty())
+}
+
+/// Build the argument list for `tmux new-window` targeting the given
+/// worktree path with the window named after the branch.
+///
+/// Returns the full argv including "tmux".
+pub fn build_new_window_command(worktree_path: &str, window_name: &str) -> Vec<String> {
+    vec![
+        "tmux".to_string(),
+        "new-window".to_string(),
+        "-n".to_string(),
+        window_name.to_string(),
+        "-c".to_string(),
+        worktree_path.to_string(),
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_inside_tmux_returns_false_when_unset() {
+        // Remove TMUX env var for this test
+        std::env::remove_var("TMUX");
+        assert!(!is_inside_tmux());
+    }
+
+    #[test]
+    fn is_inside_tmux_returns_false_when_empty() {
+        std::env::set_var("TMUX", "");
+        let result = is_inside_tmux();
+        std::env::remove_var("TMUX");
+        assert!(!result);
+    }
+
+    #[test]
+    fn is_inside_tmux_returns_true_when_set() {
+        std::env::set_var("TMUX", "/tmp/tmux-501/default,12345,0");
+        let result = is_inside_tmux();
+        std::env::remove_var("TMUX");
+        assert!(result);
+    }
+
+    #[test]
+    fn build_new_window_command_constructs_correct_args() {
+        let cmd = build_new_window_command("/home/user/.worktrees/repo/feature-auth", "feature-auth");
+        assert_eq!(
+            cmd,
+            vec![
+                "tmux",
+                "new-window",
+                "-n",
+                "feature-auth",
+                "-c",
+                "/home/user/.worktrees/repo/feature-auth",
+            ]
+        );
+    }
+
+    #[test]
+    fn build_new_window_command_handles_branch_with_slashes() {
+        let cmd = build_new_window_command("/wt/feat-login", "feat-login");
+        assert_eq!(cmd[3], "feat-login");
+        assert_eq!(cmd[5], "/wt/feat-login");
+    }
+}

--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -49,7 +49,7 @@ pub fn resolve_switch_action(
 
     if use_tmux && inside_tmux {
         SwitchAction::TmuxNewWindow(build_new_window_command(worktree_path, window_name))
-    } else if use_tmux && tmux_flag && !inside_tmux {
+    } else if tmux_flag && !inside_tmux {
         // User explicitly asked for tmux but we're not in a session
         SwitchAction::PrintPath {
             warn_not_in_tmux: true,


### PR DESCRIPTION
Closes #59

## Summary
Add tmux integration behind a `[shell] tmux = true` config flag. When enabled and running inside tmux, `trench switch` opens a new tmux window named after the worktree in the worktree directory. A `--tmux` CLI flag forces tmux mode on both `switch` and `open` commands regardless of config. Graceful fallback to normal behavior when not inside a tmux session.

## User Stories Addressed
- US-9: Enhanced navigation with tmux — switch to a worktree and have it open in a new tmux window

## Automated Testing
- Total tests added: 20
- Tests passing: 20
- Tests failing: 0
- `cargo clippy`: pass
- `cargo test`: pass (908 total tests, 0 failures)

## UAT Checklist
- [ ] Add `[shell]\ntmux = true` to `~/.config/trench/config.toml`, run `trench switch <branch>` inside tmux → new tmux window opens at worktree path with branch name as window title
- [ ] Run `trench switch <branch>` outside tmux with config enabled → falls back to normal print behavior silently
- [ ] Run `trench switch <branch> --tmux` inside tmux without config → new tmux window opens (flag overrides config)
- [ ] Run `trench switch <branch> --tmux` outside tmux → prints warning and falls back to normal behavior
- [ ] Run `trench switch <branch>` with no config and no flag → normal behavior unchanged (regression check)
- [ ] Run `trench open <branch> --tmux` inside tmux → opens tmux window instead of $EDITOR
- [ ] Run `trench open <branch> --tmux` outside tmux → warns and falls back to $EDITOR
- [ ] Add `[shell]\ntmux = true` to `.trench.toml` (project config) → project setting overrides global
- [ ] Verify `trench switch --help` shows `--tmux` flag documentation
- [ ] Verify `trench open --help` shows `--tmux` flag documentation

## Known Issues
None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a --tmux flag to switch and open to open worktrees in new tmux windows.
  * New shell config option (project/global) to enable tmux by default, with CLI taking precedence.

* **Behavior**
  * Auto-detects running inside tmux; gracefully falls back and warns when --tmux is used outside tmux.
  * open skips editor when tmux is used and records the open only after successful tmux launch.

* **Tests**
  * Added tests for tmux detection, command construction, config deserialization and precedence, and CLI parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->