### PR TITLE
feat(tui): list view switch + plumbing (#127)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -235,7 +235,10 @@ fn main() -> anyhow::Result<()> {
         std::io::stdin().is_terminal(),
         std::io::stdout().is_terminal(),
     ) {
-        return tui::run();
+        if let Some(path) = tui::run()? {
+            println!("{path}");
+        }
+        return Ok(());
     }
 
     let dry_run = cli.dry_run;

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -934,7 +934,13 @@ impl App {
                                 self.switch_path = Some(result.path);
                                 self.running = false;
                             }
-                            Err(_) => {}
+                            Err(e) => {
+                                self.list_state.status_message =
+                                    Some(screens::list::StatusMessage {
+                                        text: format!("Switch failed: {e}"),
+                                        success: false,
+                                    });
+                            }
                         }
                     }
                 }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -923,6 +923,7 @@ impl App {
     }
 
     fn handle_list_key(&mut self, key: KeyEvent) {
+        self.list_state.status_message = None;
         match key.code {
             KeyCode::Enter => {
                 if let Some(row) = self.list_state.rows.get(self.list_state.selected) {
@@ -1562,6 +1563,21 @@ mod tests {
         app.handle_key_event(KeyEvent::new(KeyCode::Char('q'), KeyModifiers::NONE));
         assert!(!app.is_running());
         assert!(app.switch_path.is_none(), "quit should not set switch_path");
+    }
+
+    #[test]
+    fn status_message_clears_on_keypress() {
+        let mut app = app_with_rows();
+        app.list_state.status_message = Some(screens::list::StatusMessage {
+            text: "test error".into(),
+            success: false,
+        });
+        // Press any key (j to move down)
+        app.handle_key_event(KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE));
+        assert!(
+            app.list_state.status_message.is_none(),
+            "status message should be cleared after keypress"
+        );
     }
 
     #[test]

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -129,6 +129,7 @@ pub struct App {
     pub hook_rx: Option<std::sync::mpsc::Receiver<screens::hook_log::HookOutputMessage>>,
     pub editor_request: Option<String>,
     pub repo_path: Option<String>,
+    pub switch_path: Option<String>,
     pub auto_refresh: bool,
     pub watcher: Option<watcher::DebouncedWatcher>,
 }
@@ -148,6 +149,7 @@ impl App {
             hook_rx: None,
             editor_request: None,
             repo_path: None,
+            switch_path: None,
             auto_refresh: true,
             watcher: None,
         }
@@ -1222,6 +1224,12 @@ mod tests {
     fn app_has_repo_path_initially_none() {
         let app = App::new();
         assert!(app.repo_path.is_none());
+    }
+
+    #[test]
+    fn app_has_switch_path_initially_none() {
+        let app = App::new();
+        assert!(app.switch_path.is_none());
     }
 
     #[test]

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -931,19 +931,26 @@ impl App {
             KeyCode::Enter => {
                 if let Some(row) = self.list_state.rows.get(self.list_state.selected) {
                     let name = row.name.clone();
-                    if let Some((cwd, db)) = Self::open_db() {
-                        match crate::cli::commands::switch::execute(&name, &cwd, &db) {
-                            Ok(result) => {
-                                self.switch_path = Some(result.path);
-                                self.running = false;
-                            }
-                            Err(e) => {
-                                self.list_state.status_message =
-                                    Some(screens::list::StatusMessage {
-                                        text: format!("Switch failed: {e}"),
-                                        success: false,
-                                    });
-                            }
+                    let Some((cwd, db)) = Self::open_db() else {
+                        self.list_state.status_message =
+                            Some(screens::list::StatusMessage {
+                                text: "Switch failed: could not access current repo state"
+                                    .into(),
+                                success: false,
+                            });
+                        return;
+                    };
+                    match crate::cli::commands::switch::execute(&name, &cwd, &db) {
+                        Ok(result) => {
+                            self.switch_path = Some(result.path);
+                            self.running = false;
+                        }
+                        Err(e) => {
+                            self.list_state.status_message =
+                                Some(screens::list::StatusMessage {
+                                    text: format!("Switch failed: {e}"),
+                                    success: false,
+                                });
                         }
                     }
                 }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -925,22 +925,16 @@ impl App {
     fn handle_list_key(&mut self, key: KeyEvent) {
         match key.code {
             KeyCode::Enter => {
-                let identity = self
-                    .list_state
-                    .rows
-                    .get(self.list_state.selected)
-                    .map(|r| r.name.clone());
-                self.adopt_selected_if_unmanaged();
-                if let Some(ref name) = identity {
-                    if let Some(idx) = self.list_state.rows.iter().position(|r| r.name == *name) {
-                        self.list_state.selected = idx;
-                    }
-                }
-                // Load detail data for the selected worktree
-                if let Some(name) = identity {
-                    self.save_list_session();
-                    if self.load_detail(&name) {
-                        self.push_screen(Screen::Detail);
+                if let Some(row) = self.list_state.rows.get(self.list_state.selected) {
+                    let name = row.name.clone();
+                    if let Some((cwd, db)) = Self::open_db() {
+                        match crate::cli::commands::switch::execute(&name, &cwd, &db) {
+                            Ok(result) => {
+                                self.switch_path = Some(result.path);
+                                self.running = false;
+                            }
+                            Err(_) => {}
+                        }
                     }
                 }
             }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -28,7 +28,7 @@ type PanicHook = dyn Fn(&std::panic::PanicHookInfo<'_>) + Send + Sync;
 static PREV_PANIC_HOOK: Mutex<Option<Arc<PanicHook>>> = Mutex::new(None);
 
 /// Launch the TUI. This is the single public entry point.
-pub fn run() -> Result<()> {
+pub fn run() -> Result<Option<String>> {
     install_panic_hook();
     let mut terminal = ratatui::init();
     let mut app = App::new();
@@ -60,7 +60,7 @@ pub fn run() -> Result<()> {
     // Restore session state (selected worktree, scroll position) from last run
     app.restore_list_session();
 
-    let result = (|| -> Result<()> {
+    let result = (|| -> Result<Option<String>> {
         while app.is_running() {
             // Process any pending hook output messages
             app.process_hook_messages();
@@ -89,7 +89,7 @@ pub fn run() -> Result<()> {
                 terminal = ratatui::init();
             }
         }
-        Ok(())
+        Ok(app.switch_path.take())
     })();
 
     ratatui::restore();

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -511,6 +511,10 @@ impl App {
     }
 
     pub fn handle_key_event(&mut self, key: KeyEvent) {
+        if self.active_screen() == Screen::List {
+            self.list_state.status_message = None;
+        }
+
         // Global keys handled at app level
         match (key.code, key.modifiers) {
             (KeyCode::Char('c'), KeyModifiers::CONTROL) => self.running = false,
@@ -923,7 +927,6 @@ impl App {
     }
 
     fn handle_list_key(&mut self, key: KeyEvent) {
-        self.list_state.status_message = None;
         match key.code {
             KeyCode::Enter => {
                 if let Some(row) = self.list_state.rows.get(self.list_state.selected) {
@@ -1583,6 +1586,21 @@ mod tests {
         assert!(
             app.list_state.status_message.is_none(),
             "status message should be cleared after keypress"
+        );
+    }
+
+    #[test]
+    fn status_message_clears_on_global_key() {
+        let mut app = app_with_rows();
+        app.list_state.status_message = Some(screens::list::StatusMessage {
+            text: "test error".into(),
+            success: false,
+        });
+        // Press ? (global key that opens Help)
+        app.handle_key_event(KeyEvent::new(KeyCode::Char('?'), KeyModifiers::NONE));
+        assert!(
+            app.list_state.status_message.is_none(),
+            "status message should be cleared by global keys too"
         );
     }
 

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -986,6 +986,25 @@ impl App {
                     self.load_hook_log_replay(&name);
                 }
             }
+            KeyCode::Char('d') => {
+                let identity = self
+                    .list_state
+                    .rows
+                    .get(self.list_state.selected)
+                    .map(|r| r.name.clone());
+                self.adopt_selected_if_unmanaged();
+                if let Some(ref name) = identity {
+                    if let Some(idx) = self.list_state.rows.iter().position(|r| r.name == *name) {
+                        self.list_state.selected = idx;
+                    }
+                }
+                if let Some(name) = identity {
+                    self.save_list_session();
+                    if self.load_detail(&name) {
+                        self.push_screen(Screen::Detail);
+                    }
+                }
+            }
             _ => {}
         }
     }
@@ -1485,7 +1504,7 @@ mod tests {
     fn question_mark_toggles_help_from_detail_screen() {
         let mut app = app_with_rows();
         // Navigate to detail
-        app.handle_key_event(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+        app.handle_key_event(KeyEvent::new(KeyCode::Char('d'), KeyModifiers::NONE));
         assert_eq!(app.active_screen(), Screen::Detail);
 
         // Open help from detail
@@ -1568,15 +1587,15 @@ mod tests {
     }
 
     #[test]
-    fn enter_on_list_with_rows_pushes_detail() {
+    fn d_on_list_with_rows_pushes_detail() {
         let mut app = app_with_rows();
         assert_eq!(app.active_screen(), Screen::List);
 
-        app.handle_key_event(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+        app.handle_key_event(KeyEvent::new(KeyCode::Char('d'), KeyModifiers::NONE));
         assert_eq!(
             app.active_screen(),
             Screen::Detail,
-            "Enter on List with rows should push Detail screen"
+            "d on List with rows should push Detail screen"
         );
         assert_eq!(app.nav_stack_depth(), 2);
     }
@@ -1616,7 +1635,7 @@ mod tests {
     fn deep_stack_navigation_push_pop_sequence() {
         let mut app = app_with_rows();
         // List → Detail → Help → pop → pop → List
-        app.handle_key_event(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+        app.handle_key_event(KeyEvent::new(KeyCode::Char('d'), KeyModifiers::NONE));
         assert_eq!(app.active_screen(), Screen::Detail);
         assert_eq!(app.nav_stack_depth(), 2);
 
@@ -1644,7 +1663,7 @@ mod tests {
     fn question_mark_opens_help_from_detail_screen() {
         let mut app = app_with_rows();
         // Navigate to Detail first
-        app.handle_key_event(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+        app.handle_key_event(KeyEvent::new(KeyCode::Char('d'), KeyModifiers::NONE));
         assert_eq!(app.active_screen(), Screen::Detail);
 
         // ? should still open Help from Detail
@@ -2948,7 +2967,7 @@ mod tests {
     fn replay_dismiss_returns_to_detail_not_list() {
         let mut app = app_with_rows();
         // Navigate to Detail
-        app.handle_key_event(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+        app.handle_key_event(KeyEvent::new(KeyCode::Char('d'), KeyModifiers::NONE));
         assert_eq!(app.active_screen(), Screen::Detail);
 
         // Simulate replay hook log pushed from Detail

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1563,6 +1563,14 @@ mod tests {
     }
 
     #[test]
+    fn quit_leaves_switch_path_none() {
+        let mut app = App::new();
+        app.handle_key_event(KeyEvent::new(KeyCode::Char('q'), KeyModifiers::NONE));
+        assert!(!app.is_running());
+        assert!(app.switch_path.is_none(), "quit should not set switch_path");
+    }
+
+    #[test]
     fn q_on_non_root_screen_pops_back() {
         let mut app = App::new();
         // Push Help

--- a/src/tui/screens/help.rs
+++ b/src/tui/screens/help.rs
@@ -36,10 +36,12 @@ pub fn keybinding_groups() -> &'static [KeybindingGroup] {
             bindings: &[
                 KeybindingEntry { key: "j / ↓", description: "Move down" },
                 KeybindingEntry { key: "k / ↑", description: "Move up" },
-                KeybindingEntry { key: "Enter", description: "Open detail view" },
+                KeybindingEntry { key: "Enter", description: "Switch to worktree" },
+                KeybindingEntry { key: "d", description: "Open detail view" },
                 KeybindingEntry { key: "n", description: "Create worktree" },
                 KeybindingEntry { key: "s", description: "Sync worktree" },
                 KeybindingEntry { key: "D", description: "Delete worktree" },
+                KeybindingEntry { key: "l", description: "View hook log" },
             ],
         },
         KeybindingGroup {
@@ -201,5 +203,15 @@ mod tests {
         let keys: Vec<&str> = global.bindings.iter().map(|b| b.key).collect();
         assert!(keys.contains(&"?"), "Global group missing '?' keybinding");
         assert!(keys.contains(&"q / Esc"), "Global group missing quit keybinding");
+    }
+
+    #[test]
+    fn list_group_contains_switch_detail_and_log_bindings() {
+        let groups = keybinding_groups();
+        let list = groups.iter().find(|g| g.context == "List").unwrap();
+        let descs: Vec<&str> = list.bindings.iter().map(|b| b.description).collect();
+        assert!(descs.contains(&"Switch to worktree"), "List group missing switch binding");
+        assert!(descs.contains(&"Open detail view"), "List group missing detail binding");
+        assert!(descs.contains(&"View hook log"), "List group missing log binding");
     }
 }

--- a/src/tui/screens/list.rs
+++ b/src/tui/screens/list.rs
@@ -27,15 +27,27 @@ pub struct WorktreeRow {
     pub processes: String,
 }
 
+/// A transient status message displayed in the list view footer area.
+/// Auto-cleared on the next keypress.
+pub struct StatusMessage {
+    pub text: String,
+    pub success: bool,
+}
+
 /// State for the worktree list screen.
 pub struct ListState {
     pub rows: Vec<WorktreeRow>,
     pub selected: usize,
+    pub status_message: Option<StatusMessage>,
 }
 
 impl ListState {
     pub fn new(rows: Vec<WorktreeRow>) -> Self {
-        Self { rows, selected: 0 }
+        Self {
+            rows,
+            selected: 0,
+            status_message: None,
+        }
     }
 
     pub fn select_next(&mut self) {
@@ -576,5 +588,11 @@ mod tests {
             "managed row should use theme.foreground, got: {:?}",
             cell.fg
         );
+    }
+
+    #[test]
+    fn list_state_has_status_message_initially_none() {
+        let state = ListState::new(vec![]);
+        assert!(state.status_message.is_none());
     }
 }

--- a/src/tui/screens/list.rs
+++ b/src/tui/screens/list.rs
@@ -191,7 +191,7 @@ fn compute_status(
     (status, ab)
 }
 
-const FOOTER_KEYS: &str = " n create  s sync  D delete  l log  Enter detail  q quit ";
+const FOOTER_KEYS: &str = " Enter switch  d detail  n create  s sync  D delete  l log  q quit ";
 
 pub fn render(state: &ListState, frame: &mut Frame, area: Rect, theme: &crate::tui::theme::Theme) {
     let base_style = Style::default().fg(theme.foreground).bg(theme.background);
@@ -480,13 +480,12 @@ mod tests {
         let state = ListState::new(sample_rows());
         let buf = render_to_buffer(&state, 100, 10);
         let text = buffer_text(&buf);
+        assert!(text.contains("Enter switch"), "footer should show Enter switch");
+        assert!(text.contains("d detail"), "footer should show d detail");
         assert!(text.contains("n create"), "footer should show n create");
         assert!(text.contains("s sync"), "footer should show s sync");
         assert!(text.contains("D delete"), "footer should show D delete");
-        assert!(
-            text.contains("Enter detail"),
-            "footer should show Enter detail"
-        );
+        assert!(text.contains("l log"), "footer should show l log");
         assert!(text.contains("q quit"), "footer should show q quit");
     }
 

--- a/src/tui/screens/list.rs
+++ b/src/tui/screens/list.rs
@@ -216,10 +216,9 @@ pub fn render(state: &ListState, frame: &mut Frame, area: Rect, theme: &crate::t
         let msg = Paragraph::new("No worktrees. Press n to create one.")
             .style(base_style)
             .alignment(ratatui::layout::Alignment::Center);
-        let footer = Paragraph::new(Line::from(FOOTER_KEYS)).style(footer_style);
         let chunks = Layout::vertical([Constraint::Min(1), Constraint::Length(1)]).split(area);
         frame.render_widget(msg, chunks[0]);
-        frame.render_widget(footer, chunks[1]);
+        render_footer(state, frame, chunks[1], theme, &footer_style);
         return;
     }
 
@@ -272,8 +271,33 @@ pub fn render(state: &ListState, frame: &mut Frame, area: Rect, theme: &crate::t
 
     frame.render_stateful_widget(table, chunks[0], &mut table_state);
 
-    let footer = Paragraph::new(Line::from(FOOTER_KEYS)).style(footer_style);
-    frame.render_widget(footer, chunks[1]);
+    render_footer(state, frame, chunks[1], theme, &footer_style);
+}
+
+/// Render the footer area: status message if active, otherwise keybinding hints.
+fn render_footer(
+    state: &ListState,
+    frame: &mut Frame,
+    area: Rect,
+    theme: &crate::tui::theme::Theme,
+    footer_style: &Style,
+) {
+    if let Some(ref status) = state.status_message {
+        let color = if status.success {
+            theme.success
+        } else {
+            theme.error
+        };
+        let style = Style::default()
+            .fg(color)
+            .bg(theme.background)
+            .add_modifier(Modifier::BOLD);
+        let footer = Paragraph::new(Line::from(format!(" {}", status.text))).style(style);
+        frame.render_widget(footer, area);
+    } else {
+        let footer = Paragraph::new(Line::from(FOOTER_KEYS)).style(*footer_style);
+        frame.render_widget(footer, area);
+    }
 }
 
 #[cfg(test)]
@@ -594,5 +618,35 @@ mod tests {
     fn list_state_has_status_message_initially_none() {
         let state = ListState::new(vec![]);
         assert!(state.status_message.is_none());
+    }
+
+    #[test]
+    fn status_message_replaces_footer_when_set() {
+        let mut state = ListState::new(sample_rows());
+        state.status_message = Some(StatusMessage {
+            text: "Switch failed: worktree not found".into(),
+            success: false,
+        });
+        let buf = render_to_buffer(&state, 100, 10);
+        let text = buffer_text(&buf);
+        assert!(
+            text.contains("Switch failed"),
+            "should show status message text"
+        );
+        assert!(
+            !text.contains("Enter switch"),
+            "should not show footer keys when status is active"
+        );
+    }
+
+    #[test]
+    fn footer_shows_keys_when_no_status_message() {
+        let state = ListState::new(sample_rows());
+        let buf = render_to_buffer(&state, 100, 10);
+        let text = buffer_text(&buf);
+        assert!(
+            text.contains("Enter switch"),
+            "should show footer keys when no status"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Add worktree switching to TUI list view — press Enter to switch, `d` to open detail
- Plumb switch path through `tui::run()` return type so shell wrapper can cd to the worktree
- Update footer and help overlay keybindings

## Changes

**Key rebinding (`src/tui/mod.rs`)**
- Enter → calls `switch::execute()`, sets `switch_path`, exits TUI
- `d` → opens detail view (moved from Enter)
- Added `switch_path: Option<String>` field to `App` struct

**Return type plumbing (`src/tui/mod.rs`, `src/main.rs`)**
- `tui::run()`: `Result<()>` → `Result<Option<String>>`
- `main.rs`: prints path to stdout on `Some(path)`

**UI updates (`src/tui/screens/list.rs`, `src/tui/screens/help.rs`)**
- Footer: `Enter switch  d detail  n create  s sync  D delete  l log  q quit`
- Help overlay: List group updated with switch, detail, and log bindings

## Test Plan

- [x] 912 tests pass (3 new, 6 updated)
- [ ] `cargo run` → Enter on worktree → TUI exits, path printed to stdout
- [ ] `d` opens detail view, `q`/`Esc` exits cleanly with no output
- [ ] Footer and help overlay show updated key layout
- [ ] Shell wrapper: `tn` → Enter on worktree → cd'd into worktree directory

Closes #127

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Switching worktrees now prints the selected path to stdout when used.
* **User Interface**
  * Key changes: Enter switches worktree, "d" opens detail view, "l" shows hook log.
  * Footer displays transient success/error status messages (hides key hints while present).
  * Status messages are cleared on any list-screen keypress.
* **Documentation**
  * Help text and footer keybinding descriptions updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->