### PR TITLE
feat(tui): tmux-aware switch spawns new window instead of exiting

### DIFF
--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -942,9 +942,16 @@ impl App {
         match action {
             crate::tmux::TmuxAction::TmuxNewWindow(argv) => {
                 if argv.len() > 1 {
-                    let _ = std::process::Command::new(&argv[0])
+                    if let Err(e) = std::process::Command::new(&argv[0])
                         .args(&argv[1..])
-                        .spawn();
+                        .spawn()
+                    {
+                        self.list_state.status_message =
+                            Some(screens::list::StatusMessage {
+                                text: format!("Failed to spawn tmux window: {e}"),
+                                success: false,
+                            });
+                    }
                 }
                 true
             }
@@ -1347,6 +1354,32 @@ mod tests {
         assert!(
             app.switch_path.is_none(),
             "tmux new-window should not set switch_path"
+        );
+    }
+
+    #[test]
+    fn apply_switch_result_tmux_spawn_failure_shows_status_message() {
+        let mut app = App::new();
+        let result = crate::cli::commands::switch::SwitchResult {
+            path: "/tmp/wt/feat-z".into(),
+            name: "feat-z".into(),
+        };
+        // Use a non-existent binary to force a spawn failure.
+        let action = crate::tmux::TmuxAction::TmuxNewWindow(vec![
+            "/nonexistent/binary".into(),
+            "arg".into(),
+        ]);
+        let needs_refresh = app.apply_switch_result(result, action);
+        assert!(needs_refresh, "should still request refresh on spawn failure");
+        let msg = app
+            .list_state
+            .status_message
+            .as_ref()
+            .expect("status_message should be set on spawn failure");
+        assert!(!msg.success, "status_message should indicate failure");
+        assert!(
+            msg.text.contains("tmux"),
+            "status_message should mention tmux"
         );
     }
 

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -46,6 +46,7 @@ pub fn run() -> Result<Option<String>> {
 
     if let Some(ref resolved) = resolved_config {
         app.theme = theme::from_name(&resolved.ui.theme);
+        app.tmux_enabled = resolved.shell.tmux;
     }
 
     // Set auto_refresh before any refresh that may build a watcher
@@ -130,6 +131,7 @@ pub struct App {
     pub editor_request: Option<String>,
     pub repo_path: Option<String>,
     pub switch_path: Option<String>,
+    pub tmux_enabled: bool,
     pub auto_refresh: bool,
     pub watcher: Option<watcher::DebouncedWatcher>,
 }
@@ -150,6 +152,7 @@ impl App {
             editor_request: None,
             repo_path: None,
             switch_path: None,
+            tmux_enabled: false,
             auto_refresh: true,
             watcher: None,
         }
@@ -926,6 +929,33 @@ impl App {
         }
     }
 
+    /// Handle the outcome of a switch operation, considering tmux context.
+    ///
+    /// Returns `true` if the caller should refresh the list (tmux window was
+    /// spawned and the TUI stays open). Returns `false` when the TUI should
+    /// exit and return the switch path to the shell wrapper.
+    fn apply_switch_result(
+        &mut self,
+        result: crate::cli::commands::switch::SwitchResult,
+        action: crate::tmux::TmuxAction,
+    ) -> bool {
+        match action {
+            crate::tmux::TmuxAction::TmuxNewWindow(argv) => {
+                if argv.len() > 1 {
+                    let _ = std::process::Command::new(&argv[0])
+                        .args(&argv[1..])
+                        .spawn();
+                }
+                true
+            }
+            crate::tmux::TmuxAction::Fallback { .. } => {
+                self.switch_path = Some(result.path);
+                self.running = false;
+                false
+            }
+        }
+    }
+
     fn handle_list_key(&mut self, key: KeyEvent) {
         match key.code {
             KeyCode::Enter => {
@@ -942,8 +972,16 @@ impl App {
                     };
                     match crate::cli::commands::switch::execute(&name, &cwd, &db) {
                         Ok(result) => {
-                            self.switch_path = Some(result.path);
-                            self.running = false;
+                            let action = crate::tmux::resolve_tmux_action(
+                                false,
+                                self.tmux_enabled,
+                                crate::tmux::is_inside_tmux(),
+                                &result.path,
+                                &result.name,
+                            );
+                            if self.apply_switch_result(result, action) {
+                                self.refresh_list();
+                            }
                         }
                         Err(e) => {
                             self.list_state.status_message =
@@ -1260,6 +1298,56 @@ mod tests {
     fn app_has_switch_path_initially_none() {
         let app = App::new();
         assert!(app.switch_path.is_none());
+    }
+
+    #[test]
+    fn app_has_tmux_enabled_initially_false() {
+        let app = App::new();
+        assert!(!app.tmux_enabled, "tmux_enabled should default to false");
+    }
+
+    #[test]
+    fn apply_switch_result_fallback_sets_switch_path_and_stops() {
+        let mut app = App::new();
+        let result = crate::cli::commands::switch::SwitchResult {
+            path: "/tmp/wt/feat-x".into(),
+            name: "feat-x".into(),
+        };
+        let action = crate::tmux::TmuxAction::Fallback {
+            warn_not_in_tmux: false,
+        };
+        let needs_refresh = app.apply_switch_result(result, action);
+        assert!(!needs_refresh, "fallback should not request refresh");
+        assert!(!app.is_running(), "fallback should stop the app");
+        assert_eq!(
+            app.switch_path.as_deref(),
+            Some("/tmp/wt/feat-x"),
+            "fallback should set switch_path"
+        );
+    }
+
+    #[test]
+    fn apply_switch_result_tmux_new_window_stays_running() {
+        let mut app = App::new();
+        let result = crate::cli::commands::switch::SwitchResult {
+            path: "/tmp/wt/feat-y".into(),
+            name: "feat-y".into(),
+        };
+        let action = crate::tmux::TmuxAction::TmuxNewWindow(vec![
+            "tmux".into(),
+            "new-window".into(),
+            "-n".into(),
+            "feat-y".into(),
+            "-c".into(),
+            "/tmp/wt/feat-y".into(),
+        ]);
+        let needs_refresh = app.apply_switch_result(result, action);
+        assert!(needs_refresh, "tmux new-window should request refresh");
+        assert!(app.is_running(), "tmux new-window should keep app running");
+        assert!(
+            app.switch_path.is_none(),
+            "tmux new-window should not set switch_path"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #128

## Summary
When the user is inside a tmux session and `[shell] tmux = true` is configured, pressing Enter on a worktree in the TUI list now spawns a new tmux window (`tmux new-window -n <name> -c <path>`) in the worktree directory and refreshes the list, instead of exiting the TUI and returning the path. This reuses the existing `resolve_tmux_action()` and `build_new_window_command()` utilities from `src/tmux.rs`. Outside tmux (or without the config), behavior is unchanged — the TUI exits and returns the path for the shell wrapper to `cd` into.

## User Stories Addressed
- **US-3:** Inside tmux, switching opens a new tmux window and the TUI stays running

## Automated Testing
- Total tests added: 3
- Tests passing: 3
- Tests failing: 0
- `cargo clippy`: pass (pre-existing warnings only)
- `cargo test`: pass (893 total)

### New Tests
1. `app_has_tmux_enabled_initially_false` — verifies `tmux_enabled` defaults to `false`
2. `apply_switch_result_fallback_sets_switch_path_and_stops` — verifies fallback path exits TUI with `switch_path`
3. `apply_switch_result_tmux_new_window_stays_running` — verifies tmux path keeps TUI running without setting `switch_path`

## UAT Checklist
- [ ] Without tmux: `trench` → select worktree → Enter → TUI exits, shell `cd`s to worktree (unchanged behavior)
- [ ] Inside tmux with `[shell] tmux = true` in config: `trench` → select worktree → Enter → new tmux window opens in worktree directory, TUI stays running
- [ ] Inside tmux without config: `trench` → select worktree → Enter → TUI exits normally (fallback)
- [ ] After tmux window spawn: list refreshes and shows updated `last_accessed` timestamp
- [ ] Tmux window spawn perceived latency < 100ms

## Known Issues
None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional tmux integration (disabled by default). When enabled, switching can open targets in new tmux windows and keep the app running; fallback still exits to the selected target.

* **Bug Fixes / UX**
  * Spawn failures now show a clear failure status and refresh the list instead of silently exiting.

* **Tests**
  * Added unit tests covering default state, fallback, new-window success, and spawn-failure behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->