### PR TITLE
feat(shell): rename shell function tr → tn

### DIFF
--- a/src/cli/commands/shell_init.rs
+++ b/src/cli/commands/shell_init.rs
@@ -37,7 +37,7 @@ fn generate_posix() -> &'static str {
 }
 
 fn generate_fish() -> &'static str {
-    r#"function tr
+    r#"function tn
     if test (count $argv) -gt 0 -a "$argv[1]" = "switch"
         set -l rest $argv[2..-1]
         set -l dir (command trench switch --print-path $rest)
@@ -131,11 +131,15 @@ mod tests {
     }
 
     #[test]
-    fn fish_output_defines_tr_function() {
+    fn fish_output_defines_tn_function() {
         let output = generate(ShellType::Fish);
         assert!(
-            output.contains("function tr"),
-            "fish output should define function tr"
+            output.contains("function tn"),
+            "fish output should define function tn"
+        );
+        assert!(
+            !output.contains("\nfunction tr\n"),
+            "fish output should not define old function tr"
         );
     }
 

--- a/src/cli/commands/shell_init.rs
+++ b/src/cli/commands/shell_init.rs
@@ -138,7 +138,7 @@ mod tests {
             "fish output should define function tn"
         );
         assert!(
-            !output.contains("\nfunction tr\n"),
+            !output.contains("function tr\n"),
             "fish output should not define old function tr"
         );
     }

--- a/src/cli/commands/shell_init.rs
+++ b/src/cli/commands/shell_init.rs
@@ -1,6 +1,6 @@
-//! Generate shell function definitions for `tr()` shell integration.
+//! Generate shell function definitions for `tn()` shell integration.
 //!
-//! The `tr()` function wraps `trench switch --print-path` with `cd` so
+//! The `tn()` function wraps `trench switch --print-path` with `cd` so
 //! switching worktrees changes the shell's working directory. All other
 //! subcommands pass through to `trench` unmodified.
 
@@ -15,7 +15,7 @@ pub fn generate(shell: ShellType) -> &'static str {
 }
 
 fn generate_posix() -> &'static str {
-    r#"tr() {
+    r#"tn() {
     if [ "$1" = "switch" ]; then
         shift
         local dir
@@ -62,11 +62,15 @@ mod tests {
     use super::*;
 
     #[test]
-    fn bash_output_defines_tr_function() {
+    fn bash_output_defines_tn_function() {
         let output = generate(ShellType::Bash);
         assert!(
-            output.contains("tr()"),
-            "bash output should define tr() function"
+            output.contains("tn()"),
+            "bash output should define tn() function"
+        );
+        assert!(
+            !output.contains("tr()"),
+            "bash output should not define old tr() function"
         );
     }
 
@@ -98,11 +102,15 @@ mod tests {
     }
 
     #[test]
-    fn zsh_output_defines_tr_function() {
+    fn zsh_output_defines_tn_function() {
         let output = generate(ShellType::Zsh);
         assert!(
-            output.contains("tr()"),
-            "zsh output should define tr() function"
+            output.contains("tn()"),
+            "zsh output should define tn() function"
+        );
+        assert!(
+            !output.contains("tr()"),
+            "zsh output should not define old tr() function"
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -174,11 +174,8 @@ enum Commands {
     },
     /// Output shell function definition for eval.
     ///
-    /// The `tr()` shell function wraps `trench switch --print-path` with `cd`
+    /// The `tn()` shell function wraps `trench switch --print-path` with `cd`
     /// so you can instantly navigate between worktrees.
-    ///
-    /// Note: this will shadow the POSIX `tr` utility (translate characters).
-    /// To access the original, use `command tr`.
     ///
     /// Add this to your shell configuration file:
     ///
@@ -1891,18 +1888,22 @@ mod tests {
     }
 
     #[test]
-    fn shell_init_help_warns_about_posix_tr_shadowing() {
+    fn shell_init_help_has_no_shadowing_warning() {
         let result = Cli::try_parse_from(["trench", "shell-init", "--help"]);
         let err = result.unwrap_err();
         assert_eq!(err.kind(), clap::error::ErrorKind::DisplayHelp);
         let output = err.to_string();
         assert!(
-            output.contains("shadow"),
-            "shell-init help should warn about POSIX tr shadowing, got:\n{output}"
+            !output.contains("shadow"),
+            "shell-init help should not contain shadowing warning, got:\n{output}"
         );
         assert!(
-            output.contains("command tr"),
-            "shell-init help should explain how to access the POSIX tr utility, got:\n{output}"
+            !output.contains("command tr"),
+            "shell-init help should not reference 'command tr' workaround, got:\n{output}"
+        );
+        assert!(
+            output.contains("tn()"),
+            "shell-init help should reference tn() function, got:\n{output}"
         );
     }
 


### PR DESCRIPTION
## Summary

- Rename shell integration function from `tr()` to `tn()` across bash, zsh, and fish templates to eliminate conflict with the standard Unix `tr` utility
- Remove the POSIX `tr` shadowing warning from `shell-init --help` since `tn` doesn't conflict with anything

Closes #126

## Changes

- **`src/cli/commands/shell_init.rs`** — Renamed `tr()` → `tn()` in posix template, `function tr` → `function tn` in fish template; updated module doc comments; updated 3 test functions with presence + absence assertions
- **`src/main.rs`** — Updated clap doc comment to reference `tn()`; removed shadowing warning lines; replaced `shell_init_help_warns_about_posix_tr_shadowing` test with `shell_init_help_has_no_shadowing_warning`

## Test Plan

- [x] All 909 existing tests pass (`cargo test`)
- [x] `trench shell-init zsh` outputs `tn()`, not `tr()`
- [x] `trench shell-init bash` outputs `tn()`, not `tr()`
- [x] `trench shell-init fish` outputs `function tn`, not `function tr`
- [x] `trench shell-init --help` references `tn()` with no shadowing warning
- [x] No source code references to `tr()` as shell function remain

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Renamed the shell integration entry point used by the installer to avoid naming conflicts and improve consistency.

* **Documentation**
  * Updated CLI help and usage text to reference the new shell integration name and removed the prior shadowing workaround and warning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->